### PR TITLE
feat: Add batch create/update endpoints for problem resources

### DIFF
--- a/lib/dbservice/paragraphs.ex
+++ b/lib/dbservice/paragraphs.ex
@@ -150,8 +150,10 @@ defmodule Dbservice.Paragraphs do
   @doc """
   Builds attrs for inserting a `problem_lang` row when creating a resource.
 
-  For comprehension problems, requires a `paragraph` body, creates a paragraph row,
-  and sets `paragraph_id` on the `problem_lang` row. `meta_data` is forwarded as-is.
+  For comprehension problems, the linked `paragraph_id` is resolved in this order:
+  1. `params["paragraph_id"]` when an integer (e.g. injected by batch endpoint with a shared paragraph).
+  2. `params["paragraph"]` body string — a new paragraph row is created and its id used.
+  3. Otherwise, returns `{:error, {:missing_paragraph_body, _}}`.
 
   ## Examples
 
@@ -180,25 +182,37 @@ defmodule Dbservice.Paragraphs do
 
   @doc false
   defp build_comprehension_insert_attrs(resource, params, lang_id) do
+    case Map.get(params, "paragraph_id") do
+      pid when is_integer(pid) ->
+        {:ok, comprehension_attrs(resource, params, lang_id, pid)}
+
+      _ ->
+        build_comprehension_insert_attrs_from_body(resource, params, lang_id)
+    end
+  end
+
+  @doc false
+  defp build_comprehension_insert_attrs_from_body(resource, params, lang_id) do
     case paragraph_body_for_comprehension(params) do
       body when is_binary(body) ->
         case create_paragraph(%{"body" => body}) do
-          {:ok, %Paragraph{id: pid}} ->
-            {:ok,
-             %{
-               "res_id" => resource.id,
-               "lang_id" => lang_id,
-               "meta_data" => Map.get(params, "meta_data"),
-               "paragraph_id" => pid
-             }}
-
-          {:error, cs} ->
-            {:error, cs}
+          {:ok, %Paragraph{id: pid}} -> {:ok, comprehension_attrs(resource, params, lang_id, pid)}
+          {:error, cs} -> {:error, cs}
         end
 
       _ ->
         {:error, {:missing_paragraph_body, "`paragraph` is required for comprehension problems"}}
     end
+  end
+
+  @doc false
+  defp comprehension_attrs(resource, params, lang_id, paragraph_id) do
+    %{
+      "res_id" => resource.id,
+      "lang_id" => lang_id,
+      "meta_data" => Map.get(params, "meta_data"),
+      "paragraph_id" => paragraph_id
+    }
   end
 
   @doc false

--- a/lib/dbservice/resources.ex
+++ b/lib/dbservice/resources.ex
@@ -814,6 +814,11 @@ defmodule Dbservice.Resources do
     end
   end
 
+  defp update_problem_language(_resource, %{"lang_code" => nil}), do: :ok
+
+  defp update_problem_language(_resource, %{} = params) when not is_map_key(params, "lang_code"),
+    do: :ok
+
   defp update_problem_language(resource, params) do
     lang = Dbservice.Languages.get_language_by_code(params["lang_code"])
     lang_id = lang && lang.id

--- a/lib/dbservice/resources.ex
+++ b/lib/dbservice/resources.ex
@@ -700,12 +700,31 @@ defmodule Dbservice.Resources do
 
   defp update_resource_associations(resource, params) do
     update_resource_curriculums(resource, params)
+    update_resource_curriculum_difficulty_level(resource, params)
     update_resource_topic(resource, params)
     update_resource_chapter(resource, params)
     update_resource_concepts(resource, params)
 
     if resource.type == "problem" do
       update_problem_language(resource, params)
+    end
+  end
+
+  # When only `difficulty_level` is sent (no `curriculum_grades`), `update_resource_curriculums`
+  # is skipped — but difficulty_level lives on resource_curriculum, so we update existing rows here.
+  defp update_resource_curriculum_difficulty_level(resource, params) do
+    if Map.has_key?(params, "difficulty_level") and not Map.has_key?(params, "curriculum_grades") do
+      difficulty_level = Map.get(params, "difficulty_level")
+
+      resource.id
+      |> Dbservice.ResourceCurriculums.list_resource_curriculums_by_resource_id()
+      |> Enum.each(fn rc ->
+        if rc.difficulty_level != difficulty_level do
+          Dbservice.ResourceCurriculums.update_resource_curriculum(rc, %{
+            difficulty_level: difficulty_level
+          })
+        end
+      end)
     end
   end
 
@@ -814,12 +833,27 @@ defmodule Dbservice.Resources do
     end
   end
 
-  defp update_problem_language(_resource, %{"lang_code" => nil}), do: :ok
-
-  defp update_problem_language(_resource, %{} = params) when not is_map_key(params, "lang_code"),
-    do: :ok
-
   defp update_problem_language(resource, params) do
+    cond do
+      has_lang_code?(params) ->
+        update_problem_language_for_lang(resource, params)
+
+      has_problem_language_fields?(params) ->
+        update_all_problem_languages(resource, params)
+
+      true ->
+        :ok
+    end
+  end
+
+  defp has_lang_code?(%{"lang_code" => code}) when is_binary(code) and code != "", do: true
+  defp has_lang_code?(_), do: false
+
+  defp has_problem_language_fields?(params) do
+    Map.has_key?(params, "meta_data") or Map.has_key?(params, "paragraph")
+  end
+
+  defp update_problem_language_for_lang(resource, params) do
     lang = Dbservice.Languages.get_language_by_code(params["lang_code"])
     lang_id = lang && lang.id
 
@@ -830,17 +864,19 @@ defmodule Dbservice.Resources do
           lang_id
         )
 
-      if pl do
-        attrs =
-          Dbservice.Paragraphs.problem_language_update_attrs(
-            resource,
-            params,
-            pl
-          )
-
-        Dbservice.ProblemLanguages.update_problem_language(pl, attrs)
-      end
+      if pl, do: do_update_problem_language(resource, params, pl)
     end
+  end
+
+  defp update_all_problem_languages(resource, params) do
+    from(pl in ProblemLanguage, where: pl.res_id == ^resource.id)
+    |> Repo.all()
+    |> Enum.each(&do_update_problem_language(resource, params, &1))
+  end
+
+  defp do_update_problem_language(resource, params, pl) do
+    attrs = Dbservice.Paragraphs.problem_language_update_attrs(resource, params, pl)
+    Dbservice.ProblemLanguages.update_problem_language(pl, attrs)
   end
 
   def resolve_tag_ids(tags) do

--- a/lib/dbservice_web/controllers/resource_controller.ex
+++ b/lib/dbservice_web/controllers/resource_controller.ex
@@ -266,7 +266,9 @@ defmodule DbserviceWeb.ResourceController do
 
     description(
       "Update multiple problems in one request. Each entry must include id (resource id) " <>
-        "and the same fields as PATCH /api/resource. Only resources with type problem are updated."
+        "and the same fields as PATCH /api/resource. Only resources with type problem are updated. " <>
+        "Optional top-level `paragraph` updates the body of the shared paragraph(s) linked to the " <>
+        "comprehension problems being updated."
     )
 
     parameters do
@@ -286,6 +288,8 @@ defmodule DbserviceWeb.ResourceController do
       |> put_status(:unprocessable_entity)
       |> json(%{error: "problems must be a non-empty array"})
     else
+      update_shared_paragraph_if_provided(problems, params["paragraph"])
+
       {updated, failed} =
         problems
         |> Enum.with_index()
@@ -299,6 +303,37 @@ defmodule DbserviceWeb.ResourceController do
         failed: Enum.reverse(failed)
       })
     end
+  end
+
+  defp update_shared_paragraph_if_provided(problems, paragraph) do
+    case nonempty_string(paragraph) do
+      nil ->
+        :ok
+
+      body ->
+        problem_ids =
+          problems
+          |> Enum.map(&extract_batch_problem_id/1)
+          |> Enum.reject(&is_nil/1)
+
+        update_paragraphs_for_problem_ids(problem_ids, body)
+    end
+  end
+
+  defp update_paragraphs_for_problem_ids([], _body), do: :ok
+
+  defp update_paragraphs_for_problem_ids(problem_ids, body) do
+    from(pl in ProblemLanguage,
+      where: pl.res_id in ^problem_ids and not is_nil(pl.paragraph_id),
+      select: pl.paragraph_id,
+      distinct: true
+    )
+    |> Repo.all()
+    |> Enum.each(fn pid ->
+      pid
+      |> Paragraphs.fetch_paragraph!()
+      |> Paragraphs.update_paragraph(%{"body" => body})
+    end)
   end
 
   def tests_containing_problems(conn, params) do

--- a/lib/dbservice_web/controllers/resource_controller.ex
+++ b/lib/dbservice_web/controllers/resource_controller.ex
@@ -174,12 +174,17 @@ defmodule DbserviceWeb.ResourceController do
     post("/api/resources/problems/batch")
 
     description(
-      "Create multiple problems in one request. Each entry uses the same body shape as POST /api/resource " <>
-        "for type problem. Returns created resources and per-index failures (partial success)."
+      "Create multiple problems in one request. Optional top-level `paragraph` is created once and shared " <>
+        "by all comprehension problems in the same request (no duplicate paragraph rows). Each `problems[i]` " <>
+        "entry uses the same body shape as POST /api/resource for type problem. " <>
+        "Returns created resources and per-index failures (partial success)."
     )
 
     parameters do
-      body(:body, Schema.ref(:ProblemsBatchCreateRequest), "Array of problem payloads",
+      body(
+        :body,
+        Schema.ref(:ProblemsBatchCreateRequest),
+        "Top-level `paragraph` and `problems` array",
         required: true
       )
     end
@@ -195,20 +200,66 @@ defmodule DbserviceWeb.ResourceController do
       |> put_status(:unprocessable_entity)
       |> json(%{error: "problems must be a non-empty array"})
     else
-      {created, failed} =
-        problems
-        |> Enum.with_index()
-        |> Enum.reduce({[], []}, &accumulate_batch_create/2)
-
-      conn
-      |> put_status(:ok)
-      |> json(%{
-        created:
-          Enum.map(Enum.reverse(created), &DbserviceWeb.ResourceJSON.show(%{resource: &1})),
-        failed: Enum.reverse(failed)
-      })
+      handle_batch_create_with_shared_paragraph(conn, problems, params)
     end
   end
+
+  defp handle_batch_create_with_shared_paragraph(conn, problems, params) do
+    case resolve_shared_paragraph_id(params) do
+      {:ok, shared_paragraph_id} ->
+        run_batch_create(conn, problems, shared_paragraph_id)
+
+      {:error, %Ecto.Changeset{} = cs} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{errors: DbserviceWeb.ChangesetJSON.translate_errors(cs)})
+    end
+  end
+
+  defp run_batch_create(conn, problems, shared_paragraph_id) do
+    {created, failed} =
+      problems
+      |> Enum.with_index()
+      |> Enum.map(fn {item, idx} ->
+        {inject_shared_paragraph_id(item, shared_paragraph_id), idx}
+      end)
+      |> Enum.reduce({[], []}, &accumulate_batch_create/2)
+
+    conn
+    |> put_status(:ok)
+    |> json(%{
+      created: Enum.map(Enum.reverse(created), &DbserviceWeb.ResourceJSON.show(%{resource: &1})),
+      failed: Enum.reverse(failed)
+    })
+  end
+
+  defp resolve_shared_paragraph_id(params) do
+    case nonempty_string(params["paragraph"]) do
+      nil ->
+        {:ok, nil}
+
+      body ->
+        case Paragraphs.create_paragraph(%{"body" => body}) do
+          {:ok, %{id: pid}} -> {:ok, pid}
+          {:error, _} = err -> err
+        end
+    end
+  end
+
+  defp inject_shared_paragraph_id(item, nil), do: item
+
+  defp inject_shared_paragraph_id(item, paragraph_id) when is_integer(paragraph_id) do
+    item
+    |> Map.drop(["paragraph"])
+    |> Map.put_new("paragraph_id", paragraph_id)
+  end
+
+  defp nonempty_string(s) when is_binary(s) do
+    t = String.trim(s)
+    if t == "", do: nil, else: t
+  end
+
+  defp nonempty_string(_), do: nil
 
   swagger_path :update_problems_batch do
     PhoenixSwagger.Path.patch("/api/resources/problems/batch")

--- a/lib/dbservice_web/controllers/resource_controller.ex
+++ b/lib/dbservice_web/controllers/resource_controller.ex
@@ -2,18 +2,18 @@ defmodule DbserviceWeb.ResourceController do
   use DbserviceWeb, :controller
 
   import Ecto.Query
-  alias Dbservice.Repo
-  alias Dbservice.Resources
-  alias Dbservice.Resources.Resource
-  alias Dbservice.Resources.ResourceTopic
-  alias Dbservice.Resources.ResourceChapter
-  alias Dbservice.Resources.ResourceCurriculum
-  alias Dbservice.Topics.Topic
-  alias Dbservice.TopicCurriculums.TopicCurriculum
+
   alias Dbservice.Chapters.Chapter
   alias Dbservice.Languages.Language
-  alias Dbservice.Resources.ProblemLanguage
   alias Dbservice.Paragraphs
+  alias Dbservice.Repo
+  alias Dbservice.Resources
+  alias Dbservice.Resources.ProblemLanguage
+  alias Dbservice.Resources.Resource
+  alias Dbservice.Resources.ResourceChapter
+  alias Dbservice.Resources.ResourceCurriculum
+  alias Dbservice.Resources.ResourceTopic
+  alias Dbservice.TopicCurriculums.TopicCurriculum
   alias Dbservice.Topics.Topic
 
   action_fallback(DbserviceWeb.FallbackController)
@@ -30,6 +30,7 @@ defmodule DbserviceWeb.ResourceController do
     |> Map.merge(SwaggerSchemaResource.problem_resource())
     |> Map.merge(SwaggerSchemaResource.move_resources())
     |> Map.merge(SwaggerSchemaResource.tests_containing_problems())
+    |> Map.merge(SwaggerSchemaResource.problems_batch())
   end
 
   swagger_path :index do
@@ -169,6 +170,86 @@ defmodule DbserviceWeb.ResourceController do
     response(200, "OK", Schema.ref(:TestsContainingProblemsResponse))
   end
 
+  swagger_path :create_problems_batch do
+    post("/api/resources/problems/batch")
+
+    description(
+      "Create multiple problems in one request. Each entry uses the same body shape as POST /api/resource " <>
+        "for type problem. Returns created resources and per-index failures (partial success)."
+    )
+
+    parameters do
+      body(:body, Schema.ref(:ProblemsBatchCreateRequest), "Array of problem payloads",
+        required: true
+      )
+    end
+
+    response(200, "OK", Schema.ref(:ProblemsBatchResponse))
+  end
+
+  def create_problems_batch(conn, params) do
+    problems = params["problems"] || []
+
+    if problems == [] do
+      conn
+      |> put_status(:unprocessable_entity)
+      |> json(%{error: "problems must be a non-empty array"})
+    else
+      {created, failed} =
+        problems
+        |> Enum.with_index()
+        |> Enum.reduce({[], []}, &accumulate_batch_create/2)
+
+      conn
+      |> put_status(:ok)
+      |> json(%{
+        created:
+          Enum.map(Enum.reverse(created), &DbserviceWeb.ResourceJSON.show(%{resource: &1})),
+        failed: Enum.reverse(failed)
+      })
+    end
+  end
+
+  swagger_path :update_problems_batch do
+    PhoenixSwagger.Path.patch("/api/resources/problems/batch")
+
+    description(
+      "Update multiple problems in one request. Each entry must include id (resource id) " <>
+        "and the same fields as PATCH /api/resource. Only resources with type problem are updated."
+    )
+
+    parameters do
+      body(:body, Schema.ref(:ProblemsBatchUpdateRequest), "Array of problem patches with id",
+        required: true
+      )
+    end
+
+    response(200, "OK", Schema.ref(:ProblemsBatchUpdateResponse))
+  end
+
+  def update_problems_batch(conn, params) do
+    problems = params["problems"] || []
+
+    if problems == [] do
+      conn
+      |> put_status(:unprocessable_entity)
+      |> json(%{error: "problems must be a non-empty array"})
+    else
+      {updated, failed} =
+        problems
+        |> Enum.with_index()
+        |> Enum.reduce({[], []}, &accumulate_batch_update/2)
+
+      conn
+      |> put_status(:ok)
+      |> json(%{
+        updated:
+          Enum.map(Enum.reverse(updated), &DbserviceWeb.ResourceJSON.show(%{resource: &1})),
+        failed: Enum.reverse(failed)
+      })
+    end
+  end
+
   def tests_containing_problems(conn, params) do
     problem_ids = params["problem_ids"] || []
 
@@ -298,14 +379,17 @@ defmodule DbserviceWeb.ResourceController do
     end
   end
 
-  defp create_new_resource(conn, params) do
-    result =
-      Repo.transaction(fn ->
-        params =
-          Map.put(params, "tag_ids", Dbservice.Resources.resolve_tag_ids(params["tags"] || []))
+  defp transaction_create_resource(params) do
+    Repo.transaction(fn ->
+      params =
+        Map.put(params, "tag_ids", Dbservice.Resources.resolve_tag_ids(params["tags"] || []))
 
-        handle_resource_creation_and_association(params)
-      end)
+      handle_resource_creation_and_association(params)
+    end)
+  end
+
+  defp create_new_resource(conn, params) do
+    result = transaction_create_resource(params)
 
     case result do
       {:ok, resource} ->
@@ -334,6 +418,108 @@ defmodule DbserviceWeb.ResourceController do
         |> put_status(:unprocessable_entity)
         |> json(%{error: reason})
     end
+  end
+
+  defp accumulate_batch_create({item, index}, {created_acc, failed_acc}) do
+    case safe_batch_call(fn -> batch_create_one_problem(item, index) end, index) do
+      {:ok, resource} -> {[resource | created_acc], failed_acc}
+      {:error, row} -> {created_acc, [row | failed_acc]}
+    end
+  end
+
+  defp batch_create_one_problem(item, index) do
+    item = Map.put_new(item, "type", "problem")
+
+    if item["type"] != "problem" do
+      {:error, %{index: index, error: "type must be \"problem\""}}
+    else
+      case transaction_create_resource(item) do
+        {:ok, resource} ->
+          {:ok, resource}
+
+        {:error, reason} ->
+          {:error, Map.merge(%{index: index}, format_batch_transaction_error(reason))}
+      end
+    end
+  end
+
+  defp accumulate_batch_update({item, index}, {ok_acc, failed_acc}) do
+    case safe_batch_call(fn -> batch_update_one_problem(item, index) end, index) do
+      {:ok, resource} -> {[resource | ok_acc], failed_acc}
+      {:error, row} -> {ok_acc, [row | failed_acc]}
+    end
+  end
+
+  defp safe_batch_call(fun, index) do
+    fun.()
+  rescue
+    e ->
+      {:error, %{index: index, error: Exception.message(e)}}
+  end
+
+  defp batch_update_one_problem(item, index) do
+    id = extract_batch_problem_id(item)
+
+    if is_nil(id) do
+      {:error, %{index: index, error: "id is required"}}
+    else
+      do_batch_update_one_problem(item, index, id)
+    end
+  end
+
+  defp extract_batch_problem_id(item) do
+    id = Map.get(item, "id") || Map.get(item, :id)
+    normalize_id(id)
+  end
+
+  defp do_batch_update_one_problem(item, index, id) do
+    case Repo.get(Resource, id) do
+      nil ->
+        {:error, %{index: index, error: "resource not found"}}
+
+      %Resource{type: "problem"} = resource ->
+        item_with_id = Map.put(item, "id", id)
+        apply_problem_batch_update(resource, item_with_id, index)
+
+      _ ->
+        {:error, %{index: index, error: "resource #{id} is not type problem"}}
+    end
+  end
+
+  defp apply_problem_batch_update(resource, item_with_id, index) do
+    case Resources.update_resource_and_associations(resource, item_with_id) do
+      {:ok, %Resource{} = u} ->
+        {:ok, u}
+
+      {:error, %Ecto.Changeset{} = cs} ->
+        {:error, %{index: index, errors: DbserviceWeb.ChangesetJSON.translate_errors(cs)}}
+
+      {:error, msg} when is_binary(msg) ->
+        {:error, %{index: index, error: msg}}
+
+      {:error, other} ->
+        {:error, %{index: index, error: inspect(other)}}
+    end
+  end
+
+  defp format_batch_transaction_error({:changeset_error, changeset}) do
+    %{errors: DbserviceWeb.ChangesetJSON.translate_errors(changeset)}
+  end
+
+  defp format_batch_transaction_error({:curriculum_error, reason}) do
+    %{error: "Failed to create resource curriculum entries: #{inspect(reason)}"}
+  end
+
+  defp format_batch_transaction_error({:cms_status_error, reason}) do
+    %{error: reason}
+  end
+
+  defp format_batch_transaction_error({:comprehension_error, reason}) do
+    %{error: reason}
+  end
+
+  defp format_batch_transaction_error(other) do
+    %{error: inspect(other)}
   end
 
   defp handle_resource_creation_and_association(params) do

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -11,7 +11,7 @@ defmodule DbserviceWeb.Router do
   end
 
   pipeline :browser do
-    plug :accepts, ["html"]
+    plug(:accepts, ["html"])
     plug(:fetch_session)
     plug(:fetch_live_flash)
     plug(:put_root_layout, {DbserviceWeb.Layouts, :root})
@@ -20,30 +20,30 @@ defmodule DbserviceWeb.Router do
   end
 
   pipeline :dashboard_auth do
-    plug :admin_basic_auth
+    plug(:admin_basic_auth)
   end
 
   scope "/", DbserviceWeb do
-    pipe_through :browser
+    pipe_through(:browser)
 
-    live "/imports", ImportLive.Index
-    live "/imports/new", ImportLive.New
-    live "/imports/:id", ImportLive.Show
+    live("/imports", ImportLive.Index)
+    live("/imports/new", ImportLive.New)
+    live("/imports/:id", ImportLive.Show)
 
     # Add route for CSV template downloads
-    get "/templates/:type/download", TemplateController, :download_csv_template
+    get("/templates/:type/download", TemplateController, :download_csv_template)
   end
 
   # Protected endpoints (basic auth) for dropout, re-enrollment, auth group, product, program, batch imports
   scope "/", DbserviceWeb do
-    pipe_through [:browser, :dashboard_auth]
+    pipe_through([:browser, :dashboard_auth])
 
-    post "/imports/dropout", ImportController, :create_dropout_import
-    post "/imports/re_enrollment", ImportController, :create_re_enrollment_import
-    post "/imports/auth_group", ImportController, :create_auth_group_import
-    post "/imports/product", ImportController, :create_product_import
-    post "/imports/program", ImportController, :create_program_import
-    post "/imports/batch", ImportController, :create_batch_import
+    post("/imports/dropout", ImportController, :create_dropout_import)
+    post("/imports/re_enrollment", ImportController, :create_re_enrollment_import)
+    post("/imports/auth_group", ImportController, :create_auth_group_import)
+    post("/imports/product", ImportController, :create_product_import)
+    post("/imports/program", ImportController, :create_program_import)
+    post("/imports/batch", ImportController, :create_batch_import)
   end
 
   scope "/api", DbserviceWeb do
@@ -117,6 +117,8 @@ defmodule DbserviceWeb.Router do
     get("/resources/curriculum", ResourceController, :curriculum_resources)
     post("/resources/move", ResourceController, :move_resources)
     post("/resources/tests-containing-problems", ResourceController, :tests_containing_problems)
+    post("/resources/problems/batch", ResourceController, :create_problems_batch)
+    patch("/resources/problems/batch", ResourceController, :update_problems_batch)
     get("/resource/subtypes/:type", ResourceController, :get_subtypes)
     get("/problems/search", ResourceController, :search_problems)
 

--- a/lib/dbservice_web/swagger_schemas/resource.ex
+++ b/lib/dbservice_web/swagger_schemas/resource.ex
@@ -430,8 +430,8 @@ defmodule DbserviceWeb.SwaggerSchema.Resource do
 
           properties do
             problems(
-              Schema.array(Schema.ref(:ProblemResource)),
-              "Payloads for each problem to create"
+              Schema.array(:object),
+              "Payloads for each problem to create (same shape as ProblemResource)"
             )
           end
 
@@ -443,7 +443,7 @@ defmodule DbserviceWeb.SwaggerSchema.Resource do
           description("Created resources (same shape as GET resource) and per-index failures")
 
           properties do
-            created(Schema.array(:object), "Successfully created problems")
+            created(Schema.array(:object), "Successfully created problems (Resource shape)")
             failed(Schema.array(:object), "Entries with index and error or errors")
           end
         end,
@@ -471,7 +471,7 @@ defmodule DbserviceWeb.SwaggerSchema.Resource do
           title("ProblemsBatchUpdateResponse")
 
           properties do
-            updated(Schema.array(:object), "Successfully updated resources")
+            updated(Schema.array(:object), "Successfully updated resources (Resource shape)")
             failed(Schema.array(:object), "Entries with index and error or errors")
           end
         end

--- a/lib/dbservice_web/swagger_schemas/resource.ex
+++ b/lib/dbservice_web/swagger_schemas/resource.ex
@@ -417,4 +417,64 @@ defmodule DbserviceWeb.SwaggerSchema.Resource do
         end
     }
   end
+
+  def problems_batch do
+    %{
+      ProblemsBatchCreateRequest:
+        swagger_schema do
+          title("ProblemsBatchCreateRequest")
+
+          description(
+            "Batch create problems; each element matches POST /api/resource for type problem (type may be omitted)."
+          )
+
+          properties do
+            problems(
+              Schema.array(Schema.ref(:ProblemResource)),
+              "Payloads for each problem to create"
+            )
+          end
+
+          example(%{problems: [%{type: "problem", subtype: "mcq", lang_code: "en"}]})
+        end,
+      ProblemsBatchResponse:
+        swagger_schema do
+          title("ProblemsBatchResponse")
+          description("Created resources (same shape as GET resource) and per-index failures")
+
+          properties do
+            created(Schema.array(:object), "Successfully created problems")
+            failed(Schema.array(:object), "Entries with index and error or errors")
+          end
+        end,
+      ProblemsBatchUpdateRequest:
+        swagger_schema do
+          title("ProblemsBatchUpdateRequest")
+
+          description(
+            "Batch update; each object includes id (resource id) and PATCH fields like PATCH /api/resource"
+          )
+
+          properties do
+            problems(Schema.array(:object), "Problem patches with id")
+          end
+
+          example(%{
+            problems: [
+              %{id: 5014, meta_data: %{text: "updated"}},
+              %{id: 5015, chapter_id: 100}
+            ]
+          })
+        end,
+      ProblemsBatchUpdateResponse:
+        swagger_schema do
+          title("ProblemsBatchUpdateResponse")
+
+          properties do
+            updated(Schema.array(:object), "Successfully updated resources")
+            failed(Schema.array(:object), "Entries with index and error or errors")
+          end
+        end
+    }
+  end
 end

--- a/lib/dbservice_web/swagger_schemas/resource.ex
+++ b/lib/dbservice_web/swagger_schemas/resource.ex
@@ -479,10 +479,16 @@ defmodule DbserviceWeb.SwaggerSchema.Resource do
           )
 
           properties do
+            paragraph(
+              :string,
+              "Optional reading-comprehension passage; updates the shared paragraph linked to every comprehension problem in this batch"
+            )
+
             problems(Schema.array(:object), "Problem patches with id")
           end
 
           example(%{
+            paragraph: "Updated shared reading passage for the comprehension set.",
             problems: [
               %{id: 5014, meta_data: %{text: "updated"}},
               %{id: 5015, chapter_id: 100}

--- a/lib/dbservice_web/swagger_schemas/resource.ex
+++ b/lib/dbservice_web/swagger_schemas/resource.ex
@@ -425,17 +425,40 @@ defmodule DbserviceWeb.SwaggerSchema.Resource do
           title("ProblemsBatchCreateRequest")
 
           description(
-            "Batch create problems; each element matches POST /api/resource for type problem (type may be omitted)."
+            "Batch create problems. Optional top-level `paragraph` is created once and shared by all " <>
+              "comprehension problems in the same request. Each `problems[i]` matches POST /api/resource " <>
+              "for type problem (type may be omitted)."
           )
 
           properties do
+            paragraph(
+              :string,
+              "Optional reading-comprehension passage; created once and linked to every comprehension problem in this batch"
+            )
+
             problems(
               Schema.array(:object),
               "Payloads for each problem to create (same shape as ProblemResource)"
             )
           end
 
-          example(%{problems: [%{type: "problem", subtype: "mcq", lang_code: "en"}]})
+          example(%{
+            paragraph: "This is the shared reading passage for the comprehension set.",
+            problems: [
+              %{
+                subtype: "comprehension",
+                lang_code: "en",
+                name: [%{lang_code: "en", resource: "Q1"}],
+                meta_data: %{text: "q1", answer: ["2"], options: ["o1", "o2"]}
+              },
+              %{
+                subtype: "comprehension",
+                lang_code: "en",
+                name: [%{lang_code: "en", resource: "Q2"}],
+                meta_data: %{text: "q2", answer: ["1"], options: ["o1", "o2"]}
+              }
+            ]
+          })
         end,
       ProblemsBatchResponse:
         swagger_schema do


### PR DESCRIPTION
## Summary

Adds two endpoints to create and update problem resources in bulk, with **partial-success** semantics and the same body shape as the existing single-resource APIs.

- **POST `/api/resources/problems/batch`** — create many problems in one request.
- **PATCH `/api/resources/problems/batch`** — update many problems in one request.

## Endpoints

### `POST /api/resources/problems/batch`
- Body: `{ "problems": [ ...payloads matching POST /api/resource ... ] }`
- `type` defaults to `"problem"` per item.
- Each problem is created in **its own DB transaction**; one failing item does **not** roll back the others.
- 200 response:

  ```json
  {
    "created": [ /* full resource JSON */ ],
    "failed":  [ { "index": 1, "errors": { ... } }, { "index": 3, "error": "..." } ]
  }