### PR TITLE
fix: hardcode ssl: true for prod Repo config

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -6,7 +6,7 @@ source(["config/.env", "config/.env.#{config_env()}"])
 if config_env() == :prod do
   config :dbservice, Dbservice.Repo,
     url: env!("DATABASE_URL", :string!),
-    ssl: System.get_env("DATABASE_SSL") == "true",
+    ssl: true,
     pool_size: env!("POOL_SIZE", :integer) || 10
 
   secret_key_base = env!("SECRET_KEY_BASE", :string!)


### PR DESCRIPTION
## Summary
- Hardcode `ssl: true` in `config/runtime.exs` for the prod `Dbservice.Repo` config, replacing the opt-in `DATABASE_SSL` env var check.
- Resolves SSL connection errors where the Postgres server requires encryption (e.g. `no pg_hba.conf entry for host ..., no encryption`).

## Note
This reverses the recent opt-in behavior introduced by c749629 / 4027241. If the prior prod connectivity issue resurfaces, we may also need:
```elixir
ssl_opts: [verify: :verify_none]
```
(or a proper `cacertfile`) depending on cert verification behavior on the current OTP version.

## Test plan
- [ ] Deploy to a staging/prod-like environment and confirm Repo connects without `no pg_hba.conf entry` errors
- [ ] Confirm no new `certificate verify failed` / `unknown ca` errors appear in logs
- [ ] Verify normal API traffic against the DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)