### PR TITLE
fix(prod): set ssl_opts verify_none so RDS connections succeed

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -7,6 +7,12 @@ if config_env() == :prod do
   config :dbservice, Dbservice.Repo,
     url: env!("DATABASE_URL", :string!),
     ssl: true,
+    # Postgrex 0.18+ made `ssl: true` verify the server cert against the OS CA
+    # store by default. The RDS cert chains to the Amazon RDS root CA, which
+    # isn't in the default bundle, so verification fails with "Unknown CA" and
+    # migrations/connections can't be established. We keep the connection
+    # encrypted but skip CA verification to restore the pre-0.18 behaviour.
+    ssl_opts: [verify: :verify_none],
     pool_size: env!("POOL_SIZE", :integer, 10)
 
   secret_key_base = env!("SECRET_KEY_BASE", :string!)


### PR DESCRIPTION
## What

Adds `ssl_opts: [verify: :verify_none]` to the prod `Dbservice.Repo` config in `config/runtime.exs`.

## Why

Postgrex 0.18+ (we pin 0.22 in `mix.lock`) changed `ssl: true` to verify the server certificate against the OS CA store by default. Our RDS cert chains to the Amazon RDS root CA, which isn't in the default bundle, so connections failed with `Fatal - Unknown CA`. On `release` this broke the prod EC2 deploy's `mix ecto.migrate` and took the app down with a sitewide 502.

This was already applied to `release` (which restored prod). This PR brings the same fix to `main` so the ECS/Fargate path and any future `release` rebuild from `main` stay consistent.

## Safety

Scoped to the `config_env() == :prod` Repo block. It only *relaxes* cert verification — the connection stays encrypted. It cannot break a connection that currently works; it can only allow ones that strict CA verification was rejecting. Staging already connects fine, so this is a no-op there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)