### PR TITLE
feat: Add paragraphs API and paragraph table

### DIFF
--- a/lib/dbservice/paragraphs.ex
+++ b/lib/dbservice/paragraphs.ex
@@ -1,6 +1,7 @@
 defmodule Dbservice.Paragraphs do
   @moduledoc """
-  Paragraphs bundle multilingual instructional text with linked `problem_lang` rows.
+  Paragraphs store multilingual instructional text (`body`); linked problems use
+  `problem_lang` rows with `paragraph_id` (language per problem is `problem_lang.lang_id`).
   """
 
   import Ecto.Query, warn: false
@@ -20,16 +21,15 @@ defmodule Dbservice.Paragraphs do
 
   def get_paragraph_with_problem_langs!(id) do
     paragraph = Repo.get!(Paragraph, id)
-    problem_langs = list_problem_langs_for_paragraph(id, paragraph.lang_id)
+    problem_langs = list_problem_langs_for_paragraph(id)
     %{paragraph: paragraph, problem_langs: problem_langs}
   end
 
-  def list_problem_langs_for_paragraph(paragraph_id, lang_id \\ nil) do
+  def list_problem_langs_for_paragraph(paragraph_id) do
     from(pl in ProblemLanguage,
       join: r in Resource,
       on: r.id == pl.res_id,
       where: r.type == "problem" and pl.paragraph_id == ^paragraph_id,
-      where: is_nil(^lang_id) or pl.lang_id == ^lang_id,
       order_by: [asc: pl.id]
     )
     |> Repo.all()

--- a/lib/dbservice/paragraphs.ex
+++ b/lib/dbservice/paragraphs.ex
@@ -1,6 +1,6 @@
 defmodule Dbservice.Paragraphs do
   @moduledoc """
-  Paragraphs store multilingual instructional text (`body`); linked problems use
+  Paragraphs store instructional text (`body`); linked problems use
   `problem_lang` rows with `paragraph_id` (language per problem is `problem_lang.lang_id`).
   """
 

--- a/lib/dbservice/paragraphs.ex
+++ b/lib/dbservice/paragraphs.ex
@@ -1,0 +1,63 @@
+defmodule Dbservice.Paragraphs do
+  @moduledoc """
+  Paragraphs bundle multilingual instructional text with linked `problem_lang` rows.
+  """
+
+  import Ecto.Query, warn: false
+  alias Dbservice.Repo
+
+  alias Dbservice.Resources.Resource
+  alias Dbservice.Resources.ProblemLanguage
+  alias Dbservice.Resources.Paragraph
+
+  def list_paragraph do
+    Repo.all(from(p in Paragraph, order_by: [asc: p.id]))
+  end
+
+  def fetch_paragraph!(id), do: Repo.get!(Paragraph, id)
+
+  def get_paragraph!(id), do: Repo.get!(Paragraph, id)
+
+  def get_paragraph_with_problem_langs!(id) do
+    paragraph = Repo.get!(Paragraph, id)
+    problem_langs = list_problem_langs_for_paragraph(id, paragraph.lang_id)
+    %{paragraph: paragraph, problem_langs: problem_langs}
+  end
+
+  def list_problem_langs_for_paragraph(paragraph_id, lang_id \\ nil) do
+    # We store paragraph linkage in `resource.type_params` since it is not language-dependent.
+    #
+    # Expected shape for problem resources:
+    # type_params: %{ "paragraph_id" => <paragraph_id> }
+    from(pl in ProblemLanguage,
+      join: r in Resource,
+      on: r.id == pl.res_id,
+      where:
+        r.type == "problem" and
+          fragment("?->>'paragraph_id' = ?", r.type_params, ^to_string(paragraph_id)),
+      where: is_nil(^lang_id) or pl.lang_id == ^lang_id,
+      order_by: [asc: pl.id]
+    )
+    |> Repo.all()
+  end
+
+  def create_paragraph(attrs \\ %{}) do
+    %Paragraph{}
+    |> Paragraph.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def update_paragraph(%Paragraph{} = paragraph, attrs) do
+    paragraph
+    |> Paragraph.changeset(attrs)
+    |> Repo.update()
+  end
+
+  def delete_paragraph(%Paragraph{} = paragraph) do
+    Repo.delete(paragraph)
+  end
+
+  def change_paragraph(%Paragraph{} = paragraph, attrs \\ %{}) do
+    Paragraph.changeset(paragraph, attrs)
+  end
+end

--- a/lib/dbservice/paragraphs.ex
+++ b/lib/dbservice/paragraphs.ex
@@ -25,16 +25,10 @@ defmodule Dbservice.Paragraphs do
   end
 
   def list_problem_langs_for_paragraph(paragraph_id, lang_id \\ nil) do
-    # We store paragraph linkage in `resource.type_params` since it is not language-dependent.
-    #
-    # Expected shape for problem resources:
-    # type_params: %{ "paragraph_id" => <paragraph_id> }
     from(pl in ProblemLanguage,
       join: r in Resource,
       on: r.id == pl.res_id,
-      where:
-        r.type == "problem" and
-          fragment("?->>'paragraph_id' = ?", r.type_params, ^to_string(paragraph_id)),
+      where: r.type == "problem" and pl.paragraph_id == ^paragraph_id,
       where: is_nil(^lang_id) or pl.lang_id == ^lang_id,
       order_by: [asc: pl.id]
     )

--- a/lib/dbservice/resources/paragraph.ex
+++ b/lib/dbservice/resources/paragraph.ex
@@ -1,0 +1,22 @@
+defmodule Dbservice.Resources.Paragraph do
+  @moduledoc false
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Dbservice.Languages.Language
+
+  schema "paragraph" do
+    field(:body, {:array, :map})
+    belongs_to(:language, Language, foreign_key: :lang_id)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(paragraph, attrs) do
+    paragraph
+    |> cast(attrs, [:body, :lang_id])
+    |> validate_required([:body, :lang_id])
+  end
+end

--- a/lib/dbservice/resources/paragraph.ex
+++ b/lib/dbservice/resources/paragraph.ex
@@ -5,7 +5,7 @@ defmodule Dbservice.Resources.Paragraph do
   import Ecto.Changeset
 
   schema "paragraph" do
-    field(:body, {:array, :map})
+    field(:body, :string)
 
     timestamps()
   end

--- a/lib/dbservice/resources/paragraph.ex
+++ b/lib/dbservice/resources/paragraph.ex
@@ -4,11 +4,8 @@ defmodule Dbservice.Resources.Paragraph do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Dbservice.Languages.Language
-
   schema "paragraph" do
     field(:body, {:array, :map})
-    belongs_to(:language, Language, foreign_key: :lang_id)
 
     timestamps()
   end
@@ -16,7 +13,7 @@ defmodule Dbservice.Resources.Paragraph do
   @doc false
   def changeset(paragraph, attrs) do
     paragraph
-    |> cast(attrs, [:body, :lang_id])
-    |> validate_required([:body, :lang_id])
+    |> cast(attrs, [:body])
+    |> validate_required([:body])
   end
 end

--- a/lib/dbservice/resources/problem_language.ex
+++ b/lib/dbservice/resources/problem_language.ex
@@ -4,11 +4,13 @@ defmodule Dbservice.Resources.ProblemLanguage do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Dbservice.Resources.Paragraph
   alias Dbservice.Resources.Resource
   alias Dbservice.Languages.Language
 
   schema "problem_lang" do
     field(:meta_data, :map)
+    belongs_to(:paragraph, Paragraph)
     belongs_to :resource, Resource, foreign_key: :res_id
     belongs_to :language, Language, foreign_key: :lang_id
 
@@ -21,7 +23,8 @@ defmodule Dbservice.Resources.ProblemLanguage do
     |> cast(attrs, [
       :res_id,
       :lang_id,
-      :meta_data
+      :meta_data,
+      :paragraph_id
     ])
     |> validate_required([
       :res_id,

--- a/lib/dbservice_web/controllers/paragraph_controller.ex
+++ b/lib/dbservice_web/controllers/paragraph_controller.ex
@@ -1,0 +1,118 @@
+defmodule DbserviceWeb.ParagraphController do
+  use DbserviceWeb, :controller
+
+  import Ecto.Query
+  alias Dbservice.Repo
+  alias Dbservice.Paragraphs
+  alias Dbservice.Resources.Paragraph
+
+  action_fallback(DbserviceWeb.FallbackController)
+
+  use PhoenixSwagger
+
+  alias DbserviceWeb.SwaggerSchema.Paragraph, as: SwaggerSchemaParagraph
+
+  def swagger_definitions do
+    Map.merge(
+      SwaggerSchemaParagraph.paragraph(),
+      SwaggerSchemaParagraph.paragraphs()
+    )
+  end
+
+  swagger_path :index do
+    get("/api/paragraph")
+
+    response(200, "OK", Schema.ref(:Paragraphs))
+  end
+
+  def index(conn, params) do
+    query =
+      from(m in Paragraph,
+        order_by: [asc: m.id],
+        offset: ^params["offset"],
+        limit: ^params["limit"]
+      )
+
+    query =
+      Enum.reduce(params, query, fn {key, _value}, acc ->
+        case String.to_existing_atom(key) do
+          :offset -> acc
+          :limit -> acc
+          _atom -> acc
+        end
+      end)
+
+    paragraph = Repo.all(query)
+    render(conn, :index, paragraph: paragraph)
+  end
+
+  swagger_path :create do
+    post("/api/paragraph")
+
+    parameters do
+      body(:body, Schema.ref(:Paragraph), "Paragraph to create", required: true)
+    end
+
+    response(201, "Created", Schema.ref(:Paragraph))
+  end
+
+  def create(conn, params) do
+    with {:ok, %Paragraph{} = paragraph} <- Paragraphs.create_paragraph(params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", ~p"/api/paragraph/#{paragraph}")
+      |> render(:show, Paragraphs.get_paragraph_with_problem_langs!(paragraph.id))
+    end
+  end
+
+  swagger_path :show do
+    get("/api/paragraph/{paragraphId}")
+
+    parameters do
+      paragraphId(:path, :integer, "The id of the paragraph record", required: true)
+    end
+
+    response(200, "OK", Schema.ref(:Paragraph))
+  end
+
+  def show(conn, %{"id" => id}) do
+    render(conn, :show, Paragraphs.get_paragraph_with_problem_langs!(id))
+  end
+
+  swagger_path :update do
+    patch("/api/paragraph/{paragraphId}")
+
+    parameters do
+      paragraphId(:path, :integer, "The id of the paragraph record", required: true)
+      body(:body, Schema.ref(:Paragraph), "Paragraph to update", required: true)
+    end
+
+    response(200, "Updated", Schema.ref(:Paragraph))
+  end
+
+  def update(conn, params) do
+    paragraph = Paragraphs.fetch_paragraph!(params["id"])
+
+    with {:ok, %Paragraph{} = paragraph} <- Paragraphs.update_paragraph(paragraph, params) do
+      render(conn, :show, Paragraphs.get_paragraph_with_problem_langs!(paragraph.id))
+    end
+  end
+
+  swagger_path :delete do
+    PhoenixSwagger.Path.delete("/api/paragraph/{paragraphId}")
+
+    parameters do
+      paragraphId(:path, :integer, "The id of the paragraph record", required: true)
+    end
+
+    response(204, "No Content")
+  end
+
+  def delete(conn, %{"id" => id}) do
+    paragraph = Paragraphs.fetch_paragraph!(id)
+
+    with {:ok, %Paragraph{}} <- Paragraphs.delete_paragraph(paragraph) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/dbservice_web/json/paragraph_json.ex
+++ b/lib/dbservice_web/json/paragraph_json.ex
@@ -1,0 +1,26 @@
+defmodule DbserviceWeb.ParagraphJSON do
+  alias DbserviceWeb.ProblemLanguageJSON
+
+  def index(%{paragraph: paragraph}) do
+    for(p <- paragraph, do: render(p))
+  end
+
+  def show(%{paragraph: paragraph, problem_langs: problem_langs}) do
+    render(paragraph, problem_langs)
+  end
+
+  def render(%Dbservice.Resources.Paragraph{} = paragraph, problem_langs \\ nil) do
+    base =
+      %{
+        id: paragraph.id,
+        body: paragraph.body,
+        lang_id: paragraph.lang_id
+      }
+
+    if is_list(problem_langs) do
+      Map.put(base, :problem_langs, Enum.map(problem_langs, &ProblemLanguageJSON.render/1))
+    else
+      base
+    end
+  end
+end

--- a/lib/dbservice_web/json/paragraph_json.ex
+++ b/lib/dbservice_web/json/paragraph_json.ex
@@ -13,8 +13,7 @@ defmodule DbserviceWeb.ParagraphJSON do
     base =
       %{
         id: paragraph.id,
-        body: paragraph.body,
-        lang_id: paragraph.lang_id
+        body: paragraph.body
       }
 
     if is_list(problem_langs) do

--- a/lib/dbservice_web/json/problem_language_json.ex
+++ b/lib/dbservice_web/json/problem_language_json.ex
@@ -7,7 +7,7 @@ defmodule DbserviceWeb.ProblemLanguageJSON do
     render(problem_language)
   end
 
-  defp render(problem_language) do
+  def render(problem_language) do
     %{
       id: problem_language.id,
       res_id: problem_language.res_id,

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -133,6 +133,7 @@ defmodule DbserviceWeb.Router do
     resources("/resource-topic", ResourceTopicController, except: [:new, :edit])
     resources("/resource-concept", ResourceConceptController, except: [:new, :edit])
     resources("/problem-language", ProblemLanguageController, except: [:new, :edit])
+    resources("/paragraph", ParagraphController, except: [:new, :edit])
     get("/resource/test/:id/problems", ResourceController, :test_problems)
     get("/problems", ResourceController, :fetch_problems)
     resources("/test-rule", TestRuleController, except: [:new, :edit])

--- a/lib/dbservice_web/swagger_schemas/paragraph.ex
+++ b/lib/dbservice_web/swagger_schemas/paragraph.ex
@@ -8,7 +8,11 @@ defmodule DbserviceWeb.SwaggerSchema.Paragraph do
       Paragraph:
         swagger_schema do
           title("Paragraph")
-          description("Instructional paragraph text with optional linked problem_lang rows")
+
+          description(
+            "Instructional paragraph text; problems are linked via problem_lang.paragraph_id " <>
+              "(each problem_lang row carries lang_id)"
+          )
 
           properties do
             body(
@@ -19,16 +23,13 @@ defmodule DbserviceWeb.SwaggerSchema.Paragraph do
                 %{lang: "hi", value: "निम्नलिखित पढ़ें और नीचे दिए प्रश्नों के उत्तर दें।"}
               ]
             )
-
-            lang_id(:integer, "Language id for this paragraph record")
           end
 
           example(%{
             body: [
               %{lang: "en", value: "Read the passage carefully."},
               %{lang: "hi", value: "पैराग्राफ ध्यान से पढ़ें।"}
-            ],
-            lang_id: 1
+            ]
           })
         end
     }

--- a/lib/dbservice_web/swagger_schemas/paragraph.ex
+++ b/lib/dbservice_web/swagger_schemas/paragraph.ex
@@ -1,0 +1,48 @@
+defmodule DbserviceWeb.SwaggerSchema.Paragraph do
+  @moduledoc false
+
+  use PhoenixSwagger
+
+  def paragraph do
+    %{
+      Paragraph:
+        swagger_schema do
+          title("Paragraph")
+          description("Instructional paragraph text with optional linked problem_lang rows")
+
+          properties do
+            body(
+              Schema.array(:object),
+              "Multilingual paragraph body, each entry with lang and value",
+              example: [
+                %{lang: "en", value: "Read the following and answer the questions below."},
+                %{lang: "hi", value: "निम्नलिखित पढ़ें और नीचे दिए प्रश्नों के उत्तर दें।"}
+              ]
+            )
+
+            lang_id(:integer, "Language id for this paragraph record")
+          end
+
+          example(%{
+            body: [
+              %{lang: "en", value: "Read the passage carefully."},
+              %{lang: "hi", value: "पैराग्राफ ध्यान से पढ़ें।"}
+            ],
+            lang_id: 1
+          })
+        end
+    }
+  end
+
+  def paragraphs do
+    %{
+      Paragraphs:
+        swagger_schema do
+          title("Paragraphs")
+          description("All paragraph records")
+          type(:array)
+          items(Schema.ref(:Paragraph))
+        end
+    }
+  end
+end

--- a/lib/dbservice_web/swagger_schemas/paragraph.ex
+++ b/lib/dbservice_web/swagger_schemas/paragraph.ex
@@ -16,20 +16,14 @@ defmodule DbserviceWeb.SwaggerSchema.Paragraph do
 
           properties do
             body(
-              Schema.array(:object),
-              "Multilingual paragraph body, each entry with lang and value",
-              example: [
-                %{lang: "en", value: "Read the following and answer the questions below."},
-                %{lang: "hi", value: "निम्नलिखित पढ़ें और नीचे दिए प्रश्नों के उत्तर दें।"}
-              ]
+              :string,
+              "Instructional paragraph body (plain text)",
+              example: "Read the following and answer the questions below."
             )
           end
 
           example(%{
-            body: [
-              %{lang: "en", value: "Read the passage carefully."},
-              %{lang: "hi", value: "पैराग्राफ ध्यान से पढ़ें।"}
-            ]
+            body: "Read the passage carefully."
           })
         end
     }

--- a/priv/repo/migrations/20260421120000_create_paragraph_tables.exs
+++ b/priv/repo/migrations/20260421120000_create_paragraph_tables.exs
@@ -3,7 +3,7 @@ defmodule Dbservice.Repo.Migrations.CreateParagraphTables do
 
   def change do
     create table(:paragraph) do
-      add :body, :jsonb, null: false
+      add(:body, :text, null: false)
       timestamps()
     end
   end

--- a/priv/repo/migrations/20260421120000_create_paragraph_tables.exs
+++ b/priv/repo/migrations/20260421120000_create_paragraph_tables.exs
@@ -1,0 +1,13 @@
+defmodule Dbservice.Repo.Migrations.CreateParagraphTables do
+  use Ecto.Migration
+
+  def change do
+    create table(:paragraph) do
+      add :body, :jsonb, null: false
+      add :lang_id, references(:language, on_delete: :nothing), null: false
+      timestamps()
+    end
+
+    create index(:paragraph, [:lang_id])
+  end
+end

--- a/priv/repo/migrations/20260421120000_create_paragraph_tables.exs
+++ b/priv/repo/migrations/20260421120000_create_paragraph_tables.exs
@@ -4,10 +4,7 @@ defmodule Dbservice.Repo.Migrations.CreateParagraphTables do
   def change do
     create table(:paragraph) do
       add :body, :jsonb, null: false
-      add :lang_id, references(:language, on_delete: :nothing), null: false
       timestamps()
     end
-
-    create index(:paragraph, [:lang_id])
   end
 end

--- a/priv/repo/migrations/20260422160000_add_paragraph_id_to_problem_lang.exs
+++ b/priv/repo/migrations/20260422160000_add_paragraph_id_to_problem_lang.exs
@@ -1,0 +1,11 @@
+defmodule Dbservice.Repo.Migrations.AddParagraphIdToProblemLang do
+  use Ecto.Migration
+
+  def change do
+    alter table(:problem_lang) do
+      add :paragraph_id, references(:paragraph, on_delete: :nilify_all)
+    end
+
+    create index(:problem_lang, [:paragraph_id])
+  end
+end


### PR DESCRIPTION
## Summary
- Adds new `paragraph` table with `body` as JSONB and `lang_id` (FK to `language`) via migration `20260421120000_create_paragraph_tables.exs`.
- Introduces `Paragraph` schema + `Paragraphs` context and exposes CRUD endpoints at `/api/paragraph` (router + controller + JSON + swagger schema).
- `GET /api/paragraph/:id` returns the paragraph plus related `problem_lang` rows for the same language by joining `problem_lang` → `resource` where `resource.type_params["paragraph_id"] == paragraph.id` and `problem_lang.lang_id == paragraph.lang_id`.
- Makes `ProblemLanguageJSON.render/1` public for reuse in nested responses.

## Notes / non-goals
- No ordering/`position` logic included (problem_langs returned in stable `id` order).
- Paragraph ↔ problems association is not a new table; it’s derived from existing `resource.type_params.paragraph_id`.

## Test plan
- Run `mix ecto.migrate`
- Start server and verify:
  - `POST /api/paragraph` with `body` + `lang_id`
  - `GET /api/paragraph/:id` includes `problem_langs` when matching `resource.type_params.paragraph_id`