### PR TITLE
support paragraph field in single problem update api

### DIFF
--- a/lib/dbservice/paragraphs.ex
+++ b/lib/dbservice/paragraphs.ex
@@ -85,6 +85,33 @@ defmodule Dbservice.Paragraphs do
   end
 
   @doc """
+  Updates the body of every distinct paragraph linked to any `problem_lang`
+  row whose `res_id` is in `resource_ids`. Returns `:ok`; no-ops on an empty
+  list or non-binary body. Shared by the single PATCH and batch endpoints so
+  one shared paragraph is updated once even when many problem_lang rows
+  reference it.
+  """
+  def update_paragraphs_for_resources([], _body), do: :ok
+  def update_paragraphs_for_resources(_resource_ids, body) when not is_binary(body), do: :ok
+
+  def update_paragraphs_for_resources(resource_ids, body)
+      when is_list(resource_ids) and is_binary(body) do
+    from(pl in ProblemLanguage,
+      where: pl.res_id in ^resource_ids and not is_nil(pl.paragraph_id),
+      select: pl.paragraph_id,
+      distinct: true
+    )
+    |> Repo.all()
+    |> Enum.each(fn pid ->
+      pid
+      |> fetch_paragraph!()
+      |> update_paragraph(%{"body" => body})
+    end)
+
+    :ok
+  end
+
+  @doc """
   Deletes a paragraph.
 
   ## Examples

--- a/lib/dbservice/resources.ex
+++ b/lib/dbservice/resources.ex
@@ -8,6 +8,7 @@ defmodule Dbservice.Resources do
 
   alias Dbservice.Resources.Resource
   alias Dbservice.Resources.ProblemLanguage
+  alias Dbservice.Resources.Paragraph
   alias Dbservice.Languages.Language
   alias Dbservice.Resources.{ResourceTopic, ResourceChapter, ResourceConcept}
   alias Dbservice.Utils.Util
@@ -15,6 +16,7 @@ defmodule Dbservice.Resources do
   alias Dbservice.Chapters.Chapter
   alias Dbservice.Topics.Topic
   alias Dbservice.ChapterCurriculums
+  alias Dbservice.Paragraphs
 
   # Type + subtype → code_prefix; keep in sync with resource_types in priv/repo/seeds/resources.exs
   @non_problem_code_prefixes %{
@@ -839,13 +841,61 @@ defmodule Dbservice.Resources do
   defp update_problem_language(resource, params) do
     cond do
       has_lang_code?(params) ->
+        params = pre_sync_shared_paragraph(resource, params)
         update_problem_language_for_lang(resource, params)
 
       has_problem_language_fields?(params) ->
+        params = pre_sync_shared_paragraph(resource, params)
         update_all_problem_languages(resource, params)
 
       true ->
         :ok
+    end
+  end
+
+  # When `params["paragraph"]` carries a body for a comprehension problem, upsert the
+  # shared paragraph once. Existing distinct paragraphs are updated via a single helper;
+  # if no problem_lang row has a paragraph yet, one is created and injected via
+  # `paragraph_id` so per-row updates assign it. `paragraph` is then stripped so the
+  # per-row update path doesn't redundantly re-upsert.
+  defp pre_sync_shared_paragraph(resource, params) do
+    body = Paragraphs.paragraph_body_for_comprehension(params)
+
+    if is_binary(body) and Paragraphs.comprehension_problem?(resource, params) do
+      do_pre_sync_shared_paragraph(resource, params, body)
+    else
+      params
+    end
+  end
+
+  defp do_pre_sync_shared_paragraph(resource, params, body) do
+    existing_paragraph_ids =
+      from(pl in ProblemLanguage,
+        where: pl.res_id == ^resource.id and not is_nil(pl.paragraph_id),
+        select: pl.paragraph_id,
+        distinct: true
+      )
+      |> Repo.all()
+
+    case existing_paragraph_ids do
+      [] ->
+        inject_new_shared_paragraph(params, body)
+
+      _ ->
+        :ok = Paragraphs.update_paragraphs_for_resources([resource.id], body)
+        Map.drop(params, ["paragraph"])
+    end
+  end
+
+  defp inject_new_shared_paragraph(params, body) do
+    case Paragraphs.create_paragraph(%{"body" => body}) do
+      {:ok, %Paragraph{id: pid}} ->
+        params
+        |> Map.drop(["paragraph"])
+        |> Map.put("paragraph_id", pid)
+
+      _ ->
+        params
     end
   end
 

--- a/lib/dbservice_web/controllers/resource_controller.ex
+++ b/lib/dbservice_web/controllers/resource_controller.ex
@@ -320,21 +320,8 @@ defmodule DbserviceWeb.ResourceController do
     end
   end
 
-  defp update_paragraphs_for_problem_ids([], _body), do: :ok
-
-  defp update_paragraphs_for_problem_ids(problem_ids, body) do
-    from(pl in ProblemLanguage,
-      where: pl.res_id in ^problem_ids and not is_nil(pl.paragraph_id),
-      select: pl.paragraph_id,
-      distinct: true
-    )
-    |> Repo.all()
-    |> Enum.each(fn pid ->
-      pid
-      |> Paragraphs.fetch_paragraph!()
-      |> Paragraphs.update_paragraph(%{"body" => body})
-    end)
-  end
+  defp update_paragraphs_for_problem_ids(problem_ids, body),
+    do: Paragraphs.update_paragraphs_for_resources(problem_ids, body)
 
   def tests_containing_problems(conn, params) do
     problem_ids = params["problem_ids"] || []

--- a/lib/dbservice_web/swagger_schemas/resource.ex
+++ b/lib/dbservice_web/swagger_schemas/resource.ex
@@ -35,6 +35,11 @@ defmodule DbserviceWeb.SwaggerSchema.Resource do
             exam_ids(:array, "Exam ids associated with the resource")
             cms_status(:string, "Status name from cms_status table. Also accepts cms_status_id.")
             cms_status_id(:integer, "cms_status.id value to set status directly")
+
+            paragraph(
+              :string,
+              "Reading passage for comprehension problems (PATCH only). Upserts the shared paragraph linked to every `problem_lang` row of this resource via `paragraph_id`; ignored for non-comprehension subtypes."
+            )
           end
 
           example(%{

--- a/test/dbservice/paragraphs_test.exs
+++ b/test/dbservice/paragraphs_test.exs
@@ -1,0 +1,69 @@
+defmodule Dbservice.ParagraphsTest do
+  use Dbservice.DataCase, async: true
+
+  alias Dbservice.Languages.Language
+  alias Dbservice.Paragraphs
+  alias Dbservice.Repo
+  alias Dbservice.Resources.Paragraph
+  alias Dbservice.Resources.ProblemLanguage
+  alias Dbservice.Resources.Resource
+
+  describe "update_paragraphs_for_resources/2" do
+    setup do
+      paragraph = Repo.insert!(%Paragraph{body: "original passage"})
+
+      resource =
+        Repo.insert!(%Resource{
+          type: "problem",
+          subtype: "comprehension",
+          type_params: %{}
+        })
+
+      en =
+        Repo.insert!(%Language{
+          name: "English",
+          code: "test_en_#{System.unique_integer([:positive])}"
+        })
+
+      hi =
+        Repo.insert!(%Language{
+          name: "Hindi",
+          code: "test_hi_#{System.unique_integer([:positive])}"
+        })
+
+      Repo.insert!(%ProblemLanguage{
+        res_id: resource.id,
+        lang_id: en.id,
+        paragraph_id: paragraph.id,
+        meta_data: %{}
+      })
+
+      Repo.insert!(%ProblemLanguage{
+        res_id: resource.id,
+        lang_id: hi.id,
+        paragraph_id: paragraph.id,
+        meta_data: %{}
+      })
+
+      %{paragraph: paragraph, resource: resource}
+    end
+
+    test "updates the shared paragraph body when multiple problem_lang rows share it",
+         %{paragraph: paragraph, resource: resource} do
+      assert :ok =
+               Paragraphs.update_paragraphs_for_resources([resource.id], "new passage body")
+
+      assert Repo.get!(Paragraph, paragraph.id).body == "new passage body"
+    end
+
+    test "no-ops on empty resource id list" do
+      assert :ok = Paragraphs.update_paragraphs_for_resources([], "ignored")
+    end
+
+    test "no-ops when body is not a binary",
+         %{paragraph: paragraph, resource: resource} do
+      assert :ok = Paragraphs.update_paragraphs_for_resources([resource.id], nil)
+      assert Repo.get!(Paragraph, paragraph.id).body == "original passage"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Addresses the PR #496 comment thread: `paragraph` should work on `PATCH /api/resource/:id` for comprehension problems, not just the batch endpoint.
- Functional wiring was already on `main` via `50592cd`, but it called the per-row paragraph upsert N times for N `problem_lang` rows sharing one paragraph. This PR pre-syncs the shared paragraph **once** and strips the key before per-row processing, mirroring the batch endpoint's dedup behavior.
- Adds `Paragraphs.update_paragraphs_for_resources/2` and reuses it from both the single PATCH (`update_problem_language` in `Resources`) and the batch endpoint (`resource_controller.update_paragraphs_for_problem_ids`).
- Documents the `paragraph` field on the `Resource` swagger schema so API consumers can discover it.
- Adds a unit test for `Paragraphs.update_paragraphs_for_resources/2` covering the shared-paragraph dedup case.

## Behavior matrix for `PATCH /api/resource/:id` on a comprehension problem
| State of `problem_lang` rows | Body of `params["paragraph"]` | Effect |
| --- | --- | --- |
| ≥1 row already linked to existing paragraph(s) | non-empty string | each distinct paragraph updated once |
| All rows have `paragraph_id = nil` | non-empty string | one new paragraph created, injected via `paragraph_id` into per-row updates |
| Any | absent / blank string | no-op on paragraph (other fields update normally) |

## Test plan
- [ ] `mix test test/dbservice/paragraphs_test.exs` (added unit test; local run blocked by missing `postgres` role on my machine, please verify in CI)
- [ ] Manual: `PATCH /api/resource/:id` on a comprehension problem with `{"paragraph": "new body"}` → linked paragraph row body is updated
- [ ] Manual: same PATCH with `{"meta_data": {...}}` only (no paragraph) → paragraph untouched, `problem_lang.meta_data` updated
- [ ] Regression: `POST /api/resources/problems/batch` and `PATCH /api/resources/problems/batch` still behave as before (they now go through the shared helper)
- [ ] `mix check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)