### PR TITLE
#23 Warning fixes #21 association error fix

### DIFF
--- a/lib/dbservice/sessions.ex
+++ b/lib/dbservice/sessions.ex
@@ -150,7 +150,6 @@ defmodule Dbservice.Sessions do
   """
   def get_session_occurence!(id) do
     Repo.get!(SessionOccurence, id)
-    |> Repo.preload(:users)
   end
 
   @doc """

--- a/lib/dbservice/users/student.ex
+++ b/lib/dbservice/users/student.ex
@@ -2,6 +2,9 @@ defmodule Dbservice.Users.Student do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Dbservice.Users
+  alias Dbservice.Groups
+
   schema "student" do
     field :category, :string
     field :father_name, :string

--- a/lib/dbservice/users/teacher.ex
+++ b/lib/dbservice/users/teacher.ex
@@ -2,6 +2,9 @@ defmodule Dbservice.Users.Teacher do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Dbservice.Users
+  alias Dbservice.Schools
+
   schema "teacher" do
     field :designation, :string
     field :grade, :string

--- a/lib/dbservice_web/views/session_occurence_view.ex
+++ b/lib/dbservice_web/views/session_occurence_view.ex
@@ -22,6 +22,7 @@ defmodule DbserviceWeb.SessionOccurenceView do
 
   def render("session_occurence_with_users.json", %{session_occurence: session_occurence}) do
     session_occurence = session_occurence |> Repo.preload(:users)
+
     %{
       id: session_occurence.id,
       start_time: session_occurence.start_time,

--- a/lib/dbservice_web/views/session_occurence_view.ex
+++ b/lib/dbservice_web/views/session_occurence_view.ex
@@ -2,6 +2,7 @@ defmodule DbserviceWeb.SessionOccurenceView do
   use DbserviceWeb, :view
   alias DbserviceWeb.SessionOccurenceView
   alias DbserviceWeb.UserView
+  alias Dbservice.Repo
 
   def render("index.json", %{session_occurence: session_occurence}) do
     render_many(session_occurence, SessionOccurenceView, "session_occurence.json")
@@ -20,6 +21,7 @@ defmodule DbserviceWeb.SessionOccurenceView do
   end
 
   def render("session_occurence_with_users.json", %{session_occurence: session_occurence}) do
+    session_occurence = session_occurence |> Repo.preload(:users)
     %{
       id: session_occurence.id,
       start_time: session_occurence.start_time,


### PR DESCRIPTION
Targets #23 & #21

### Summary
1. Added imports to avoid warnings when running phoenix server
2. Preloading users in the view so that it only loads when `_with_users.json` is called and it works for create session occurrence endpoint as well along with show and update