### PR TITLE
Return paragraph in all problem-metadata APIs for comprehension subtype

### DIFF
--- a/lib/dbservice/paragraphs.ex
+++ b/lib/dbservice/paragraphs.ex
@@ -127,6 +127,24 @@ defmodule Dbservice.Paragraphs do
   def comprehension_problem?(_, _), do: false
 
   @doc """
+  Adds `paragraph: %{id, body}` to `map` when `resource` is a comprehension
+  problem and `paragraph` is a loaded `%Paragraph{}`. Returns `map` unchanged
+  otherwise — including when `paragraph` is `nil` or `%Ecto.Association.NotLoaded{}`.
+
+  Lets JSON renderers pass `Map.get(problem_lang, :paragraph)` directly without
+  pre-checking whether the association was preloaded.
+  """
+  def maybe_put_paragraph(map, %Resource{} = resource, %Paragraph{} = paragraph) do
+    if comprehension_problem?(resource, %{}) do
+      Map.put(map, :paragraph, %{id: paragraph.id, body: paragraph.body})
+    else
+      map
+    end
+  end
+
+  def maybe_put_paragraph(map, _resource, _paragraph), do: map
+
+  @doc """
   Returns the reading-passage body from `params["paragraph"]`, trimmed.
   Returns `nil` for non-map params, missing key, or blank string.
 

--- a/lib/dbservice/resources.ex
+++ b/lib/dbservice/resources.ex
@@ -78,13 +78,16 @@ defmodule Dbservice.Resources do
   defp fetch_and_format_problems(test_resource, lang_id, curriculum_id) do
     problem_ids = extract_problem_ids_from_test(test_resource.type_params)
 
+    problem_lang_query =
+      from(pl in ProblemLanguage, where: pl.lang_id == ^lang_id, preload: :paragraph)
+
     problems =
       from(r in Resource,
         where: r.id in ^problem_ids and r.type == "problem",
         preload: [
           :resource_curriculum,
           :chapter,
-          problem_language: ^from(pl in ProblemLanguage, where: pl.lang_id == ^lang_id)
+          problem_language: ^problem_lang_query
         ]
       )
       |> Repo.all()
@@ -1084,6 +1087,7 @@ defmodule Dbservice.Resources do
     |> apply_problem_sorting(params)
     |> apply_problem_pagination(params)
     |> Repo.all()
+    |> Repo.preload(:paragraph)
     |> Enum.map(fn problem_lang ->
       resource = Repo.get!(Resource, problem_lang.res_id)
 

--- a/lib/dbservice_web/controllers/problem_language_controller.ex
+++ b/lib/dbservice_web/controllers/problem_language_controller.ex
@@ -39,7 +39,8 @@ defmodule DbserviceWeb.ProblemLanguageController do
       from(m in ProblemLanguage,
         order_by: [asc: m.id],
         offset: ^params["offset"],
-        limit: ^params["limit"]
+        limit: ^params["limit"],
+        preload: [:paragraph, :resource]
       )
 
     query =
@@ -89,7 +90,10 @@ defmodule DbserviceWeb.ProblemLanguageController do
   end
 
   def show(conn, %{"id" => id}) do
-    problem_language = ProblemLanguages.get_problem_language!(id)
+    problem_language =
+      ProblemLanguages.get_problem_language!(id)
+      |> Repo.preload([:paragraph, :resource])
+
     render(conn, "show.json", problem_language: problem_language)
   end
 
@@ -109,6 +113,7 @@ defmodule DbserviceWeb.ProblemLanguageController do
 
     with {:ok, %ProblemLanguage{} = problem_language} <-
            ProblemLanguages.update_problem_language(problem_language, params) do
+      problem_language = Repo.preload(problem_language, [:paragraph, :resource])
       render(conn, "show.json", problem_language: problem_language)
     end
   end
@@ -134,6 +139,8 @@ defmodule DbserviceWeb.ProblemLanguageController do
   defp create_new_problem_language(conn, params) do
     with {:ok, %ProblemLanguage{} = problem_language} <-
            ProblemLanguages.create_problem_language(params) do
+      problem_language = Repo.preload(problem_language, [:paragraph, :resource])
+
       conn
       |> put_status(:created)
       |> put_resp_header("location", ~p"/api/problem-language/#{problem_language}")
@@ -144,6 +151,8 @@ defmodule DbserviceWeb.ProblemLanguageController do
   defp update_existing_problem_language(conn, existing_problem_language, params) do
     with {:ok, %ProblemLanguage{} = problem_language} <-
            ProblemLanguages.update_problem_language(existing_problem_language, params) do
+      problem_language = Repo.preload(problem_language, [:paragraph, :resource])
+
       conn
       |> put_status(:ok)
       |> render("show.json", problem_language: problem_language)

--- a/lib/dbservice_web/controllers/resource_controller.ex
+++ b/lib/dbservice_web/controllers/resource_controller.ex
@@ -799,7 +799,12 @@ defmodule DbserviceWeb.ResourceController do
           }
         )
 
-      problems = Repo.all(query)
+      problems =
+        query
+        |> Repo.all()
+        |> Enum.map(fn p ->
+          %{p | problem_lang: Repo.preload(p.problem_lang, :paragraph)}
+        end)
 
       render(conn, "problems.json", problems: problems)
     end

--- a/lib/dbservice_web/controllers/resource_controller.ex
+++ b/lib/dbservice_web/controllers/resource_controller.ex
@@ -836,7 +836,7 @@ defmodule DbserviceWeb.ResourceController do
         join: l in Language,
         on: l.id == p.lang_id,
         where: p.res_id == ^res_id and l.code == ^lang_code,
-        preload: [resource: {r, [:resource_curriculum]}, language: l]
+        preload: [:paragraph, resource: {r, [:resource_curriculum]}, language: l]
       )
 
     case Repo.one(query) do
@@ -862,7 +862,8 @@ defmodule DbserviceWeb.ResourceController do
               resource: problem_lang.resource,
               meta_data: problem_lang.meta_data,
               lang_code: problem_lang.language.code,
-              resource_curriculum: rc
+              resource_curriculum: rc,
+              paragraph: problem_lang.paragraph
             )
         end
     end

--- a/lib/dbservice_web/json/problem_language_json.ex
+++ b/lib/dbservice_web/json/problem_language_json.ex
@@ -1,4 +1,8 @@
 defmodule DbserviceWeb.ProblemLanguageJSON do
+  alias Dbservice.Paragraphs
+  alias Dbservice.Resources.Paragraph
+  alias Dbservice.Resources.Resource
+
   def index(%{problem_language: problem_language}) do
     for(pl <- problem_language, do: render(pl))
   end
@@ -8,12 +12,28 @@ defmodule DbserviceWeb.ProblemLanguageJSON do
   end
 
   def render(problem_language) do
-    %{
+    base = %{
       id: problem_language.id,
       res_id: problem_language.res_id,
       lang_id: problem_language.lang_id,
       paragraph_id: problem_language.paragraph_id,
       meta_data: problem_language.meta_data
     }
+
+    maybe_put_paragraph(
+      base,
+      Map.get(problem_language, :resource),
+      Map.get(problem_language, :paragraph)
+    )
   end
+
+  defp maybe_put_paragraph(map, %Resource{} = resource, %Paragraph{} = paragraph) do
+    if Paragraphs.comprehension_problem?(resource, %{}) do
+      Map.put(map, :paragraph, %{id: paragraph.id, body: paragraph.body})
+    else
+      map
+    end
+  end
+
+  defp maybe_put_paragraph(map, _resource, _paragraph), do: map
 end

--- a/lib/dbservice_web/json/problem_language_json.ex
+++ b/lib/dbservice_web/json/problem_language_json.ex
@@ -1,7 +1,5 @@
 defmodule DbserviceWeb.ProblemLanguageJSON do
   alias Dbservice.Paragraphs
-  alias Dbservice.Resources.Paragraph
-  alias Dbservice.Resources.Resource
 
   def index(%{problem_language: problem_language}) do
     for(pl <- problem_language, do: render(pl))
@@ -12,28 +10,16 @@ defmodule DbserviceWeb.ProblemLanguageJSON do
   end
 
   def render(problem_language) do
-    base = %{
+    %{
       id: problem_language.id,
       res_id: problem_language.res_id,
       lang_id: problem_language.lang_id,
       paragraph_id: problem_language.paragraph_id,
       meta_data: problem_language.meta_data
     }
-
-    maybe_put_paragraph(
-      base,
+    |> Paragraphs.maybe_put_paragraph(
       Map.get(problem_language, :resource),
       Map.get(problem_language, :paragraph)
     )
   end
-
-  defp maybe_put_paragraph(map, %Resource{} = resource, %Paragraph{} = paragraph) do
-    if Paragraphs.comprehension_problem?(resource, %{}) do
-      Map.put(map, :paragraph, %{id: paragraph.id, body: paragraph.body})
-    else
-      map
-    end
-  end
-
-  defp maybe_put_paragraph(map, _resource, _paragraph), do: map
 end

--- a/lib/dbservice_web/json/resource_json.ex
+++ b/lib/dbservice_web/json/resource_json.ex
@@ -202,8 +202,19 @@ defmodule DbserviceWeb.ResourceJSON do
         ConceptJSON.render(concept)
       end)
 
-    Map.put(problem_map, :concepts, concepts)
+    problem_map
+    |> Map.put(:concepts, concepts)
+    |> maybe_put_paragraph(resource, extract_paragraph(problem_lang))
   end
+
+  defp extract_paragraph(problem_lang) when is_map(problem_lang) do
+    case Map.get(problem_lang, :paragraph) do
+      %Dbservice.Resources.Paragraph{} = paragraph -> paragraph
+      _ -> nil
+    end
+  end
+
+  defp extract_paragraph(_), do: nil
 
   def problem_lang(
         %{

--- a/lib/dbservice_web/json/resource_json.ex
+++ b/lib/dbservice_web/json/resource_json.ex
@@ -3,6 +3,7 @@ defmodule DbserviceWeb.ResourceJSON do
   alias Dbservice.Resources.ResourceTopic
   alias Dbservice.Resources.ResourceChapter
   alias Dbservice.Concepts
+  alias Dbservice.Paragraphs
   alias Dbservice.ResourceConcepts
   alias Dbservice.ResourceCurriculums
   alias Dbservice.Repo
@@ -204,12 +205,14 @@ defmodule DbserviceWeb.ResourceJSON do
     Map.put(problem_map, :concepts, concepts)
   end
 
-  def problem_lang(%{
-        resource: resource,
-        meta_data: meta_data,
-        lang_code: lang_code,
-        resource_curriculum: rc
-      }) do
+  def problem_lang(
+        %{
+          resource: resource,
+          meta_data: meta_data,
+          lang_code: lang_code,
+          resource_curriculum: rc
+        } = assigns
+      ) do
     base = render(resource)
 
     # Fetch concept information
@@ -231,5 +234,16 @@ defmodule DbserviceWeb.ResourceJSON do
       difficulty_level: rc.difficulty_level,
       concepts: concepts
     })
+    |> maybe_put_paragraph(resource, Map.get(assigns, :paragraph))
   end
+
+  defp maybe_put_paragraph(map, resource, %Dbservice.Resources.Paragraph{} = paragraph) do
+    if Paragraphs.comprehension_problem?(resource, %{}) do
+      Map.put(map, :paragraph, %{id: paragraph.id, body: paragraph.body})
+    else
+      map
+    end
+  end
+
+  defp maybe_put_paragraph(map, _resource, _paragraph), do: map
 end

--- a/lib/dbservice_web/json/resource_json.ex
+++ b/lib/dbservice_web/json/resource_json.ex
@@ -204,17 +204,8 @@ defmodule DbserviceWeb.ResourceJSON do
 
     problem_map
     |> Map.put(:concepts, concepts)
-    |> maybe_put_paragraph(resource, extract_paragraph(problem_lang))
+    |> Paragraphs.maybe_put_paragraph(resource, Map.get(problem_lang, :paragraph))
   end
-
-  defp extract_paragraph(problem_lang) when is_map(problem_lang) do
-    case Map.get(problem_lang, :paragraph) do
-      %Dbservice.Resources.Paragraph{} = paragraph -> paragraph
-      _ -> nil
-    end
-  end
-
-  defp extract_paragraph(_), do: nil
 
   def problem_lang(
         %{
@@ -245,16 +236,6 @@ defmodule DbserviceWeb.ResourceJSON do
       difficulty_level: rc.difficulty_level,
       concepts: concepts
     })
-    |> maybe_put_paragraph(resource, Map.get(assigns, :paragraph))
+    |> Paragraphs.maybe_put_paragraph(resource, Map.get(assigns, :paragraph))
   end
-
-  defp maybe_put_paragraph(map, resource, %Dbservice.Resources.Paragraph{} = paragraph) do
-    if Paragraphs.comprehension_problem?(resource, %{}) do
-      Map.put(map, :paragraph, %{id: paragraph.id, body: paragraph.body})
-    else
-      map
-    end
-  end
-
-  defp maybe_put_paragraph(map, _resource, _paragraph), do: map
 end


### PR DESCRIPTION
## Summary
Every API endpoint that returns problem metadata now includes the linked `paragraph` (`id`, `body`) in its response when the resource's `subtype` is `comprehension`. Gated by `Paragraphs.comprehension_problem?/2` — non-comprehension problems are unchanged.

Addresses review feedback: _"Need to add it in all apis where problem meta data is sent."_

## Endpoints updated
- `GET /api/resource/problem/:problem_id/:lang_code/:curriculum_id`
- `GET /api/resource/test/:id/problems`
- `GET /api/problems`
- `GET /api/problems/search`
- `GET /api/problem-language`
- `GET /api/problem-language/:id`
- `POST /api/problem-language`
- `PATCH /api/problem-language/:id`

## Changes
- **Queries** preload `:paragraph` on the `problem_lang` row (and `:resource` where the renderer needs to inspect `subtype`) so paragraph data flows through without N+1 lookups.
- **JSON views** (`ResourceJSON.problem_lang/1`, `ResourceJSON.render_problem/1`, `ProblemLanguageJSON.render/1`) add a `paragraph: %{id, body}` key only when the resource is a comprehension problem.

## Example
`GET /api/resource/problem/5047/en/1` for a comprehension problem:

```json
{
  "id": 5047,
  "type": "problem",
  "subtype": "comprehension",
  "meta_data": { ... },
  "lang_code": "en",
  "curriculum_id": 1,
  ...
  "paragraph": {
    "id": 42,
    "body": "Reading passage text..."
  }
}
```

For non-comprehension problems the response shape is unchanged (no `paragraph` key).

## Test plan
- [ ] `GET /api/resource/problem/<comp_id>/en/<curr_id>` returns `paragraph: {id, body}`
- [ ] `GET /api/resource/problem/<mcq_id>/en/<curr_id>` omits `paragraph`
- [ ] `GET /api/resource/test/<test_id>/problems?lang_code=en&curriculum_id=1` returns `paragraph` for each comprehension problem in the list and omits it for others
- [ ] `GET /api/problems?topic_id=<id>&curriculum_id=<id>&lang_code=en` includes `paragraph` on comprehension entries
- [ ] `GET /api/problems/search?subtype=comprehension&lang_code=en` includes `paragraph` on each result
- [ ] `GET /api/problem-language`, `GET /api/problem-language/:id`, and the POST/PATCH responses include `paragraph` when the underlying resource is comprehension and omit it otherwise
- [ ] 404 paths for missing resources still behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)