### PR TITLE
Rename cms_permission → cms_user_permission and extend schema

### DIFF
--- a/priv/repo/migrations/20260521081639_rename_cms_permission_and_add_columns.exs
+++ b/priv/repo/migrations/20260521081639_rename_cms_permission_and_add_columns.exs
@@ -1,0 +1,55 @@
+defmodule Dbservice.Repo.Migrations.RenameCmsPermissionAndAddColumns do
+  use Ecto.Migration
+
+  def up do
+    # Rename cms_permission -> cms_user_permission (consistent with planned
+    # lms_user_permission naming on the LMS side).
+    rename table(:cms_permission), to: table(:cms_user_permission)
+
+    execute "ALTER SEQUENCE cms_permission_id_seq RENAME TO cms_user_permission_id_seq"
+    execute "ALTER INDEX cms_permission_email_index RENAME TO cms_user_permission_email_index"
+
+    alter table(:cms_user_permission) do
+      add :full_name, :string
+      add :is_active, :boolean, null: false, default: true
+      add :last_login_at, :utc_datetime
+    end
+
+    execute """
+    ALTER TABLE cms_user_permission
+    ADD CONSTRAINT cms_user_permission_role_check
+    CHECK (role IN ('viewer', 'editor', 'admin'))
+    """
+
+    execute """
+    CREATE INDEX cms_user_permission_email_lower_index
+    ON cms_user_permission (LOWER(email))
+    """
+
+    # Seed first admin so someone can log in after the OAuth flow lands.
+    execute """
+    INSERT INTO cms_user_permission (email, role, full_name, is_active, inserted_at, updated_at)
+    VALUES ('pritam@avantifellows.org', 'admin', 'Pritam Sukumar', true, NOW(), NOW())
+    ON CONFLICT (email) DO NOTHING
+    """
+  end
+
+  def down do
+    execute "DELETE FROM cms_user_permission WHERE email = 'pritam@avantifellows.org'"
+
+    execute "DROP INDEX IF EXISTS cms_user_permission_email_lower_index"
+
+    execute "ALTER TABLE cms_user_permission DROP CONSTRAINT IF EXISTS cms_user_permission_role_check"
+
+    alter table(:cms_user_permission) do
+      remove :last_login_at
+      remove :is_active
+      remove :full_name
+    end
+
+    execute "ALTER INDEX cms_user_permission_email_index RENAME TO cms_permission_email_index"
+    execute "ALTER SEQUENCE cms_user_permission_id_seq RENAME TO cms_permission_id_seq"
+
+    rename table(:cms_user_permission), to: table(:cms_permission)
+  end
+end


### PR DESCRIPTION
## Summary
- Renames `cms_permission` → `cms_user_permission` (table, sequence, unique-email index) to match the planned `lms_user_permission` convention.
- Adds columns needed by the upcoming CMS auth flow: `full_name`, `is_active` (default `true`), `last_login_at`.
- Adds `CHECK (role IN ('viewer','editor','admin'))` to enforce the three-role RBAC model.
- Adds a case-insensitive `LOWER(email)` index for login lookups.
- Seeds `pritam@avantifellows.org` as the initial `admin` (idempotent via `ON CONFLICT DO NOTHING`) so someone can sign in once Google OAuth lands in nex-gen-cms.

Existing `cms_permission` table is empty on staging — verified — so the rename + constraint additions are safe.

## Context
Follow-up to #429, which created the `cms_permission` table but stopped before any consuming code. nex-gen-cms is now building Google OAuth + role-based access (viewer / editor / admin) against this table. It will connect to Postgres directly for auth (content paths continue to go through db-service API), so no schema/context/endpoints are added here.

## Schema (after migration)
```
cms_user_permission (
  id             BIGSERIAL PRIMARY KEY,
  email          VARCHAR(255) NOT NULL UNIQUE,
  role           VARCHAR(255) NOT NULL DEFAULT 'viewer'
                   CHECK (role IN ('viewer','editor','admin')),
  full_name      VARCHAR(255),
  is_active      BOOLEAN NOT NULL DEFAULT true,
  last_login_at  TIMESTAMP,
  inserted_at    TIMESTAMP NOT NULL,
  updated_at     TIMESTAMP NOT NULL
)
-- indexes: unique on email, expression index on LOWER(email)
```

## Test plan
- [ ] CI passes (`mix ecto.migrate` runs cleanly)
- [ ] After staging deploy, verify table is renamed: `\d cms_user_permission`
- [ ] Verify pritam@avantifellows.org exists as admin: `SELECT * FROM cms_user_permission`
- [ ] Verify CHECK rejects invalid role: `INSERT ... role='banana'` should fail
- [ ] `mix ecto.rollback` reverses cleanly (local check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)