### PR TITLE
fix(infra): bugs blocking ECS Fargate deploy (found in Phase 4 validation)

### DIFF
--- a/.github/workflows/production_deploy_ecs.yml
+++ b/.github/workflows/production_deploy_ecs.yml
@@ -21,6 +21,10 @@ env:
   CONTAINER_NAME: db-service
   SUBNETS: subnet-84ffe8ec,subnet-434c080f,subnet-5cd65827
   SECURITY_GROUP_NAME: db-service-prod-sg
+  # Smoke check hits the shared ALB directly (Host header) so it doesn't depend
+  # on public DNS (which lives in Cloudflare, not Route53).
+  SERVICE_HOST: db.avantifellows.org
+  ALB_NAME: af-load-balancer
 
 concurrency:
   group: deploy-prod-ecs
@@ -160,8 +164,15 @@ jobs:
       - name: Smoke check
         run: |
           set -euo pipefail
+          ALB_DNS=$(aws elbv2 describe-load-balancers \
+            --names "$ALB_NAME" \
+            --query 'LoadBalancers[0].DNSName' --output text)
+          ALB_IP=$(getent hosts "$ALB_DNS" | awk '{print $1; exit}')
+          echo "Resolving ${SERVICE_HOST} -> ${ALB_DNS} (${ALB_IP})"
           for i in 1 2 3 4 5 6; do
-            CODE=$(curl -sk -o /dev/null -w "%{http_code}" https://db.avantifellows.org/api/health || echo "000")
+            CODE=$(curl -sk -o /dev/null -w "%{http_code}" \
+              --resolve "${SERVICE_HOST}:443:${ALB_IP}" \
+              "https://${SERVICE_HOST}/api/health" || echo "000")
             echo "attempt $i: HTTP $CODE"
             if [ "$CODE" = "200" ]; then exit 0; fi
             sleep 10

--- a/.github/workflows/staging_deploy_ecs.yml
+++ b/.github/workflows/staging_deploy_ecs.yml
@@ -21,6 +21,10 @@ env:
   CONTAINER_NAME: db-service
   SUBNETS: subnet-84ffe8ec,subnet-434c080f,subnet-5cd65827
   SECURITY_GROUP_NAME: db-service-staging-sg
+  # Smoke check hits the shared ALB directly (Host header) so it doesn't depend
+  # on public DNS (which lives in Cloudflare, not Route53).
+  SERVICE_HOST: staging-database.avantifellows.org
+  ALB_NAME: af-load-balancer
 
 concurrency:
   group: deploy-staging-ecs
@@ -160,8 +164,15 @@ jobs:
       - name: Smoke check
         run: |
           set -euo pipefail
+          ALB_DNS=$(aws elbv2 describe-load-balancers \
+            --names "$ALB_NAME" \
+            --query 'LoadBalancers[0].DNSName' --output text)
+          ALB_IP=$(getent hosts "$ALB_DNS" | awk '{print $1; exit}')
+          echo "Resolving ${SERVICE_HOST} -> ${ALB_DNS} (${ALB_IP})"
           for i in 1 2 3 4 5 6; do
-            CODE=$(curl -sk -o /dev/null -w "%{http_code}" https://staging-db.avantifellows.org/api/health || echo "000")
+            CODE=$(curl -sk -o /dev/null -w "%{http_code}" \
+              --resolve "${SERVICE_HOST}:443:${ALB_IP}" \
+              "https://${SERVICE_HOST}/api/health" || echo "000")
             echo "attempt $i: HTTP $CODE"
             if [ "$CODE" = "200" ]; then exit 0; fi
             sleep 10

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -7,10 +7,10 @@ if config_env() == :prod do
   config :dbservice, Dbservice.Repo,
     url: env!("DATABASE_URL", :string!),
     ssl: true,
-    pool_size: env!("POOL_SIZE", :integer) || 10
+    pool_size: env!("POOL_SIZE", :integer, 10)
 
   secret_key_base = env!("SECRET_KEY_BASE", :string!)
-  port = env!("PORT", :integer) || 4000
+  port = env!("PORT", :integer, 4000)
   host = env!("PHX_HOST", :string!)
 
   config :dbservice, DbserviceWeb.Endpoint,

--- a/lib/dbservice/application.ex
+++ b/lib/dbservice/application.ex
@@ -33,9 +33,9 @@ defmodule Dbservice.Application do
   end
 
   defp goth_child_spec do
-    case env!("GOOGLE_CREDENTIALS_JSON", :string, nil) do
+    case blank_to_nil(env!("GOOGLE_CREDENTIALS_JSON", :string, nil)) do
       nil ->
-        case env!("PATH_TO_CREDENTIALS", :string, nil) do
+        case blank_to_nil(env!("PATH_TO_CREDENTIALS", :string, nil)) do
           nil -> handle_missing_credentials()
           json_path -> load_credentials_from_file(json_path)
         end
@@ -44,6 +44,17 @@ defmodule Dbservice.Application do
         build_goth_spec(json_string)
     end
   end
+
+  # Env vars injected as empty strings (e.g. a blank ECS task override) should
+  # be treated as "not set" rather than a present-but-empty path/JSON.
+  defp blank_to_nil(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp blank_to_nil(value), do: value
 
   defp handle_missing_credentials do
     if Application.get_env(:dbservice, :environment) == :test do
@@ -73,6 +84,13 @@ defmodule Dbservice.Application do
             "https://www.googleapis.com/auth/drive.readonly"
           ]}}
     ]
+  rescue
+    error ->
+      # Don't let malformed Google credentials crash the whole service — the
+      # REST API and health check must stay up even if Sheets auth is broken.
+      require Logger
+      Logger.error("Goth init failed, starting without Google auth: #{inspect(error)}")
+      []
   end
 
   defp handle_credentials_error(reason) do

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -2,6 +2,10 @@ resource "aws_ecr_repository" "this" {
   name                 = "db-service-${var.environment}"
   image_tag_mutability = "MUTABLE"
 
+  # Allow `terraform destroy` to remove the repo even when it still holds
+  # images pushed by the deploy pipeline.
+  force_delete = true
+
   image_scanning_configuration {
     scan_on_push = true
   }

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -32,6 +32,7 @@ locals {
   image    = "${aws_ecr_repository.this.repository_url}:${var.image_tag}"
 
   container_env = [
+    { name = "PHX_SERVER", value = "true" },
     { name = "PORT", value = tostring(var.app_port) },
     { name = "PHX_HOST", value = local.phx_host },
     { name = "POOL_SIZE", value = var.pool_size },
@@ -98,6 +99,10 @@ resource "aws_ecs_service" "this" {
   platform_version = "LATEST"
 
   enable_execute_command = true
+
+  # Give the Phoenix release time to boot before the ALB starts failing the
+  # task on health checks. Without this, a slow cold start gets killed.
+  health_check_grace_period_seconds = 120
 
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200

--- a/terraform/envs/staging.tfvars
+++ b/terraform/envs/staging.tfvars
@@ -1,10 +1,11 @@
-environment            = "staging"
-domain_prefix          = "staging-db"
+environment = "staging"
+# "staging-db" collides with the existing EC2 staging host; use a distinct name.
+domain_prefix          = "staging-database"
 listener_rule_priority = 200
 
 # WHITELISTED_DOMAINS — comma-separated host list enforced by DomainWhitelistPlug.
 # Mirror what's currently set in the EC2 .env for staging; adjust as needed.
-whitelisted_domains = "staging-db.avantifellows.org,localhost"
+whitelisted_domains = "staging-database.avantifellows.org,localhost"
 
 # Sensitive variables (database_url, secret_key_base, bearer_token,
 # google_credentials_json, dashboard_user, dashboard_pass) MUST be supplied

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -68,6 +68,12 @@ resource "aws_iam_role_policy" "task_s3" {
 resource "aws_iam_user" "ci" {
   count = var.create_ci_user ? 1 : 0
   name  = "db-service-ci-deploy"
+
+  # Once created, the user backs GitHub Secrets. Flipping create_ci_user back
+  # to false must not silently delete it (and the access key the CI relies on).
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_iam_access_key" "ci" {
@@ -113,6 +119,21 @@ data "aws_iam_policy_document" "ci_policy" {
       "ecs:DescribeTasks",
       "ecs:ListTasks",
       "ecs:StopTask",
+    ]
+    resources = ["*"]
+  }
+
+  # Needed by the deploy workflow to resolve the task security group/subnets
+  # for the one-off migration RunTask, and to smoke-check via the ALB.
+  statement {
+    sid    = "Discovery"
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSubnets",
+      "elasticloadbalancing:DescribeLoadBalancers",
+      "elasticloadbalancing:DescribeTargetGroups",
+      "elasticloadbalancing:DescribeTargetHealth",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Summary

Fixes the bugs found while validating the EC2 → ECS Fargate migration end-to-end. With these, the staging deploy workflow can build, migrate, deploy, and pass the smoke check. Each item below caused (or would cause) a real failure during a deploy.

## Blockers (deploy fails without these)

1. **`iam.tf` — CI user missing EC2/ELB Describe perms.** Workflow failed at "Resolve task security group" with `UnauthorizedOperation`. Added `ec2:DescribeSecurityGroups`, `ec2:DescribeSubnets`, and `elasticloadbalancing:Describe*` (the last for the new ALB-based smoke check).
2. **`ecs.tf` — task definition missing `PHX_SERVER=true`.** Phase 0's `runtime.exs` gates the HTTP listener on it, so Phoenix never started → ALB health check timed out → tasks killed in a loop.
3. **Workflow smoke check hit a hardcoded public hostname.** `staging-db.avantifellows.org` (a) didn't match the configured prefix and (b) public DNS is in **Cloudflare, not Route53**, so the Route53 record terraform creates is invisible. Smoke check now hits the shared ALB directly via `--resolve` + Host header, so it validates the actual deployment without depending on public DNS.

## Robustness (work now, would bite later)

4. **`iam.tf` — `prevent_destroy` on the CI user.** Flipping `create_ci_user = false` (as the original docs suggested) would delete the user + the access key backing GitHub Secrets.
5. **`ecr.tf` — `force_delete = true`.** `terraform destroy` failed once the repo held images; had to empty ECR by hand.
6. **`ecs.tf` — `health_check_grace_period_seconds = 120`.** Was `0`; ALB started health-checking before Phoenix finished booting.

## App-code fixes

7. **`runtime.exs` — `env!/3` default instead of `env!(..) || N`.** `env!` raises on a missing var, so the `|| 10` / `|| 4000` fallbacks were dead code. Forced us to pass `POOL_SIZE`/`PORT` explicitly.
8. **`application.ex` — blank-string credentials + non-fatal Goth.** Empty-string env vars are now treated as "unset". Goth init is wrapped so malformed Google credentials log an error instead of crashing the whole supervisor (which took down the REST API + health check).

## Config

9. **`staging.tfvars` — `domain_prefix = "staging-database"`.** `staging-db` collides with the existing EC2 staging host.

## Still needs a team decision (not in this PR)

- **DNS:** `terraform/dns.tf` manages a Route53 record, but the org's authoritative DNS is Cloudflare. For users to reach the service by hostname, a Cloudflare record pointing at the ALB is required (manual, or adopt the Cloudflare TF provider). The smoke-check fix sidesteps this for CI, but production access still needs it.

## Test status

Validated against staging: build → ECR push → migration task → service deploy all pass. Smoke check fix verified to hit the ALB directly. The `workflow_dispatch` trigger is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)