### PR TITLE
feat: Add cascading deletes for chapter and topic resources

### DIFF
--- a/lib/dbservice_web/controllers/chapter_controller.ex
+++ b/lib/dbservice_web/controllers/chapter_controller.ex
@@ -6,6 +6,7 @@ defmodule DbserviceWeb.ChapterController do
   alias Dbservice.Chapters
   alias Dbservice.Chapters.Chapter
   alias Dbservice.ChapterCurriculums.ChapterCurriculum
+  alias Dbservice.Resources.ResourceChapter
   alias Dbservice.Utils.Util
 
   action_fallback(DbserviceWeb.FallbackController)
@@ -156,6 +157,10 @@ defmodule DbserviceWeb.ChapterController do
     Repo.transaction(fn ->
       # First delete related chapter_curriculum records
       from(cc in ChapterCurriculum, where: cc.chapter_id == ^id)
+      |> Repo.delete_all()
+
+      # Delete related resource_chapter records
+      from(rc in ResourceChapter, where: rc.chapter_id == ^id)
       |> Repo.delete_all()
 
       # Then retrieve and delete the chapter


### PR DESCRIPTION
## Summary
Enhanced the delete operations for chapters and topics to properly handle cascading deletes of related records, preventing foreign key constraint violations.

## Changes
### Chapter Deletion
- Added deletion of `resource_chapter` records before deleting the chapter
- Maintains existing `chapter_curriculum` deletion logic
- All deletions wrapped in a transaction for atomicity

### Topic Deletion
- Added deletion of `topic_curriculum` records before deleting the topic
- Added deletion of `resource_topic` records before deleting the topic
- Implemented transaction-based deletion similar to chapter deletion
- Added proper error handling with 422 status on failure

## Technical Details
- Both delete operations now use `Repo.transaction` to ensure all-or-nothing behavior
- Related records are deleted in the correct order to avoid foreign key constraint errors
- Consistent error handling pattern across both controllers

## Testing
- [x] Verified chapter deletion with associated curriculum and resource records
- [x] Verified topic deletion with associated curriculum and resource records
- [x] Confirmed transaction rollback on failure

## Related Tables
- `chapter_curriculum`
- `resource_chapter`
- `topic_curriculum`
- `resource_topic`