### PR TITLE
fix: DELETE /api/resource/:id by deleting associations first

### DIFF
--- a/lib/dbservice/resources.ex
+++ b/lib/dbservice/resources.ex
@@ -411,20 +411,7 @@ defmodule Dbservice.Resources do
   """
   def delete_resource(%Resource{} = resource) do
     Repo.transaction(fn ->
-      from(rch in Dbservice.Resources.ResourceChapter, where: rch.resource_id == ^resource.id)
-      |> Repo.delete_all()
-
-      from(rc in Dbservice.Resources.ResourceCurriculum, where: rc.resource_id == ^resource.id)
-      |> Repo.delete_all()
-
-      from(rt in Dbservice.Resources.ResourceTopic, where: rt.resource_id == ^resource.id)
-      |> Repo.delete_all()
-
-      from(rco in Dbservice.Resources.ResourceConcept, where: rco.resource_id == ^resource.id)
-      |> Repo.delete_all()
-
-      from(pl in Dbservice.Resources.ProblemLanguage, where: pl.res_id == ^resource.id)
-      |> Repo.delete_all()
+      delete_resource_associations(resource.id)
 
       resource
       |> Ecto.Changeset.change()
@@ -443,6 +430,20 @@ defmodule Dbservice.Resources do
       {:ok, {:error, %Ecto.Changeset{} = changeset}} -> {:error, changeset}
       {:error, reason} -> {:error, inspect(reason)}
     end
+  end
+
+  defp delete_resource_associations(resource_id) do
+    [
+      {Dbservice.Resources.ResourceChapter, :resource_id},
+      {Dbservice.Resources.ResourceCurriculum, :resource_id},
+      {Dbservice.Resources.ResourceTopic, :resource_id},
+      {Dbservice.Resources.ResourceConcept, :resource_id},
+      {Dbservice.Resources.ProblemLanguage, :res_id}
+    ]
+    |> Enum.each(fn {schema, fk_field} ->
+      from(r in schema, where: field(r, ^fk_field) == ^resource_id)
+      |> Repo.delete_all()
+    end)
   end
 
   @doc """

--- a/lib/dbservice/resources.ex
+++ b/lib/dbservice/resources.ex
@@ -410,7 +410,39 @@ defmodule Dbservice.Resources do
       {:error, %Ecto.Changeset{}}
   """
   def delete_resource(%Resource{} = resource) do
-    Repo.delete(resource)
+    Repo.transaction(fn ->
+      from(rch in Dbservice.Resources.ResourceChapter, where: rch.resource_id == ^resource.id)
+      |> Repo.delete_all()
+
+      from(rc in Dbservice.Resources.ResourceCurriculum, where: rc.resource_id == ^resource.id)
+      |> Repo.delete_all()
+
+      from(rt in Dbservice.Resources.ResourceTopic, where: rt.resource_id == ^resource.id)
+      |> Repo.delete_all()
+
+      from(rco in Dbservice.Resources.ResourceConcept, where: rco.resource_id == ^resource.id)
+      |> Repo.delete_all()
+
+      from(pl in Dbservice.Resources.ProblemLanguage, where: pl.res_id == ^resource.id)
+      |> Repo.delete_all()
+
+      resource
+      |> Ecto.Changeset.change()
+      |> Ecto.Changeset.foreign_key_constraint(:id,
+        name: "resource_chapter_resource_id_fkey",
+        message: "cannot delete: linked to a chapter (resource_chapter)"
+      )
+      |> Ecto.Changeset.foreign_key_constraint(:id,
+        name: "resource_curriculum_resource_id_fkey",
+        message: "cannot delete: linked to a curriculum/grade/subject (resource_curriculum)"
+      )
+      |> Repo.delete()
+    end)
+    |> case do
+      {:ok, {:ok, deleted}} -> {:ok, deleted}
+      {:ok, {:error, %Ecto.Changeset{} = changeset}} -> {:error, changeset}
+      {:error, reason} -> {:error, inspect(reason)}
+    end
   end
 
   @doc """


### PR DESCRIPTION
## Summary
- Fixed `DELETE /api/resource/:id` to delete dependent association rows first (`resource_chapter`, `resource_curriculum`, `resource_topic`, `resource_concept`, `problem_lang`) in a transaction, then delete the `resource`.
- Prevents `Ecto.ConstraintError` crashes from FK constraints like `resource_chapter_resource_id_fkey` / `resource_curriculum_resource_id_fkey`.

## Behavior changes
- Deleting a resource now also removes its join-table/child association records automatically.

## Test plan
- Pick a resource that has chapter/curriculum/topic/concept/problem_lang associations.
- `DELETE /api/resource/:id` → expect `204 No Content`.
- Verify the association rows for that `resource_id` are gone (and the resource is deleted).
