### PR TITLE
fix(ecs): IPv4 bind + port 8080 so the ALB can health-check the Fargate task

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -17,11 +17,10 @@ if config_env() == :prod do
     load_from_system_env: false,
     url: [host: host, port: 443],
     http: [
-      # Enable IPv6 and bind on all interfaces.
-      # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.
-      # See the documentation on https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html
-      # for details about using IPv6 vs IPv4 and loopback vs public addresses.
-      ip: {0, 0, 0, 0, 0, 0, 0, 0},
+      # Bind on IPv4 all-interfaces. The ECS/Fargate ALB target group connects
+      # to the task's IPv4 ENI address, so an IPv6-only bind ({0,0,0,0,0,0,0,0})
+      # makes the ALB health check time out even though the app is up.
+      ip: {0, 0, 0, 0},
       port: port
     ],
     secret_key_base: secret_key_base,

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -73,9 +73,9 @@ variable "aws_region" {
 }
 
 variable "app_port" {
-  description = "Port the container listens on."
+  description = "Port the container listens on. Must be 8080 — the shared ALB's security group only permits egress to targets on 8080."
   type        = number
-  default     = 4000
+  default     = 8080
 }
 
 variable "cpu" {


### PR DESCRIPTION
## Summary

The final two fixes that get the ECS Fargate staging deploy to pass end-to-end (build → push → migrate → deploy → smoke check all green, validated on staging). Both are required; each was masking the other behind a `Target.Timeout`.

## 1. Bind to IPv4 (`config/runtime.exs`)

The endpoint bound to IPv6 `{0, 0, 0, 0, 0, 0, 0, 0}` (`::`). Fargate's ALB target group connects to the task's **IPv4** ENI address, and the IPv6-only socket didn't accept it → ALB health check `Target.Timeout`, even though the app was up. The ECS *container* health check (`curl localhost`, which resolves to IPv6 `::1`) passed the whole time, which masked it.

```diff
-      ip: {0, 0, 0, 0, 0, 0, 0, 0},
+      ip: {0, 0, 0, 0},
```

## 2. Use port 8080 (`terraform/variables.tf`)

The shared `af-load-balancer`'s security group only permits **egress to targets on 8080** (`sg-…`: "8080-access" allows tcp/8080; the other has no egress). The app used Phoenix's default 4000, so the ALB literally couldn't open a connection to the target → `Target.Timeout`. 8080 matches the existing services behind this ALB.

```diff
-  default     = 4000
+  default     = 8080
```

`app_port` drives the container port, target-group port, SG ingress port, the `PORT` env var, and the health-check command — so this one value fixes all of them.

## How this was found

Bumping the prod log level to `:info` on a debug branch surfaced `Running DbserviceWeb.Endpoint ... at :::4000` plus healthy localhost `/api/health` 200s — proving the app was fine and the failure was purely the ALB→task network path. From there: IPv6 bind, then the ALB SG egress / port mismatch.

## Validation

Green staging run with both fixes applied (plus the already-merged #515/#516). Infra was torn down after.

## Follow-ups (not in this PR)

- `aws_lb_target_group` needs `name_prefix` + `create_before_destroy` so a future port change applies in-place instead of forcing a destroy/recreate (a port change on the existing TG fails on name conflict).
- DNS: `terraform/dns.tf` uses Route53 but the domain is on Cloudflare — a Cloudflare record to the ALB is still needed for real hostname access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)