### PR TITLE
fix(ci): replace deprecated GitHub Actions syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Find yarn cache location
         id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/production_deploy.yml
+++ b/.github/workflows/production_deploy.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
   Deploy:
     needs: build
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Deploy in EC2
         env:
           PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY  }}


### PR DESCRIPTION
## Summary

Fixes deprecated GitHub Actions syntax that will cause CI failures.

## Changes

- Replace deprecated `::set-output` command with `$GITHUB_OUTPUT` environment file in `ci.yml`
- Update `actions/checkout` from v2 to v4 in `production_deploy.yml`

## Issue

Fixes #460

## Testing

- [ ] CI pipeline runs without deprecation warnings
- [ ] Yarn cache works correctly
- [ ] Production deployment workflow functions properly