### PR TITLE
feat: add lms_student_documents table + API

### DIFF
--- a/lib/dbservice/lms_student_documents.ex
+++ b/lib/dbservice/lms_student_documents.ex
@@ -1,0 +1,71 @@
+defmodule Dbservice.LmsStudentDocuments do
+  @moduledoc """
+  The LmsStudentDocuments context.
+
+  Stores documents (e.g. research consent forms, ID proofs) tagged to a student,
+  with files held in S3 and metadata + page references stored here as JSONB.
+  """
+
+  import Ecto.Query, warn: false
+  alias Dbservice.Repo
+
+  alias Dbservice.LmsStudentDocuments.LmsStudentDocument
+
+  @doc """
+  Lists documents, optionally filtered by student_id and/or document_type.
+  Excludes soft-deleted rows.
+  """
+  def list_lms_student_documents(params \\ %{}) do
+    LmsStudentDocument
+    |> where([d], is_nil(d.deleted_at))
+    |> filter_by(params)
+    |> order_by([d], desc: d.inserted_at)
+    |> Repo.all()
+  end
+
+  defp filter_by(query, params) do
+    Enum.reduce(params, query, fn
+      {"student_id", value}, acc -> where(acc, [d], d.student_id == ^value)
+      {:student_id, value}, acc -> where(acc, [d], d.student_id == ^value)
+      {"document_type", value}, acc -> where(acc, [d], d.document_type == ^value)
+      {:document_type, value}, acc -> where(acc, [d], d.document_type == ^value)
+      _, acc -> acc
+    end)
+  end
+
+  @doc """
+  Gets a single document. Returns `nil` if not found or soft-deleted.
+  """
+  def get_lms_student_document(id) do
+    LmsStudentDocument
+    |> where([d], d.id == ^id and is_nil(d.deleted_at))
+    |> Repo.one()
+  end
+
+  @doc """
+  Creates a document.
+  """
+  def create_lms_student_document(attrs \\ %{}) do
+    %LmsStudentDocument{}
+    |> LmsStudentDocument.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Soft-deletes a document by setting deleted_at.
+  """
+  def soft_delete_lms_student_document(%LmsStudentDocument{} = doc) do
+    doc
+    |> LmsStudentDocument.changeset(%{
+      deleted_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    })
+    |> Repo.update()
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking document changes.
+  """
+  def change_lms_student_document(%LmsStudentDocument{} = doc, attrs \\ %{}) do
+    LmsStudentDocument.changeset(doc, attrs)
+  end
+end

--- a/lib/dbservice/lms_student_documents.ex
+++ b/lib/dbservice/lms_student_documents.ex
@@ -24,14 +24,22 @@ defmodule Dbservice.LmsStudentDocuments do
   end
 
   defp filter_by(query, params) do
-    Enum.reduce(params, query, fn
-      {"student_id", value}, acc -> where(acc, [d], d.student_id == ^value)
-      {:student_id, value}, acc -> where(acc, [d], d.student_id == ^value)
-      {"document_type", value}, acc -> where(acc, [d], d.document_type == ^value)
-      {:document_type, value}, acc -> where(acc, [d], d.document_type == ^value)
-      _, acc -> acc
+    Enum.reduce(params, query, fn {key, value}, acc ->
+      case normalize_key(key) do
+        :student_id -> where(acc, [d], d.student_id == ^value)
+        :document_type -> where(acc, [d], d.document_type == ^value)
+        _ -> acc
+      end
     end)
   end
+
+  defp normalize_key(key) when is_binary(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> :unknown
+  end
+
+  defp normalize_key(key), do: key
 
   @doc """
   Gets a single document. Returns `nil` if not found or soft-deleted.

--- a/lib/dbservice/lms_student_documents/lms_student_document.ex
+++ b/lib/dbservice/lms_student_documents/lms_student_document.ex
@@ -1,0 +1,68 @@
+defmodule Dbservice.LmsStudentDocuments.LmsStudentDocument do
+  @moduledoc false
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @document_types ~w(research_consent id_proof bonafide other)
+
+  schema "lms_student_documents" do
+    field :document_type, :string
+    field :pages, {:array, :map}, default: []
+    field :metadata, :map, default: %{}
+    field :uploaded_by, :string
+    field :deleted_at, :naive_datetime
+
+    belongs_to :student, Dbservice.Users.Student
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(document, attrs) do
+    document
+    |> cast(attrs, [
+      :student_id,
+      :document_type,
+      :pages,
+      :metadata,
+      :uploaded_by,
+      :deleted_at
+    ])
+    |> validate_required([:student_id, :document_type, :pages, :uploaded_by])
+    |> validate_inclusion(:document_type, @document_types)
+    |> validate_pages()
+  end
+
+  def document_types, do: @document_types
+
+  defp validate_pages(changeset) do
+    case get_field(changeset, :pages) do
+      pages when is_list(pages) and pages == [] ->
+        add_error(changeset, :pages, "must contain at least one page")
+
+      pages when is_list(pages) ->
+        if Enum.all?(pages, &valid_page?/1) do
+          changeset
+        else
+          add_error(
+            changeset,
+            :pages,
+            "each page must have s3_key, page_number, mime_type, byte_size"
+          )
+        end
+
+      _ ->
+        add_error(changeset, :pages, "must be a list")
+    end
+  end
+
+  defp valid_page?(%{} = page) do
+    is_binary(page["s3_key"] || page[:s3_key]) and
+      is_integer(page["page_number"] || page[:page_number]) and
+      is_binary(page["mime_type"] || page[:mime_type]) and
+      is_integer(page["byte_size"] || page[:byte_size])
+  end
+
+  defp valid_page?(_), do: false
+end

--- a/lib/dbservice_web/controllers/lms_student_document_controller.ex
+++ b/lib/dbservice_web/controllers/lms_student_document_controller.ex
@@ -1,0 +1,102 @@
+defmodule DbserviceWeb.LmsStudentDocumentController do
+  use DbserviceWeb, :controller
+
+  alias Dbservice.LmsStudentDocuments
+  alias Dbservice.LmsStudentDocuments.LmsStudentDocument
+
+  action_fallback(DbserviceWeb.FallbackController)
+
+  use PhoenixSwagger
+
+  alias DbserviceWeb.SwaggerSchema.LmsStudentDocument, as: SwaggerSchemaLmsStudentDocument
+
+  def swagger_definitions do
+    Map.merge(
+      SwaggerSchemaLmsStudentDocument.lms_student_document(),
+      SwaggerSchemaLmsStudentDocument.lms_student_documents()
+    )
+  end
+
+  swagger_path :index do
+    get("/api/lms-student-document")
+
+    parameters do
+      student_id(:query, :integer, "Filter by student id", required: false)
+      document_type(:query, :string, "Filter by document type", required: false)
+    end
+
+    response(200, "OK", Schema.ref(:LmsStudentDocuments))
+  end
+
+  def index(conn, params) do
+    documents = LmsStudentDocuments.list_lms_student_documents(params)
+    render(conn, :index, documents: documents)
+  end
+
+  swagger_path :create do
+    post("/api/lms-student-document")
+
+    parameters do
+      body(:body, Schema.ref(:LmsStudentDocument), "Document to create", required: true)
+    end
+
+    response(201, "Created", Schema.ref(:LmsStudentDocument))
+  end
+
+  def create(conn, params) do
+    with {:ok, %LmsStudentDocument{} = doc} <-
+           LmsStudentDocuments.create_lms_student_document(params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", ~p"/api/lms-student-document/#{doc}")
+      |> render(:show, document: doc)
+    end
+  end
+
+  swagger_path :show do
+    get("/api/lms-student-document/{id}")
+
+    parameters do
+      id(:path, :integer, "The id of the document", required: true)
+    end
+
+    response(200, "OK", Schema.ref(:LmsStudentDocument))
+  end
+
+  def show(conn, %{"id" => id}) do
+    case LmsStudentDocuments.get_lms_student_document(id) do
+      nil ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{error: "Document not found"})
+
+      doc ->
+        render(conn, :show, document: doc)
+    end
+  end
+
+  swagger_path :delete do
+    PhoenixSwagger.Path.delete("/api/lms-student-document/{id}")
+
+    parameters do
+      id(:path, :integer, "The id of the document", required: true)
+    end
+
+    response(204, "No Content")
+  end
+
+  def delete(conn, %{"id" => id}) do
+    case LmsStudentDocuments.get_lms_student_document(id) do
+      nil ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{error: "Document not found"})
+
+      doc ->
+        with {:ok, %LmsStudentDocument{}} <-
+               LmsStudentDocuments.soft_delete_lms_student_document(doc) do
+          send_resp(conn, :no_content, "")
+        end
+    end
+  end
+end

--- a/lib/dbservice_web/json/lms_student_document_json.ex
+++ b/lib/dbservice_web/json/lms_student_document_json.ex
@@ -1,0 +1,23 @@
+defmodule DbserviceWeb.LmsStudentDocumentJSON do
+  def index(%{documents: documents}) do
+    for(d <- documents, do: render(d))
+  end
+
+  def show(%{document: document}) do
+    render(document)
+  end
+
+  def render(doc) do
+    %{
+      id: doc.id,
+      student_id: doc.student_id,
+      document_type: doc.document_type,
+      pages: doc.pages,
+      metadata: doc.metadata,
+      uploaded_by: doc.uploaded_by,
+      deleted_at: doc.deleted_at,
+      inserted_at: doc.inserted_at,
+      updated_at: doc.updated_at
+    }
+  end
+end

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -143,6 +143,11 @@ defmodule DbserviceWeb.Router do
     get("/problems", ResourceController, :fetch_problems)
     resources("/test-rule", TestRuleController, except: [:new, :edit])
     resources("/alumni", AlumniController, except: [:new, :edit])
+
+    resources("/lms-student-document", LmsStudentDocumentController,
+      only: [:index, :create, :show, :delete]
+    )
+
     post("/student/create-with-enrollments", StudentController, :create_with_enrollments)
 
     get(

--- a/lib/dbservice_web/swagger_schemas/lms_student_document.ex
+++ b/lib/dbservice_web/swagger_schemas/lms_student_document.ex
@@ -1,0 +1,55 @@
+defmodule DbserviceWeb.SwaggerSchema.LmsStudentDocument do
+  @moduledoc false
+
+  use PhoenixSwagger
+
+  def lms_student_document do
+    %{
+      LmsStudentDocument:
+        swagger_schema do
+          title("LmsStudentDocument")
+          description("A document (e.g. research consent) tagged to a student")
+
+          properties do
+            id(:integer, "Document ID")
+            student_id(:integer, "Student ID", required: true)
+            document_type(:string, "Document type", required: true)
+            pages(:array, "Array of {s3_key, page_number, mime_type, byte_size}", required: true)
+            metadata(:object, "Per-type extensible fields")
+            uploaded_by(:string, "Email of the uploading user", required: true)
+            deleted_at(:string, "Soft-delete timestamp", format: "ISO-8601")
+            inserted_at(:string, "Created timestamp", format: "ISO-8601")
+            updated_at(:string, "Updated timestamp", format: "ISO-8601")
+          end
+
+          example(%{
+            id: 1,
+            student_id: 12_345,
+            document_type: "research_consent",
+            pages: [
+              %{
+                s3_key: "students/12345/research_consent/abc-def/page-1.jpg",
+                page_number: 1,
+                mime_type: "image/jpeg",
+                byte_size: 245_678
+              }
+            ],
+            metadata: %{consent_version: "v1"},
+            uploaded_by: "teacher@avantifellows.org"
+          })
+        end
+    }
+  end
+
+  def lms_student_documents do
+    %{
+      LmsStudentDocuments:
+        swagger_schema do
+          title("LmsStudentDocuments")
+          description("A collection of student documents")
+          type(:array)
+          items(Schema.ref(:LmsStudentDocument))
+        end
+    }
+  end
+end

--- a/priv/repo/migrations/20260528120000_create_lms_student_documents_table.exs
+++ b/priv/repo/migrations/20260528120000_create_lms_student_documents_table.exs
@@ -1,0 +1,35 @@
+defmodule Dbservice.Repo.Migrations.CreateLmsStudentDocumentsTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:lms_student_documents) do
+      add :student_id, references(:student, on_delete: :nothing), null: false
+
+      # Document identification (allowlist validated in app, not DB)
+      add :document_type, :string, size: 50, null: false
+
+      # Multi-page payload: [{s3_key, page_number, mime_type, byte_size}]
+      add :pages, :map, default: fragment("'[]'::jsonb"), null: false
+
+      # Extensible per-type fields
+      add :metadata, :map, default: %{}, null: false
+
+      # Email of the user who uploaded
+      add :uploaded_by, :string, size: 255, null: false
+
+      # Soft delete
+      add :deleted_at, :naive_datetime
+
+      timestamps(default: fragment("(NOW() AT TIME ZONE 'UTC')"), null: false)
+    end
+
+    create index(:lms_student_documents, [:student_id])
+    create index(:lms_student_documents, [:document_type])
+    create index(:lms_student_documents, [:student_id, :document_type])
+
+    create index(:lms_student_documents, [:student_id, :document_type],
+             where: "deleted_at IS NULL",
+             name: :lms_student_documents_active_idx
+           )
+  end
+end

--- a/test/dbservice_web/controllers/lms_student_document_controller_test.exs
+++ b/test/dbservice_web/controllers/lms_student_document_controller_test.exs
@@ -1,0 +1,130 @@
+defmodule DbserviceWeb.LmsStudentDocumentControllerTest do
+  use DbserviceWeb.ConnCase
+
+  import Dbservice.UsersFixtures
+
+  alias Dbservice.LmsStudentDocuments
+
+  @page %{
+    "s3_key" => "students/1/research_consent/abc/page-1.jpg",
+    "page_number" => 1,
+    "mime_type" => "image/jpeg",
+    "byte_size" => 245_678
+  }
+
+  setup %{conn: conn} do
+    {_user, student} = student_fixture()
+
+    create_attrs = %{
+      student_id: student.id,
+      document_type: "research_consent",
+      pages: [@page],
+      metadata: %{"consent_version" => "v1"},
+      uploaded_by: "teacher@avantifellows.org"
+    }
+
+    {:ok,
+     conn: put_req_header(conn, "accept", "application/json"),
+     student: student,
+     create_attrs: create_attrs}
+  end
+
+  describe "create document" do
+    test "renders document when data is valid", %{conn: conn, create_attrs: attrs} do
+      conn = post(conn, ~p"/api/lms-student-document", attrs)
+      %{"id" => id} = json_response(conn, 201)
+
+      conn = get(conn, ~p"/api/lms-student-document/#{id}")
+      resp = json_response(conn, 200)
+      assert resp["id"] == id
+      assert resp["document_type"] == "research_consent"
+      assert resp["uploaded_by"] == "teacher@avantifellows.org"
+      assert length(resp["pages"]) == 1
+    end
+
+    test "rejects unknown document_type", %{conn: conn, create_attrs: attrs} do
+      conn = post(conn, ~p"/api/lms-student-document", %{attrs | document_type: "phony"})
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "rejects empty pages array", %{conn: conn, create_attrs: attrs} do
+      conn = post(conn, ~p"/api/lms-student-document", %{attrs | pages: []})
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "rejects malformed page entry", %{conn: conn, create_attrs: attrs} do
+      bad_page = %{"s3_key" => "x", "page_number" => "not-an-int"}
+      conn = post(conn, ~p"/api/lms-student-document", %{attrs | pages: [bad_page]})
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "rejects missing student_id", %{conn: conn, create_attrs: attrs} do
+      conn = post(conn, ~p"/api/lms-student-document", Map.delete(attrs, :student_id))
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "index" do
+    test "lists documents filtered by student_id", %{
+      conn: conn,
+      student: student,
+      create_attrs: attrs
+    } do
+      {:ok, _doc} = LmsStudentDocuments.create_lms_student_document(attrs)
+      {_user, other_student} = student_fixture()
+
+      {:ok, _other} =
+        LmsStudentDocuments.create_lms_student_document(%{attrs | student_id: other_student.id})
+
+      conn = get(conn, ~p"/api/lms-student-document?student_id=#{student.id}")
+      resp = json_response(conn, 200)
+      assert is_list(resp)
+      assert Enum.all?(resp, fn d -> d["student_id"] == student.id end)
+      assert length(resp) == 1
+    end
+
+    test "excludes soft-deleted documents", %{conn: conn, student: student, create_attrs: attrs} do
+      {:ok, doc} = LmsStudentDocuments.create_lms_student_document(attrs)
+      {:ok, _} = LmsStudentDocuments.soft_delete_lms_student_document(doc)
+
+      conn = get(conn, ~p"/api/lms-student-document?student_id=#{student.id}")
+      resp = json_response(conn, 200)
+      assert resp == []
+    end
+  end
+
+  describe "show document" do
+    test "renders document", %{conn: conn, create_attrs: attrs} do
+      {:ok, doc} = LmsStudentDocuments.create_lms_student_document(attrs)
+      conn = get(conn, ~p"/api/lms-student-document/#{doc.id}")
+      resp = json_response(conn, 200)
+      assert resp["id"] == doc.id
+    end
+
+    test "404 for unknown id", %{conn: conn} do
+      conn = get(conn, ~p"/api/lms-student-document/999999")
+      assert json_response(conn, 404)["error"] == "Document not found"
+    end
+
+    test "404 for soft-deleted document", %{conn: conn, create_attrs: attrs} do
+      {:ok, doc} = LmsStudentDocuments.create_lms_student_document(attrs)
+      {:ok, _} = LmsStudentDocuments.soft_delete_lms_student_document(doc)
+      conn = get(conn, ~p"/api/lms-student-document/#{doc.id}")
+      assert json_response(conn, 404)["error"] == "Document not found"
+    end
+  end
+
+  describe "delete document" do
+    test "soft-deletes the document", %{conn: conn, create_attrs: attrs} do
+      {:ok, doc} = LmsStudentDocuments.create_lms_student_document(attrs)
+      conn = delete(conn, ~p"/api/lms-student-document/#{doc.id}")
+      assert response(conn, 204)
+      assert LmsStudentDocuments.get_lms_student_document(doc.id) == nil
+    end
+
+    test "404 for unknown id", %{conn: conn} do
+      conn = delete(conn, ~p"/api/lms-student-document/999999")
+      assert json_response(conn, 404)["error"] == "Document not found"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a new `lms_student_documents` table (and accompanying REST API) so the LMS can store documents (e.g. parent research-consent forms, ID proofs, bonafides) tagged to a student. File bytes live in S3; this table holds metadata + an array of page references in JSONB so multi-page documents are atomic.

- `student_id` FK + `document_type` (allowlist enforced in the changeset, not the DB) + `pages jsonb` + `metadata jsonb` (escape hatch for per-type fields) + `uploaded_by` (email) + `deleted_at` (soft delete) + timestamps
- Indexes: `student_id`, `document_type`, `(student_id, document_type)`, and a partial index on the last for active rows only
- No update endpoint — documents are atomic. Replace = create new + soft-delete old.

## Endpoints

| Method | Path | Notes |
|---|---|---|
| GET    | `/api/lms-student-document` | filter by `student_id` and/or `document_type`; excludes soft-deleted |
| POST   | `/api/lms-student-document` | validates `document_type` allowlist + `pages` shape |
| GET    | `/api/lms-student-document/:id` | 404 on soft-deleted |
| DELETE | `/api/lms-student-document/:id` | soft delete via `deleted_at` |

`pages` JSONB shape (enforced in the changeset, not the DB):

```json
[{"s3_key": "...", "page_number": 1, "mime_type": "image/jpeg", "byte_size": 245678}]
```

## Design notes

- **FK on `student_id`** (`references(:student, on_delete: :nothing)`) — diverges from the FK-less pattern on `lms_pm_school_visit_actions.visit_id`, but since documents flow *through* db-service rather than direct-write from LMS, the consistency is worth having.
- **No DB CHECK on `document_type`** — keeping the allowlist in app code so adding a new type doesn't need a migration.
- **`pages` as JSONB array, not a child table** — matches the `data jsonb` pattern on `lms_pm_school_visit_actions`. The unit of fetch is the whole document; per-page queries aren't a use case.
- **Document type allowlist** starts at: `research_consent`, `id_proof`, `bonafide`, `other`.

## Test plan

- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix credo --strict` on new files — clean
- [x] `mix test` on new controller test — 12/12 pass
- [x] `mix test` full suite — 8 pre-existing failures on `main` (in files this PR doesn't touch; see `e8f048d3` which changed an error message in `group_update_processor.ex` without updating the corresponding test). This PR adds 0 new failures.
- [ ] Deploy to staging; LMS-side upload flow will be wired up in a follow-up PR on `af_lms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)