### PR TITLE
✨ Auto-generate resource codes on create (non-problem) if not provided + 🔧 controller wiring

### DIFF
--- a/lib/dbservice/resources.ex
+++ b/lib/dbservice/resources.ex
@@ -16,6 +16,14 @@ defmodule Dbservice.Resources do
   alias Dbservice.Topics.Topic
   alias Dbservice.ChapterCurriculums
 
+  # Type + subtype → code_prefix; keep in sync with resource_types in priv/repo/seeds/resources.exs
+  @non_problem_code_prefixes %{
+    {"document", "Module"} => "M",
+    {"video", "Video Lectures"} => "V",
+    {"quiz", "Assessment"} => "Q",
+    {"document", "Previous Year Questions"} => "PYQ"
+  }
+
   @doc """
   Returns the list of resource.
   ## Examples
@@ -316,6 +324,64 @@ defmodule Dbservice.Resources do
       %Resource{}
       |> Resource.changeset(attrs)
       |> Repo.insert()
+    end
+  end
+
+  @doc """
+  After insert: problems always get `P` + zero-padded id; other types get `<prefix>-<id>` when `code` is blank.
+  Prefix comes from type/subtype (see seeds `resource_types`); unknown combinations use the first letter of `type`.
+  """
+  def assign_code_after_insert(%Resource{type: "problem"} = resource) do
+    code = generate_next_resource_code(resource.id)
+
+    case update_resource(resource, %{code: code}) do
+      {:ok, updated} -> updated
+      {:error, _} -> resource
+    end
+  end
+
+  def assign_code_after_insert(%Resource{} = resource) do
+    if code_blank?(resource.code) do
+      prefix = code_prefix_for_non_problem(resource)
+      new_code = "#{prefix}-#{resource.id}"
+
+      case update_resource(resource, %{code: new_code}) do
+        {:ok, updated} -> updated
+        {:error, _} -> resource
+      end
+    else
+      resource
+    end
+  end
+
+  defp code_blank?(nil), do: true
+  defp code_blank?(""), do: true
+
+  defp code_blank?(s) when is_binary(s) do
+    s |> String.trim() |> Kernel.==("")
+  end
+
+  defp code_blank?(_), do: true
+
+  defp code_prefix_for_non_problem(%Resource{type: type, subtype: subtype}) do
+    t = normalize_type_subtype_string(type)
+    s = normalize_type_subtype_string(subtype)
+
+    Map.get(@non_problem_code_prefixes, {t, s}) || fallback_code_prefix(t)
+  end
+
+  defp normalize_type_subtype_string(nil), do: ""
+  defp normalize_type_subtype_string(s) when is_binary(s), do: String.trim(s)
+
+  defp normalize_type_subtype_string(s),
+    do: s |> to_string() |> String.trim()
+
+  defp fallback_code_prefix(""), do: "R"
+
+  defp fallback_code_prefix(t) do
+    case String.first(t) do
+      nil -> "R"
+      c -> String.upcase(c)
     end
   end
 

--- a/lib/dbservice_web/controllers/resource_controller.ex
+++ b/lib/dbservice_web/controllers/resource_controller.ex
@@ -333,7 +333,7 @@ defmodule DbserviceWeb.ResourceController do
   defp handle_resource_creation_and_association(params) do
     case Resources.create_resource(params) do
       {:ok, %Resource{} = resource} ->
-        resource = update_code_if_problem(resource)
+        resource = Resources.assign_code_after_insert(resource)
         handle_curriculum_and_related_inserts(resource, params)
 
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -341,16 +341,6 @@ defmodule DbserviceWeb.ResourceController do
 
       {:error, reason} ->
         Repo.rollback({:cms_status_error, reason})
-    end
-  end
-
-  defp update_code_if_problem(resource) do
-    if resource.type == "problem" do
-      code = Resources.generate_next_resource_code(resource.id)
-      {:ok, updated_resource} = Resources.update_resource(resource, %{code: code})
-      updated_resource
-    else
-      resource
     end
   end
 


### PR DESCRIPTION
## Summary

🎯 This PR adds **automatic `code` assignment** when creating resources via the API **if `code` is omitted or blank**, for **non-`problem`** types. **`problem`** resources keep the existing **`P` + zero-padded id** behavior.

---

## What changed

### ✨ Resource code generation (`lib/dbservice/resources.ex`)

- **`assign_code_after_insert/1`**
  - **`problem`:** still uses `generate_next_resource_code/1` (unchanged product behavior).
  - **Other types:** if `code` is blank, sets **`<prefix>-<resource.id>`**.
- **Prefix map** aligned with `priv/repo/seeds/resources.exs` (`resource_types`):
  - **document** + **Module** → `M`
  - **video** + **Video Lectures** → `V`
  - **quiz** + **Assessment** → `Q`
  - **document** + **Previous Year Questions** → `PYQ`
- **Fallback:** first letter of `type` (uppercased), or `R` if empty.

### 🌐 API (`lib/dbservice_web/controllers/resource_controller.ex`)

- After **`create_resource`**, calls **`Resources.assign_code_after_insert/1`** so the **201 response** includes the final **`code`** (JSON already exposes `code`).

---

## How to verify

1. **POST** `/api/resource` with a non-`problem` type/subtype from the table above, **omit `code`** → response body should show e.g. `M-12345`.
2. **POST** a **`problem`** → `code` should match **`P0000123`** style (existing behavior).
3. **POST** with an explicit **`code`** → value should **not** be overwritten.
