### PR TITLE
fix(infra): target group name_prefix so replacements (port changes) apply cleanly

### DIFF
--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -1,5 +1,9 @@
 resource "aws_lb_target_group" "this" {
-  name        = "db-service-${var.environment}-tg"
+  # name_prefix (not name) so create_before_destroy below actually works — a
+  # fixed name collides with the still-existing old TG when a change forces
+  # replacement (e.g. a port change). AWS caps target-group name_prefix at 6
+  # chars; the Environment tag distinguishes staging/prod.
+  name_prefix = "dbsvc-"
   port        = var.app_port
   protocol    = "HTTP"
   target_type = "ip"


### PR DESCRIPTION
## Problem

`aws_lb_target_group.this` already has `lifecycle { create_before_destroy = true }`, but it uses a **fixed `name`** (`db-service-<env>-tg`). So when a change forces replacement — which a **port change does** (we hit this going 4000 → 8080) — Terraform tries to create the new target group *before* destroying the old one (per create_before_destroy), with the **same name**, and AWS rejects it:

```
Error: creating ELBv2 Target Group: TargetGroupName 'db-service-staging-tg' already exists
```

That's why the 8080 change couldn't apply in place and needed a full destroy/recreate.

## Fix

Use `name_prefix` instead of `name`, so the replacement TG gets a unique generated name and `create_before_destroy` actually works:

```diff
-  name        = "db-service-${var.environment}-tg"
+  name_prefix = "dbsvc-"
```

AWS caps target-group `name_prefix` at **6 characters**, hence `dbsvc-`. The `Environment` default tag still distinguishes staging vs prod (and they're separate Terraform states anyway).

## Effect

- Future port (or other replacement-forcing) changes apply in-place: TF creates the new TG, repoints the listener rule + ECS service to it, then drops the old one — no manual destroy/recreate.
- Generated names look like `dbsvc-20260530…` instead of `db-service-staging-tg`.

## Note

Applying this to an existing stack replaces the target group once (the name changes). Since staging is currently torn down, the next `terraform apply` just creates it fresh — no disruption. `terraform validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)