### PR TITLE
fix: endpoint only serves when PHX_SERVER set (unbreaks EC2 mix phx.server)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -14,7 +14,6 @@ if config_env() == :prod do
   host = env!("PHX_HOST", :string!)
 
   config :dbservice, DbserviceWeb.Endpoint,
-    server: System.get_env("PHX_SERVER") in ~w(1 true),
     load_from_system_env: false,
     url: [host: host, port: 443],
     http: [
@@ -28,4 +27,13 @@ if config_env() == :prod do
     secret_key_base: secret_key_base,
     debug_errors: false,
     check_origin: ["//#{host}"]
+
+  # `mix phx.server` (the EC2 deploy) turns serving on by itself, so leave
+  # :server unset on that path. OTP releases (ECS) don't, so flip it on when
+  # PHX_SERVER is set — rel/env.sh.eex exports it for `bin/dbservice start`.
+  # Setting `server: false` explicitly (the previous behaviour) overrode
+  # mix phx.server and stopped the EC2 deploy from ever listening.
+  if System.get_env("PHX_SERVER") in ~w(1 true) do
+    config :dbservice, DbserviceWeb.Endpoint, server: true
+  end
 end


### PR DESCRIPTION
## Problem

`config/runtime.exs` set the endpoint's `server:` to an explicit boolean on every prod boot:

```elixir
server: System.get_env("PHX_SERVER") in ~w(1 true),
```

When `PHX_SERVER` isn't set, this evaluates to `server: false` **explicitly**. Phoenix only falls back to `mix phx.server`'s built-in serving override when `:server` is *unset* — an explicit `false` wins. So the EC2 deploy, which starts the app with:

```
sudo env MIX_ENV=prod elixir --erl "-detached" -S mix phx.server
```

booted but never listened on `:4000`.

## Fix

Use the standard Phoenix release pattern — leave `:server` unset by default, and only flip it on when `PHX_SERVER` is present:

```elixir
if System.get_env("PHX_SERVER") in ~w(1 true) do
  config :dbservice, DbserviceWeb.Endpoint, server: true
end
```

## Why this works for both runtimes

| Startup | PHX_SERVER | `:server` | Serves? |
|---|---|---|---|
| **EC2** `mix phx.server` | not set | unset → `mix phx.server` enables serving | ✅ |
| **ECS** `bin/dbservice start` | exported by `rel/env.sh.eex` | `true` | ✅ |
| migration `bin/dbservice eval ...` | not set | unset, no endpoint anyway | ✅ (correctly off) |

The key change: when `PHX_SERVER` is absent we no longer set `server: false`, so `mix phx.server` can do its job on EC2.

## Test plan

- [ ] EC2 staging deploy (`mix phx.server`) starts and `GET /api/health` returns 200
- [ ] ECS release (`bin/dbservice start`) serves (rel/env.sh.eex sets PHX_SERVER=true)
- [ ] migration task (`bin/dbservice eval`) still runs without starting a server

🤖 Generated with [Claude Code](https://claude.com/claude-code)