### PR TITLE
#8 Single API for student & user registration

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -5,7 +5,7 @@ config :dbservice, Dbservice.Repo,
   username: "postgres",
   password: "postgres",
   hostname: "localhost",
-  database: "dbservice_dev",
+  database: "dbservice_seed",
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -5,7 +5,7 @@ config :dbservice, Dbservice.Repo,
   username: "postgres",
   password: "postgres",
   hostname: "localhost",
-  database: "dbservice_seed",
+  database: "dbservice_dev",
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
 

--- a/lib/dbservice/schools/enrollment_record.ex
+++ b/lib/dbservice/schools/enrollment_record.ex
@@ -2,12 +2,15 @@ defmodule Dbservice.Schools.EnrollmentRecord do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Dbservice.Users.Student
+  alias Dbservice.Schools.School
+
   schema "enrollment_record" do
     field :academic_year, :string
     field :grade, :string
     field :is_current, :boolean, default: false
-    belongs_to :student, Users.Student
-    belongs_to :school, Schools.School
+    belongs_to :student, Student
+    belongs_to :school, School
 
     timestamps()
   end

--- a/lib/dbservice/sessions/user_session.ex
+++ b/lib/dbservice/sessions/user_session.ex
@@ -2,6 +2,9 @@ defmodule Dbservice.Sessions.UserSession do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Dbservice.Users.User
+  alias Dbservice.Sessions.SessionOccurence
+
   schema "user_session" do
     field :end_time, :utc_datetime
     field :start_time, :utc_datetime
@@ -9,8 +12,8 @@ defmodule Dbservice.Sessions.UserSession do
 
     timestamps()
 
-    belongs_to :user, Users.User
-    belongs_to :session_occurence, Sessions.SessionOccurence
+    belongs_to :user, User
+    belongs_to :session_occurence, SessionOccurence
   end
 
   @doc false

--- a/lib/dbservice/users.ex
+++ b/lib/dbservice/users.ex
@@ -207,22 +207,22 @@ defmodule Dbservice.Users do
 
   ## Examples
 
-      iex> create_student(%{field: value})
+      iex> create_student_with_user(%{field: value})
       {:ok, %Student{}}
 
-      iex> create_student(%{field: bad_value})
+      iex> create_student_with_user(%{field: bad_value})
       {:error, %Ecto.Changeset{}}
 
   """
   def create_student_with_user(attrs \\ %{}) do
     alias Dbservice.Users
 
-    {:ok, user} = Users.create_user(attrs)
-    student_attrs = Map.merge(attrs, %{"user_id" => user.id})
-
-    %Student{}
-    |> Student.changeset(student_attrs)
-    |> Repo.insert()
+    with {:ok, %User{} = user} <- Users.create_user(attrs) do
+      student_attrs = Map.merge(attrs, %{"user_id" => user.id})
+      %Student{}
+      |> Student.changeset(student_attrs)
+      |> Repo.insert()
+    end
   end
 
   @doc """

--- a/lib/dbservice/users.ex
+++ b/lib/dbservice/users.ex
@@ -203,6 +203,29 @@ defmodule Dbservice.Users do
   end
 
   @doc """
+  Creates a user first and then the student.
+
+  ## Examples
+
+      iex> create_student(%{field: value})
+      {:ok, %Student{}}
+
+      iex> create_student(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_student_with_user(attrs \\ %{}) do
+    alias Dbservice.Users
+
+    {:ok, user} = Users.create_user(attrs)
+    student_attrs = Map.merge(attrs, %{"user_id" => user.id})
+
+    %Student{}
+    |> Student.changeset(student_attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
   Returns an `%Ecto.Changeset{}` for tracking student changes.
 
   ## Examples

--- a/lib/dbservice/users.ex
+++ b/lib/dbservice/users.ex
@@ -217,11 +217,10 @@ defmodule Dbservice.Users do
   def create_student_with_user(attrs \\ %{}) do
     alias Dbservice.Users
 
-    with {:ok, %User{} = user} <- Users.create_user(attrs) do
-      student_attrs = Map.merge(attrs, %{"user_id" => user.id})
-      %Student{}
-      |> Student.changeset(student_attrs)
-      |> Repo.insert()
+    with {:ok, %User{} = user} <- Users.create_user(attrs),
+         {:ok, %Student{} = student} <-
+           Users.create_student(Map.merge(attrs, %{"user_id" => user.id})) do
+      {:ok, student}
     end
   end
 

--- a/lib/dbservice/users/student.ex
+++ b/lib/dbservice/users/student.ex
@@ -1,6 +1,7 @@
 defmodule Dbservice.Users.Student do
   use Ecto.Schema
   import Ecto.Changeset
+
   alias Dbservice.Users.User
   alias Dbservice.Groups.Group
 

--- a/lib/dbservice/users/student.ex
+++ b/lib/dbservice/users/student.ex
@@ -1,6 +1,8 @@
 defmodule Dbservice.Users.Student do
   use Ecto.Schema
   import Ecto.Changeset
+  alias Dbservice.Users.User
+  alias Dbservice.Groups.Group
 
   schema "student" do
     field :category, :string
@@ -10,8 +12,8 @@ defmodule Dbservice.Users.Student do
     field :mother_phone, :string
     field :stream, :string
     field :uuid, :string
-    belongs_to :user, Users.User
-    belongs_to :group, Groups.Group
+    belongs_to :user, User
+    belongs_to :group, Group
 
     timestamps()
   end

--- a/lib/dbservice/users/teacher.ex
+++ b/lib/dbservice/users/teacher.ex
@@ -2,13 +2,16 @@ defmodule Dbservice.Users.Teacher do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Dbservice.Users.User
+  alias Dbservice.Schools.School
+
   schema "teacher" do
     field :designation, :string
     field :grade, :string
     field :subject, :string
-    belongs_to :user, Users.User
-    belongs_to :school, Schools.School
-    belongs_to :program_manager, Users.User
+    belongs_to :user, User
+    belongs_to :school, School
+    belongs_to :program_manager, User
 
     timestamps()
   end

--- a/lib/dbservice_web/controllers/student_controller.ex
+++ b/lib/dbservice_web/controllers/student_controller.ex
@@ -129,4 +129,12 @@ defmodule DbserviceWeb.StudentController do
       send_resp(conn, :no_content, "")
     end
   end
+
+  def register(conn, params) do
+    with {:ok, %Student{} = student} <- Users.create_student_with_user(params) do
+      conn
+      |> put_status(:created)
+      |> render("show_with_user.json", student: student)
+    end
+  end
 end

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -16,6 +16,7 @@ defmodule DbserviceWeb.Router do
     resources "/user", UserController, only: [:index, :create, :update, :show]
     post "/user/:id/update-batches", UserController, :update_batches
     resources "/student", StudentController, except: [:new, :edit]
+    post "/student/register", StudentController, :register
     resources "/teacher", TeacherController, except: [:new, :edit]
     resources "/school", SchoolController, except: [:new, :edit]
     resources "/enrollment-record", EnrollmentRecordController, except: [:new, :edit]

--- a/lib/dbservice_web/views/student_view.ex
+++ b/lib/dbservice_web/views/student_view.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.StudentView do
   use DbserviceWeb, :view
   alias DbserviceWeb.StudentView
+  alias DbserviceWeb.UserView
+  alias Dbservice.Repo
 
   def render("index.json", %{student: student}) do
     render_many(student, StudentView, "student.json")
@@ -8,6 +10,10 @@ defmodule DbserviceWeb.StudentView do
 
   def render("show.json", %{student: student}) do
     render_one(student, StudentView, "student.json")
+  end
+
+  def render("show_with_user.json", %{student: student}) do
+    render_one(student, StudentView, "student_with_user.json")
   end
 
   def render("student.json", %{student: student}) do
@@ -21,6 +27,22 @@ defmodule DbserviceWeb.StudentView do
       category: student.category,
       stream: student.stream,
       user_id: student.user_id,
+      group_id: student.group_id
+    }
+  end
+
+  def render("student_with_user.json", %{student: student}) do
+    student = Repo.preload(student, :user)
+    %{
+      id: student.id,
+      uuid: student.uuid,
+      father_name: student.father_name,
+      father_phone: student.father_phone,
+      mother_name: student.mother_name,
+      mother_phone: student.mother_phone,
+      category: student.category,
+      stream: student.stream,
+      user: render_one(student.user, UserView, "user.json"),
       group_id: student.group_id
     }
   end

--- a/lib/dbservice_web/views/student_view.ex
+++ b/lib/dbservice_web/views/student_view.ex
@@ -33,6 +33,7 @@ defmodule DbserviceWeb.StudentView do
 
   def render("student_with_user.json", %{student: student}) do
     student = Repo.preload(student, :user)
+
     %{
       id: student.id,
       uuid: student.uuid,


### PR DESCRIPTION
Requires #16 to be merged before

Targets #8 

### Summary
1. Single endpoint where the API client can send both user and student details in the payload and the service will create a user and a student for that.
2. The errors for user and student validation will happen as it is
3. Fixes in `belongs_to` for several structs as I figured that we need to explicitly import all the dependencies in Elixir to make things work as expected
4. `show_with_user.json` for student response to also include associated user info