### PR TITLE
Fix student family income updates from import sheets

### DIFF
--- a/lib/dbservice/users/student.ex
+++ b/lib/dbservice/users/student.ex
@@ -31,6 +31,7 @@ defmodule Dbservice.Users.Student do
     field(:stream, :string)
     field(:physically_handicapped, :boolean)
     field(:physically_handicapped_certificate, :string)
+    field(:family_income, :string)
     field(:annual_family_income, :string)
     field(:monthly_family_income, :string)
     field(:time_of_device_availability, :string)
@@ -88,6 +89,7 @@ defmodule Dbservice.Users.Student do
       :stream,
       :physically_handicapped,
       :physically_handicapped_certificate,
+      :family_income,
       :annual_family_income,
       :monthly_family_income,
       :time_of_device_availability,

--- a/lib/dbservice_web/json/student_json.ex
+++ b/lib/dbservice_web/json/student_json.ex
@@ -43,6 +43,7 @@ defmodule DbserviceWeb.StudentJSON do
       stream: student.stream,
       physically_handicapped: student.physically_handicapped,
       physically_handicapped_certificate: student.physically_handicapped_certificate,
+      family_income: student.family_income,
       annual_family_income: student.annual_family_income,
       monthly_family_income: student.monthly_family_income,
       time_of_device_availability: student.time_of_device_availability,

--- a/test/dbservice/users_test.exs
+++ b/test/dbservice/users_test.exs
@@ -211,7 +211,8 @@ defmodule Dbservice.UsersTest do
         mother_phone: "some mother_phone",
         stream: "medical",
         physically_handicapped: false,
-        annual_family_income: "some family income",
+        family_income: "some family income",
+        annual_family_income: "some annual family income",
         father_profession: "some father profession",
         father_education_level: "some father education level",
         mother_profession: "some mother profession",
@@ -231,7 +232,8 @@ defmodule Dbservice.UsersTest do
       assert student.mother_phone == "some mother_phone"
       assert student.stream == "medical"
       assert student.physically_handicapped == false
-      assert student.annual_family_income == "some family income"
+      assert student.family_income == "some family income"
+      assert student.annual_family_income == "some annual family income"
       assert student.father_profession == "some father profession"
       assert student.father_education_level == "some father education level"
       assert student.mother_profession == "some mother profession"
@@ -259,7 +261,8 @@ defmodule Dbservice.UsersTest do
         mother_phone: "some updated mother_phone",
         stream: "pcm",
         physically_handicapped: false,
-        annual_family_income: "some updated family income",
+        family_income: "some updated family income",
+        annual_family_income: "some updated annual family income",
         father_profession: "some updated father profession",
         father_education_level: "some updated father education level",
         mother_profession: "some updated mother profession",
@@ -278,7 +281,8 @@ defmodule Dbservice.UsersTest do
       assert student.mother_phone == "some updated mother_phone"
       assert student.stream == "pcm"
       assert student.physically_handicapped == false
-      assert student.annual_family_income == "some updated family income"
+      assert student.family_income == "some updated family income"
+      assert student.annual_family_income == "some updated annual family income"
       assert student.father_profession == "some updated father profession"
       assert student.father_education_level == "some updated father education level"
       assert student.mother_profession == "some updated mother profession"

--- a/test/dbservice_web/controllers/student_controller_test.exs
+++ b/test/dbservice_web/controllers/student_controller_test.exs
@@ -12,7 +12,8 @@ defmodule DbserviceWeb.StudentControllerTest do
     stream: "medical",
     student_id: "some student id",
     physically_handicapped: false,
-    annual_family_income: "some family income",
+    family_income: "some family income",
+    annual_family_income: "some annual family income",
     father_profession: "some father profession",
     father_education_level: "some father education level",
     mother_profession: "some mother profession",
@@ -30,7 +31,8 @@ defmodule DbserviceWeb.StudentControllerTest do
     stream: "pcm",
     student_id: "some updated student id",
     physically_handicapped: false,
-    annual_family_income: "some updated family income",
+    family_income: "some updated family income",
+    annual_family_income: "some updated annual family income",
     father_profession: "some updated father profession",
     father_education_level: "some updated father education level",
     mother_profession: "some updated mother profession",
@@ -116,7 +118,8 @@ defmodule DbserviceWeb.StudentControllerTest do
       assert resp["category"] == "OBC"
       assert resp["father_name"] == "some updated father name"
       assert resp["stream"] == "pcm"
-      assert resp["annual_family_income"] == "some updated family income"
+      assert resp["family_income"] == "some updated family income"
+      assert resp["annual_family_income"] == "some updated annual family income"
       assert is_integer(resp["user"]["id"])
     end
 


### PR DESCRIPTION
### Summary
This PR fixes `student_family_income` not being persisted during student detail updates.
The import mapping already maps `student_family_income` to `family_income`, but the `Student` Ecto schema did not define or cast the `family_income` field. Because of that, Ecto ignored the value during updates.

### Changes
- Added `family_income` to the `Student` schema.
- Added `family_income` to the student changeset cast fields.
- Included `family_income` in student JSON responses.
- Added test coverage for creating/updating `family_income`.

### Testing
- Ran `mix format` successfully.
- Checked lints for changed files successfully.
- Tried running focused tests, but local Postgres setup failed because role `postgres` does not exist.