### PR TITLE
fix(infra): manage DNS via Cloudflare provider instead of Route53

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -1,11 +1,11 @@
-resource "aws_route53_record" "this" {
-  zone_id = var.route53_zone_id
-  name    = "${var.domain_prefix}.avantifellows.org"
-  type    = "A"
-
-  alias {
-    name                   = data.aws_lb.shared.dns_name
-    zone_id                = data.aws_lb.shared.zone_id
-    evaluate_target_health = true
-  }
+# DNS for avantifellows.org is authoritative on Cloudflare (not Route53), so the
+# record must be created via the Cloudflare provider. A CNAME to the shared ALB's
+# stable DNS name survives ALB IP rotation.
+resource "cloudflare_record" "this" {
+  zone_id = var.cloudflare_zone_id
+  name    = var.domain_prefix
+  type    = "CNAME"
+  value   = data.aws_lb.shared.dns_name
+  proxied = var.dns_proxied
+  ttl     = 1 # 1 = "auto"; required when proxied, harmless when not
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
   }
 }
 
@@ -19,4 +23,8 @@ provider "aws" {
       ManagedBy   = "terraform"
     }
   }
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -184,10 +184,21 @@ variable "alb_https_listener_arn" {
   default     = "arn:aws:elasticloadbalancing:ap-south-1:111766607077:listener/app/af-load-balancer/8c412f577b269ab0/5b6cfc3f4677e5c4"
 }
 
-variable "route53_zone_id" {
-  description = "Hosted zone ID for avantifellows.org."
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID for avantifellows.org (zone overview in the Cloudflare dashboard)."
   type        = string
-  default     = "Z07416201O7H3W00UKZYD"
+}
+
+variable "cloudflare_api_token" {
+  description = "Cloudflare API token with DNS:Edit on the avantifellows.org zone. Set via TF_VAR_cloudflare_api_token at apply time; not needed by the deploy workflow."
+  type        = string
+  sensitive   = true
+}
+
+variable "dns_proxied" {
+  description = "Cloudflare proxy (orange cloud). true requires SSL/TLS mode Full (strict); false (DNS-only/grey) connects clients straight to the ALB. Set per env in envs/*.tfvars."
+  type        = bool
+  default     = false
 }
 
 ################################################################################


### PR DESCRIPTION
## Problem

`avantifellows.org` is authoritative on **Cloudflare**, but Phase 1's `terraform/dns.tf` created an **`aws_route53_record`** — which has no effect on public DNS. Result: even when the ECS service is healthy, it's unreachable by hostname (`staging-database.avantifellows.org` → NXDOMAIN). The only ways to reach it today are an `/etc/hosts` override or `curl --resolve`.

## Fix

Manage the record with the **Cloudflare provider** instead:

- **`main.tf`** — add `cloudflare/cloudflare ~> 4.0` to `required_providers` + a `provider "cloudflare"` block (`api_token = var.cloudflare_api_token`).
- **`dns.tf`** — replace `aws_route53_record` with a `cloudflare_record` CNAME pointing at the shared ALB's stable DNS name (`data.aws_lb.shared.dns_name`), so it survives ALB IP rotation.
- **`variables.tf`** — add `cloudflare_zone_id`, `cloudflare_api_token` (sensitive), and `dns_proxied` (default `false`); remove the now-unused `route53_zone_id`.

```hcl
resource "cloudflare_record" "this" {
  zone_id = var.cloudflare_zone_id
  name    = var.domain_prefix
  type    = "CNAME"
  value   = data.aws_lb.shared.dns_name
  proxied = var.dns_proxied
  ttl     = 1
}
```

## What you need to supply at apply time

1. **`TF_VAR_cloudflare_api_token`** — a Cloudflare API token with **DNS:Edit** on the `avantifellows.org` zone.
2. **`cloudflare_zone_id`** — the zone ID (Cloudflare dashboard → zone overview), set in `envs/*.tfvars` or via `TF_VAR_cloudflare_zone_id`.

This is an **infra-layer** concern (`terraform apply`), not the per-deploy CD workflow — the token is **not** needed as a GitHub Actions secret for `staging_deploy_ecs`.

## Proxy choice (`dns_proxied`)

- `false` (default, grey cloud): clients connect directly to the ALB; the ALB's `*.avantifellows.org` cert is valid and the Host header matches the listener rule. Simplest; recommended to validate first.
- `true` (orange cloud): Cloudflare proxies; requires the zone's SSL/TLS mode = **Full (strict)**. Set per env in `envs/*.tfvars` once validated. (The existing `staging-db` is proxied, so prod may want this for consistency.)

## Notes

- Pinned to provider **v4** (`cloudflare_record` uses `value`). On v5+ the attribute is `content`.
- `terraform validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)