### PR TITLE
Fix issue with missing fields in enrollment_record response

### DIFF
--- a/lib/dbservice_web/views/enrollment_record_view.ex
+++ b/lib/dbservice_web/views/enrollment_record_view.ex
@@ -14,7 +14,9 @@ defmodule DbserviceWeb.EnrollmentRecordView do
     %{
       id: enrollment_record.id,
       grade: enrollment_record.grade,
+      academic_year: enrollment_record.academic_year,
       is_current: enrollment_record.is_current,
+      board_medium: enrollment_record.board_medium,
       student_id: enrollment_record.student_id,
       school_id: enrollment_record.school_id,
       date_of_school_enrollment: enrollment_record.date_of_school_enrollment,


### PR DESCRIPTION
Issue_id #74 

###  **Description:**

This PR addresses an issue where two fields, academic_year and board_medium, were missing from the response of the /enrollment-record endpoint. To fix this, I added these fields to the EnrollmentRecordView module and updated the render function accordingly.

### **Checklist**

- [x] self review