### PR TITLE
Fix user session filtering for quiz flag and batch ID matching

### DIFF
--- a/lib/dbservice_web/controllers/user_controller.ex
+++ b/lib/dbservice_web/controllers/user_controller.ex
@@ -223,7 +223,9 @@ defmodule DbserviceWeb.UserController do
       session ->
         session.is_active &&
           if quiz_flag && session.meta_data["batch_id"] != "" do
-            session.meta_data["batch_id"] == class_batch_id and session.platform == "quiz"
+            # Split the comma-separated batch_id and check if class_batch_id is in the list
+            batch_ids = String.split(session.meta_data["batch_id"], ",")
+            class_batch_id in batch_ids and session.platform == "quiz"
           else
             true
           end


### PR DESCRIPTION
### Problem
The `should_include_session?/3` function in `UserController` was not returning any results when filtering user sessions with the quiz flag enabled. This was due to:

- **Incorrect batch ID matching**: The function was doing direct string equality comparison between `class_batch_id` and `session.meta_data["batch_id"]`, but the latter contains a comma-separated list of multiple batch IDs

### Solution
- Modified batch ID matching to split the comma-separated `batch_id` field and check if `class_batch_id` exists within the list using the `in` operator

### Changes
- Fixed boolean logic in `should_include_session?/3` function
- Added proper handling for comma-separated batch ID values
- Ensured quiz sessions are correctly filtered based on batch membership

### Testing
- Confirmed that batch ID matching works correctly with comma-separated values