### PR TITLE
loosen lms_student_documents document_type to free string

### DIFF
--- a/lib/dbservice/lms_student_documents/lms_student_document.ex
+++ b/lib/dbservice/lms_student_documents/lms_student_document.ex
@@ -4,8 +4,6 @@ defmodule Dbservice.LmsStudentDocuments.LmsStudentDocument do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @document_types ~w(research_consent id_proof bonafide other)
-
   schema "lms_student_documents" do
     field :document_type, :string
     field :pages, {:array, :map}, default: []
@@ -30,11 +28,9 @@ defmodule Dbservice.LmsStudentDocuments.LmsStudentDocument do
       :deleted_at
     ])
     |> validate_required([:student_id, :document_type, :pages, :uploaded_by])
-    |> validate_inclusion(:document_type, @document_types)
+    |> validate_length(:document_type, min: 1, max: 64)
     |> validate_pages()
   end
-
-  def document_types, do: @document_types
 
   defp validate_pages(changeset) do
     case get_field(changeset, :pages) do

--- a/test/dbservice_web/controllers/lms_student_document_controller_test.exs
+++ b/test/dbservice_web/controllers/lms_student_document_controller_test.exs
@@ -42,8 +42,24 @@ defmodule DbserviceWeb.LmsStudentDocumentControllerTest do
       assert length(resp["pages"]) == 1
     end
 
-    test "rejects unknown document_type", %{conn: conn, create_attrs: attrs} do
-      conn = post(conn, ~p"/api/lms-student-document", %{attrs | document_type: "phony"})
+    test "accepts any non-empty document_type (free string)", %{conn: conn, create_attrs: attrs} do
+      conn = post(conn, ~p"/api/lms-student-document", %{attrs | document_type: "anything_goes"})
+      resp = json_response(conn, 201)
+      assert resp["document_type"] == "anything_goes"
+    end
+
+    test "rejects blank document_type", %{conn: conn, create_attrs: attrs} do
+      conn = post(conn, ~p"/api/lms-student-document", %{attrs | document_type: ""})
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "rejects oversized document_type (>64 chars)", %{conn: conn, create_attrs: attrs} do
+      conn =
+        post(conn, ~p"/api/lms-student-document", %{
+          attrs
+          | document_type: String.duplicate("x", 65)
+        })
+
       assert json_response(conn, 422)["errors"] != %{}
     end
 


### PR DESCRIPTION
## Summary

- Drops the `validate_inclusion` enum check on `document_type`; replaces it with `validate_length(min: 1, max: 64)`.
- Removes the now-orphan `@document_types` constant and `document_types/0` accessor (no callers in repo).
- Mirrors the change in the controller test: removes the "rejects unknown document_type" assertion; adds positive coverage for an arbitrary string and 422s for blank / oversized strings.

## Why

The schema layer's job is storage. Which kinds of documents the product offers is policy that belongs in the LMS client. Owning the allowlist in two places forced coordinated deploys for every new document type and added schema-drift risk. After this PR, adding/removing a document type is a one-PR change in LMS.

The length cap (1–64) keeps the column tame — blocks blank inserts and runaway-length garbage, but allows any reasonable LMS-side label.

## Test plan

- [x] `mix test test/dbservice_web/controllers/lms_student_document_controller_test.exs` — 14/14 pass on this branch.
- [ ] After merge + staging redeploy: verify LMS-side upload with a new document type value succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)