### PR TITLE
feat: add school addition/update CSV import

### DIFF
--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -78,6 +78,7 @@ const Hooks = {
       this.handleEvent("submit_product_import", submitAuthenticatedImport);
       this.handleEvent("submit_program_import", submitAuthenticatedImport);
       this.handleEvent("submit_batch_import", submitAuthenticatedImport);
+      this.handleEvent("submit_school_import", submitAuthenticatedImport);
     }
   }
 };

--- a/lib/dbservice/constants/mappings.ex
+++ b/lib/dbservice/constants/mappings.ex
@@ -355,7 +355,7 @@ defmodule Dbservice.Constants.Mappings do
         "dropout",
         "re_enrollment"
       ],
-      optional: [],
+      optional: ["school_addition"],
       type: :string
     },
     "grade" => %{
@@ -390,20 +390,85 @@ defmodule Dbservice.Constants.Mappings do
     },
     "school_code" => %{
       db_field: "school_code",
-      required: ["student", "update_incorrect_school_to_correct_school", "re_enrollment"],
+      required: [
+        "student",
+        "update_incorrect_school_to_correct_school",
+        "re_enrollment",
+        "school_addition"
+      ],
       optional: [],
       type: :string
     },
     "udise_code" => %{
       db_field: "udise_code",
       required: [],
-      optional: ["student"],
+      optional: ["student", "school_addition"],
       type: :string
     },
     "school_name" => %{
       db_field: "school_name",
-      required: ["student"],
+      required: ["student", "school_addition"],
       optional: [],
+      type: :string
+    },
+    "school_gender_type" => %{
+      db_field: "school_gender_type",
+      required: [],
+      optional: ["school_addition"],
+      type: :string
+    },
+    "af_school_category" => %{
+      db_field: "af_school_category",
+      required: ["school_addition"],
+      optional: [],
+      type: :string
+    },
+    "region" => %{
+      db_field: "region",
+      required: [],
+      optional: ["school_addition"],
+      type: :string
+    },
+    "State_code" => %{
+      db_field: "state_code",
+      required: ["school_addition"],
+      optional: [],
+      type: :string
+    },
+    "state" => %{
+      db_field: "school_state",
+      required: ["school_addition"],
+      optional: [],
+      type: :string
+    },
+    "district" => %{
+      db_field: "school_district",
+      required: ["school_addition"],
+      optional: [],
+      type: :string
+    },
+    "board" => %{
+      db_field: "school_board",
+      required: [],
+      optional: ["school_addition"],
+      type: :string
+    },
+    "board_medium" => %{
+      db_field: "school_board_medium",
+      required: [],
+      optional: ["school_addition"],
+      type: :string
+    },
+    "update_date" => %{
+      db_field: "school_update_date",
+      required: [],
+      optional: ["school_addition"],
+      type: :string
+    },
+    "group" => %{
+      db_field: "school_group",
+      required: [],
+      optional: ["school_addition"],
       type: :string
     },
     "start_date" => %{
@@ -629,7 +694,7 @@ defmodule Dbservice.Constants.Mappings do
     "program_model" => %{
       db_field: "model",
       required: [],
-      optional: ["program_addition"],
+      optional: ["program_addition", "school_addition"],
       type: :string
     },
     "is_current" => %{
@@ -725,7 +790,7 @@ defmodule Dbservice.Constants.Mappings do
     },
     "district_code" => %{
       db_field: "district_code",
-      required: ["teacher_addition"],
+      required: ["teacher_addition", "school_addition"],
       optional: [],
       type: :string
     },

--- a/lib/dbservice/data_import.ex
+++ b/lib/dbservice/data_import.ex
@@ -25,6 +25,7 @@ defmodule Dbservice.DataImport do
   def format_type_name("product_addition"), do: "Product Addition"
   def format_type_name("program_addition"), do: "Program Addition"
   def format_type_name("batch_addition"), do: "Batch Addition"
+  def format_type_name("school_addition"), do: "School Addition"
   def format_type_name("alumni_addition"), do: "Alumni Addition"
 
   def format_type_name("update_incorrect_batch_id_to_correct_batch_id"),

--- a/lib/dbservice/utils/import_worker.ex
+++ b/lib/dbservice/utils/import_worker.ex
@@ -37,6 +37,7 @@ defmodule Dbservice.DataImport.ImportWorker do
   alias Dbservice.Products
   alias Dbservice.Programs
   alias Dbservice.Batches
+  alias Dbservice.Schools
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"id" => import_id}}) do
@@ -81,6 +82,7 @@ defmodule Dbservice.DataImport.ImportWorker do
       "product_addition" => &process_product_addition_record/1,
       "program_addition" => &process_program_addition_record/1,
       "batch_addition" => &process_batch_addition_record/1,
+      "school_addition" => &process_school_addition_record/1,
       "student" => &process_student_record/1,
       "student_update" => &process_student_update_record/1,
       "batch_movement" => &process_batch_movement_record/1,
@@ -1310,6 +1312,57 @@ defmodule Dbservice.DataImport.ImportWorker do
   defp maybe_put_batch(attrs, _key, nil), do: attrs
   defp maybe_put_batch(attrs, _key, ""), do: attrs
   defp maybe_put_batch(attrs, key, value), do: Map.put(attrs, key, value)
+
+  defp process_school_addition_record(record) do
+    with {:ok, code} <- validate_school_code(record["school_code"]),
+         attrs <- build_school_attrs(record, code),
+         result <- create_or_update_school(code, attrs) do
+      format_school_result(result)
+    else
+      {:error, msg} when is_binary(msg) -> {:error, msg}
+    end
+  end
+
+  defp validate_school_code(nil), do: {:error, "school_code is required for school addition"}
+
+  defp validate_school_code(code) when is_binary(code) do
+    t = String.trim(code)
+    if t == "", do: {:error, "school_code is required for school addition"}, else: {:ok, t}
+  end
+
+  defp validate_school_code(_), do: {:error, "school_code is required for school addition"}
+
+  defp build_school_attrs(record, code) do
+    %{"code" => code}
+    |> maybe_put_school("name", record["school_name"] |> trim_str())
+    |> maybe_put_school("udise_code", record["udise_code"] |> trim_str())
+    |> maybe_put_school("gender_type", record["school_gender_type"] |> trim_str())
+    |> maybe_put_school("af_school_category", record["af_school_category"] |> trim_str())
+    |> maybe_put_school("region", record["region"] |> trim_str())
+    |> maybe_put_school("state_code", record["state_code"] |> trim_str())
+    |> maybe_put_school("state", record["school_state"] |> trim_str())
+    |> maybe_put_school("district_code", record["district_code"] |> trim_str())
+    |> maybe_put_school("district", record["school_district"] |> trim_str())
+    |> maybe_put_school("board", record["school_board"] |> trim_str())
+  end
+
+  defp create_or_update_school(code, attrs) do
+    case Schools.get_school_by_code(code) do
+      nil -> Schools.create_school(attrs)
+      existing -> Schools.update_school(existing, attrs)
+    end
+  end
+
+  defp format_school_result({:ok, school}), do: {:ok, school}
+
+  defp format_school_result({:error, %Ecto.Changeset{} = cs}),
+    do: {:error, ChangesetFormatter.format_errors(cs)}
+
+  defp format_school_result({:error, other}), do: {:error, inspect(other)}
+
+  defp maybe_put_school(attrs, _key, nil), do: attrs
+  defp maybe_put_school(attrs, _key, ""), do: attrs
+  defp maybe_put_school(attrs, key, value), do: Map.put(attrs, key, value)
 
   defp parse_int(nil), do: nil
   defp parse_int(""), do: nil

--- a/lib/dbservice_web/controllers/import_controller.ex
+++ b/lib/dbservice_web/controllers/import_controller.ex
@@ -144,4 +144,26 @@ defmodule DbserviceWeb.ImportController do
         |> redirect(to: ~p"/imports/new")
     end
   end
+
+  def create_school_import(conn, params) do
+    import_params =
+      params
+      |> Map.get("import", %{})
+      |> Map.put("type", "school_addition")
+
+    case DataImport.start_import(import_params) do
+      {:ok, _import} ->
+        conn
+        |> put_flash(
+          :info,
+          "School import queued successfully! Processing will begin shortly. Check the imports page for progress updates."
+        )
+        |> redirect(to: ~p"/imports")
+
+      {:error, reason} ->
+        conn
+        |> put_flash(:error, "Import failed: #{reason}")
+        |> redirect(to: ~p"/imports/new")
+    end
+  end
 end

--- a/lib/dbservice_web/live/import_live/new.ex
+++ b/lib/dbservice_web/live/import_live/new.ex
@@ -68,7 +68,8 @@ defmodule DbserviceWeb.ImportLive.New do
       "auth_group_addition" => "submit_auth_group_import",
       "product_addition" => "submit_product_import",
       "program_addition" => "submit_program_import",
-      "batch_addition" => "submit_batch_import"
+      "batch_addition" => "submit_batch_import",
+      "school_addition" => "submit_school_import"
     }
 
     if Map.has_key?(protected_import_config, import_type) do
@@ -128,6 +129,7 @@ defmodule DbserviceWeb.ImportLive.New do
   defp get_protected_import_url("product_addition"), do: ~p"/imports/product"
   defp get_protected_import_url("program_addition"), do: ~p"/imports/program"
   defp get_protected_import_url("batch_addition"), do: ~p"/imports/batch"
+  defp get_protected_import_url("school_addition"), do: ~p"/imports/school"
   defp get_protected_import_url(_), do: ~p"/imports"
 
   def render(assigns) do
@@ -184,6 +186,7 @@ defmodule DbserviceWeb.ImportLive.New do
                     <option value="product_addition" selected={@form[:type].value == "product_addition"}>Product Addition</option>
                     <option value="program_addition" selected={@form[:type].value == "program_addition"}>Program Addition</option>
                     <option value="batch_addition" selected={@form[:type].value == "batch_addition"}>Batch Addition</option>
+                    <option value="school_addition" selected={@form[:type].value == "school_addition"}>School Addition</option>
                     <option value="alumni_addition" selected={@form[:type].value == "alumni_addition"}>Alumni Addition</option>
                     <option value="batch_movement" selected={@form[:type].value == "batch_movement"}>Student Batch Movement</option>
                     <option value="dropout" selected={@form[:type].value == "dropout"}>Student Dropout</option>

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -44,6 +44,7 @@ defmodule DbserviceWeb.Router do
     post("/imports/product", ImportController, :create_product_import)
     post("/imports/program", ImportController, :create_program_import)
     post("/imports/batch", ImportController, :create_batch_import)
+    post("/imports/school", ImportController, :create_school_import)
   end
 
   scope "/api", DbserviceWeb do


### PR DESCRIPTION
## Summary
- Adds a new **School Addition** import type to the `/imports` LiveView tool that upserts schools by `school_code` (creates new, updates existing).
- Sits behind admin basic auth, matching the existing batch/program/product/auth_group addition flows (`POST /imports/school` under `:dashboard_auth`).
- Accepts the full sheet header set: `group, academic_year, school_code, school_name, udise_code, school_gender_type, af_school_category, region, State_code, district_code, state, district, board, program_model, board_medium, update_date`. Columns without a matching `school` schema field (`group`, `academic_year`, `program_model`, `board_medium`, `update_date`) are declared so the validator passes, then ignored by the processor.
- Required headers enforced (matches `School.changeset` `validate_required`): `school_code`, `school_name`, `af_school_category`, `district_code`, `State_code`, `state`, `district`.

### Files touched
- `lib/dbservice/constants/mappings.ex` — adds `school_addition` to existing entries and registers new headers.
- `lib/dbservice/utils/import_worker.ex` — `process_school_addition_record/1` upsert via `Schools.get_school_by_code` → `update_school` / `create_school`.
- `lib/dbservice/data_import.ex` — `format_type_name("school_addition")`.
- `lib/dbservice_web/live/import_live/new.ex` — new select option + `protected_import_config` entry + `/imports/school` URL helper.
- `lib/dbservice_web/router.ex` — protected `POST /imports/school`.
- `lib/dbservice_web/controllers/import_controller.ex` — `create_school_import/2`.
- `assets/js/hooks.js` — register `submit_school_import` handler.

## Test plan
- [ ] `mix compile` succeeds (verified locally).
- [ ] Visit `/imports/new`, select **School Addition**, paste a Google Sheet URL with the headers above, submit → browser prompts for `DASHBOARD_USER`/`DASHBOARD_PASS`.
- [ ] New `school_code` rows create `school` records with the mapped fields populated.
- [ ] Existing `school_code` rows update the matching `school` record.
- [ ] Missing any of the seven required headers fails CSV validation with "Invalid format for School Addition sheet".
- [ ] Rows with blank `school_code` produce a per-row error and do not insert/update.
- [ ] Download "School Addition Template" button produces a CSV with all 16 headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)