### PR TITLE
fix: make grade id optional

### DIFF
--- a/lib/dbservice/resources/resource_curriculum.ex
+++ b/lib/dbservice/resources/resource_curriculum.ex
@@ -32,8 +32,7 @@ defmodule Dbservice.Resources.ResourceCurriculum do
     ])
     |> validate_required([
       :resource_id,
-      :curriculum_id,
-      :grade_id
+      :curriculum_id
     ])
   end
 end

--- a/lib/dbservice/utils/import_worker.ex
+++ b/lib/dbservice/utils/import_worker.ex
@@ -1431,9 +1431,8 @@ defmodule Dbservice.DataImport.ImportWorker do
     end
   end
 
-  defp ensure_resource_curriculums(_resource_id, _curriculum_ids, grade_id, _subject_id)
-       when is_nil(grade_id) or grade_id == "",
-       do: :ok
+  defp ensure_resource_curriculums(_resource_id, nil, _grade_id, _subject_id), do: :ok
+  defp ensure_resource_curriculums(_resource_id, [], _grade_id, _subject_id), do: :ok
 
   defp ensure_resource_curriculums(resource_id, curriculum_ids, grade_id, subject_id) do
     Enum.reduce_while(curriculum_ids, :ok, fn cid, :ok ->


### PR DESCRIPTION
### Description
- Made grade id optional in resource-curriculum creation

### Checklist
- [x] Locally tested