### PR TITLE
Feat: Support multiple tags for resources using tag_ids array

### DIFF
--- a/lib/dbservice/resources/resource.ex
+++ b/lib/dbservice/resources/resource.ex
@@ -11,7 +11,6 @@ defmodule Dbservice.Resources.Resource do
   alias Dbservice.Purposes.Purpose
   alias Dbservice.Concepts.Concept
   alias Dbservice.LearningObjectives.LearningObjective
-  alias Dbservice.Tags.Tag
   alias Dbservice.Users.Teacher
 
   schema "resource" do
@@ -19,6 +18,7 @@ defmodule Dbservice.Resources.Resource do
     field(:type, :string)
     field(:type_params, :map)
     field(:difficulty_level, :string)
+    field(:tag_ids, {:array, :integer})
 
     timestamps()
 
@@ -29,7 +29,6 @@ defmodule Dbservice.Resources.Resource do
     belongs_to(:purpose, Purpose)
     belongs_to(:concept, Concept)
     belongs_to(:learning_objective, LearningObjective)
-    belongs_to(:tag, Tag)
     belongs_to(:teacher, Teacher)
   end
 
@@ -48,7 +47,7 @@ defmodule Dbservice.Resources.Resource do
       :purpose_id,
       :concept_id,
       :learning_objective_id,
-      :tag_id,
+      :tag_ids,
       :teacher_id
     ])
   end

--- a/lib/dbservice/tags/tag.ex
+++ b/lib/dbservice/tags/tag.ex
@@ -13,7 +13,6 @@ defmodule Dbservice.Tags.Tag do
   alias Dbservice.LearningObjectives.LearningObjective
   alias Dbservice.Purposes.Purpose
   alias Dbservice.Sources.Source
-  alias Dbservice.Resources.Resource
 
   schema "tag" do
     field(:name, :string)
@@ -30,7 +29,6 @@ defmodule Dbservice.Tags.Tag do
     has_one(:learning_objective, LearningObjective)
     has_one(:purpose, Purpose)
     has_one(:source, Source)
-    has_one(:resource, Resource)
   end
 
   @doc false

--- a/lib/dbservice_web/controllers/resource_controller.ex
+++ b/lib/dbservice_web/controllers/resource_controller.ex
@@ -135,11 +135,27 @@ defmodule DbserviceWeb.ResourceController do
   end
 
   defp update_existing_resource(conn, existing_resource, params) do
+    merged_params = merge_tag_ids(existing_resource, params)
+
     with {:ok, %Resource{} = resource} <-
-           Resources.update_resource(existing_resource, params) do
+           Resources.update_resource(existing_resource, merged_params) do
       conn
       |> put_status(:ok)
       |> render("show.json", resource: resource)
     end
+  end
+
+  defp merge_tag_ids(existing_resource, params) do
+    existing_tags = existing_resource.tag_ids || []
+    new_tags = Map.get(params, "tag_ids", [])
+
+    # Ensure unique tags, cast to integers if necessary
+    merged_tags =
+      (existing_tags ++ new_tags)
+      # Normalize to integers
+      |> Enum.map(&String.to_integer(to_string(&1)))
+      |> Enum.uniq()
+
+    Map.put(params, "tag_ids", merged_tags)
   end
 end

--- a/lib/dbservice_web/views/resource_view.ex
+++ b/lib/dbservice_web/views/resource_view.ex
@@ -28,7 +28,7 @@ defmodule DbserviceWeb.ResourceView do
       purpose_id: resource.purpose_id,
       concept_id: resource.concept_id,
       learning_objective_id: resource.learning_objective_id,
-      tag_id: resource.tag_id,
+      tag_ids: resource.tag_ids,
       teacher_id: resource.teacher_id,
       source: render_one(resource.source, SourceView, "source.json")
     }

--- a/priv/repo/migrations/20250528131316_alter_resource_table.exs
+++ b/priv/repo/migrations/20250528131316_alter_resource_table.exs
@@ -1,0 +1,10 @@
+defmodule Dbservice.Repo.Migrations.AlterResourceTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:resource) do
+      remove :tag_id
+      add :tag_ids, {:array, :bigint}
+    end
+  end
+end


### PR DESCRIPTION
### Description

**What changed:**

- Replaced the single `tag_id` field on the `resource` table with a `tag_ids` array.
- Updated resource creation and update logic to:
  - Accept multiple tag IDs.
  - Merge new tags into existing ones without duplication.
- Added helper logic to normalize and merge tag IDs safely.

**Why we did this:**

Previously, each resource could only belong to a single exam tag (e.g., JEE or NEET), which caused issues when a resource needed to be shown in both exams.

By switching to an array-based `tag_ids` approach:

- We support multi-tagging (e.g., `[1, 2]` for both JEE and NEET).
- Prevent data duplication.
- Improve flexibility for future tagging needs.

This change ensures Gurukul can correctly show overlapping resources across exams while keeping the data model clean and extensible.
