### PR TITLE
Academic Mentorship: mentor-mentee mapping CRUD endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ config/service_account.json
 docs/ai
 
 .DS_Store
+
+.tool-versions

--- a/lib/dbservice/academic_mentorship_mappings.ex
+++ b/lib/dbservice/academic_mentorship_mappings.ex
@@ -1,0 +1,121 @@
+defmodule Dbservice.AcademicMentorshipMappings do
+  @moduledoc """
+  The AcademicMentorshipMappings context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Dbservice.Repo
+
+  alias Dbservice.AcademicMentorshipMappings.AcademicMentorshipMapping
+
+  def get_mapping!(id), do: Repo.get!(AcademicMentorshipMapping, id)
+
+  def get_mapping(id), do: Repo.get(AcademicMentorshipMapping, id)
+
+  def list_active_mappings(mentor_ids, academic_year) do
+    query =
+      from m in AcademicMentorshipMapping,
+        where: is_nil(m.deleted_at),
+        order_by: [asc: m.mentor_id, asc: m.id]
+
+    query =
+      if mentor_ids != [] do
+        from m in query, where: m.mentor_id in ^mentor_ids
+      else
+        query
+      end
+
+    query =
+      if academic_year do
+        from m in query, where: m.academic_year == ^academic_year
+      else
+        query
+      end
+
+    Repo.all(query)
+  end
+
+  def create_mapping(attrs \\ %{}) do
+    %AcademicMentorshipMapping{}
+    |> AcademicMentorshipMapping.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def create_mappings_batch(mappings_attrs) when is_list(mappings_attrs) do
+    Repo.transaction(fn ->
+      Enum.reduce_while(mappings_attrs, [], fn attrs, acc ->
+        case create_mapping(attrs) do
+          {:ok, mapping} ->
+            {:cont, [mapping | acc]}
+
+          {:error, changeset} ->
+            Repo.rollback({:validation_error, changeset, length(acc)})
+        end
+      end)
+      |> Enum.reverse()
+    end)
+  end
+
+  def soft_delete_mapping(id, updated_by) do
+    case get_mapping(id) do
+      nil ->
+        {:error, :not_found}
+
+      %AcademicMentorshipMapping{deleted_at: deleted_at} when not is_nil(deleted_at) ->
+        {:error, :already_deleted}
+
+      mapping ->
+        mapping
+        |> AcademicMentorshipMapping.soft_delete_changeset(%{
+          deleted_at: DateTime.utc_now() |> DateTime.truncate(:second),
+          updated_by: updated_by
+        })
+        |> Repo.update()
+    end
+  end
+
+  def reassign_mapping(old_mapping_id, new_mentor_id, updated_by) do
+    Repo.transaction(fn ->
+      case get_mapping(old_mapping_id) do
+        nil ->
+          Repo.rollback(:not_found)
+
+        %AcademicMentorshipMapping{deleted_at: deleted_at} when not is_nil(deleted_at) ->
+          Repo.rollback(:already_deleted)
+
+        old_mapping ->
+          now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+          case old_mapping
+               |> AcademicMentorshipMapping.soft_delete_changeset(%{
+                 deleted_at: now,
+                 updated_by: updated_by
+               })
+               |> Repo.update() do
+            {:ok, _} ->
+              new_attrs = %{
+                "mentor_id" => new_mentor_id,
+                "mentee_id" => old_mapping.mentee_id,
+                "academic_year" => old_mapping.academic_year,
+                "created_by" => old_mapping.created_by
+              }
+
+              case %AcademicMentorshipMapping{}
+                   |> AcademicMentorshipMapping.changeset(new_attrs)
+                   |> Repo.insert() do
+                {:ok, new_mapping} -> new_mapping
+                {:error, changeset} -> Repo.rollback({:insert_error, changeset})
+              end
+
+            {:error, changeset} ->
+              Repo.rollback({:update_error, changeset})
+          end
+      end
+    end)
+  end
+
+  def has_any_mappings_for_mentor?(mentor_id) do
+    from(m in AcademicMentorshipMapping, where: m.mentor_id == ^mentor_id, limit: 1)
+    |> Repo.exists?()
+  end
+end

--- a/lib/dbservice/academic_mentorship_mappings/academic_mentorship_mapping.ex
+++ b/lib/dbservice/academic_mentorship_mappings/academic_mentorship_mapping.ex
@@ -1,0 +1,67 @@
+defmodule Dbservice.AcademicMentorshipMappings.AcademicMentorshipMapping do
+  @moduledoc false
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "academic_mentorship_mentor_mentee_mapping" do
+    field :academic_year, :string
+    field :created_by, :string
+    field :updated_by, :string
+    field :deleted_at, :utc_datetime
+    field :mentor_id, :integer
+    field :mentee_id, :integer
+
+    timestamps()
+  end
+
+  @required_fields [:mentor_id, :mentee_id, :academic_year, :created_by]
+  @optional_fields [:updated_by, :deleted_at]
+
+  @doc false
+  def changeset(mapping, attrs) do
+    mapping
+    |> cast(attrs, @required_fields ++ @optional_fields)
+    |> validate_required(@required_fields)
+    |> validate_format(:academic_year, ~r/^\d{4}-\d{4}$/)
+    |> validate_academic_year_consecutive()
+    |> foreign_key_constraint(:mentor_id)
+    |> foreign_key_constraint(:mentee_id)
+    |> unique_constraint([:mentee_id, :academic_year],
+      name: :active_mentee_academic_year_unique,
+      message: "mentee already has an active mentor for this academic year"
+    )
+  end
+
+  @doc false
+  def soft_delete_changeset(mapping, attrs) do
+    mapping
+    |> cast(attrs, [:deleted_at, :updated_by])
+    |> validate_required([:deleted_at])
+  end
+
+  defp validate_academic_year_consecutive(changeset) do
+    case get_change(changeset, :academic_year) do
+      nil ->
+        changeset
+
+      year_str ->
+        case String.split(year_str, "-") do
+          [start_str, end_str] ->
+            with {start_year, ""} <- Integer.parse(start_str),
+                 {end_year, ""} <- Integer.parse(end_str) do
+              if end_year == start_year + 1 do
+                changeset
+              else
+                add_error(changeset, :academic_year, "end year must be start year + 1")
+              end
+            else
+              _ -> add_error(changeset, :academic_year, "invalid year format")
+            end
+
+          _ ->
+            changeset
+        end
+    end
+  end
+end

--- a/lib/dbservice_web/controllers/academic_mentorship_mapping_controller.ex
+++ b/lib/dbservice_web/controllers/academic_mentorship_mapping_controller.ex
@@ -1,0 +1,246 @@
+defmodule DbserviceWeb.AcademicMentorshipMappingController do
+  use DbserviceWeb, :controller
+
+  alias Dbservice.AcademicMentorshipMappings
+  alias Dbservice.AcademicMentorshipMappings.AcademicMentorshipMapping
+
+  action_fallback(DbserviceWeb.FallbackController)
+
+  use PhoenixSwagger
+
+  alias DbserviceWeb.SwaggerSchema.AcademicMentorshipMapping,
+    as: SwaggerSchemaAcademicMentorshipMapping
+
+  def swagger_definitions do
+    Map.merge(
+      SwaggerSchemaAcademicMentorshipMapping.academic_mentorship_mapping(),
+      SwaggerSchemaAcademicMentorshipMapping.academic_mentorship_mappings()
+    )
+  end
+
+  swagger_path :index do
+    get("/api/academic-mentorship-mapping")
+
+    parameters do
+      mentor_ids(:query, :string, "Comma-separated mentor IDs", required: false)
+      academic_year(:query, :string, "Academic year filter (e.g. 2025-2026)", required: false)
+    end
+
+    response(200, "OK", Schema.ref(:AcademicMentorshipMappings))
+  end
+
+  def index(conn, params) do
+    mentor_ids =
+      case params["mentor_ids"] do
+        nil ->
+          []
+
+        ids_str ->
+          ids_str
+          |> String.split(",")
+          |> Enum.map(&String.trim/1)
+          |> Enum.filter(&(&1 != ""))
+          |> Enum.map(&String.to_integer/1)
+      end
+
+    academic_year = params["academic_year"]
+    mappings = AcademicMentorshipMappings.list_active_mappings(mentor_ids, academic_year)
+    render(conn, :index, mappings: mappings)
+  end
+
+  swagger_path :show do
+    get("/api/academic-mentorship-mapping/{id}")
+
+    parameters do
+      id(:path, :integer, "The mapping ID", required: true)
+    end
+
+    response(200, "OK", Schema.ref(:AcademicMentorshipMapping))
+  end
+
+  def show(conn, %{"id" => id}) do
+    mapping = AcademicMentorshipMappings.get_mapping!(id)
+    render(conn, :show, mapping: mapping)
+  end
+
+  swagger_path :create do
+    post("/api/academic-mentorship-mapping")
+
+    parameters do
+      body(:body, Schema.ref(:AcademicMentorshipMapping), "Mapping to create", required: true)
+    end
+
+    response(201, "Created", Schema.ref(:AcademicMentorshipMapping))
+  end
+
+  def create(conn, params) do
+    with {:ok, %AcademicMentorshipMapping{} = mapping} <-
+           AcademicMentorshipMappings.create_mapping(params) do
+      conn
+      |> put_status(:created)
+      |> render(:show, mapping: mapping)
+    else
+      {:error, %Ecto.Changeset{} = changeset} ->
+        if has_unique_constraint_error?(changeset) do
+          conn
+          |> put_status(:conflict)
+          |> json(%{error: "Mentee already has an active mentor for this academic year"})
+        else
+          {:error, changeset}
+        end
+    end
+  end
+
+  swagger_path :batch_create do
+    post("/api/academic-mentorship-mapping/batch")
+    description("Create multiple mappings in a single transaction")
+
+    parameters do
+      body(:body, :object, "Batch of mappings to create", required: true)
+    end
+
+    response(201, "Created")
+  end
+
+  def batch_create(conn, %{"mappings" => mappings_attrs}) when is_list(mappings_attrs) do
+    case AcademicMentorshipMappings.create_mappings_batch(mappings_attrs) do
+      {:ok, mappings} ->
+        conn
+        |> put_status(:created)
+        |> json(%{
+          created: length(mappings),
+          mappings: Enum.map(mappings, &render_mapping/1)
+        })
+
+      {:error, {:validation_error, changeset, index}} ->
+        conn
+        |> put_status(:conflict)
+        |> json(%{
+          error: "Batch insert failed",
+          failed_index: index,
+          details: format_changeset_errors(changeset)
+        })
+
+      {:error, _} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: "Batch insert failed"})
+    end
+  end
+
+  def batch_create(conn, _params) do
+    conn
+    |> put_status(:bad_request)
+    |> json(%{error: "Missing required 'mappings' array"})
+  end
+
+  swagger_path :reassign do
+    post("/api/academic-mentorship-mapping/reassign")
+    description("Atomically reassign a mentee to a different mentor")
+
+    parameters do
+      body(:body, :object, "Reassignment details", required: true)
+    end
+
+    response(200, "OK", Schema.ref(:AcademicMentorshipMapping))
+  end
+
+  def reassign(conn, %{
+        "old_mapping_id" => old_mapping_id,
+        "new_mentor_id" => new_mentor_id,
+        "updated_by" => updated_by
+      }) do
+    case AcademicMentorshipMappings.reassign_mapping(old_mapping_id, new_mentor_id, updated_by) do
+      {:ok, new_mapping} ->
+        conn
+        |> put_status(:ok)
+        |> render(:show, mapping: new_mapping)
+
+      {:error, :not_found} ->
+        conn |> put_status(:not_found) |> json(%{error: "Mapping not found"})
+
+      {:error, :already_deleted} ->
+        conn |> put_status(:not_found) |> json(%{error: "Mapping already soft-deleted"})
+
+      {:error, {:insert_error, changeset}} ->
+        if has_unique_constraint_error?(changeset) do
+          conn
+          |> put_status(:conflict)
+          |> json(%{error: "Mentee already has an active mentor for this academic year"})
+        else
+          {:error, changeset}
+        end
+
+      {:error, _} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: "Reassignment failed"})
+    end
+  end
+
+  def reassign(conn, _params) do
+    conn
+    |> put_status(:bad_request)
+    |> json(%{error: "Missing required fields: old_mapping_id, new_mentor_id, updated_by"})
+  end
+
+  swagger_path :soft_delete do
+    PhoenixSwagger.Path.delete("/api/academic-mentorship-mapping/{id}")
+    description("Soft-delete a mapping (sets deleted_at)")
+
+    parameters do
+      id(:path, :integer, "The mapping ID", required: true)
+      body(:body, :object, "Must include updated_by", required: true)
+    end
+
+    response(200, "OK", Schema.ref(:AcademicMentorshipMapping))
+  end
+
+  def soft_delete(conn, %{"id" => id} = params) do
+    updated_by = params["updated_by"]
+
+    case AcademicMentorshipMappings.soft_delete_mapping(id, updated_by) do
+      {:ok, mapping} ->
+        conn
+        |> put_status(:ok)
+        |> render(:show, mapping: mapping)
+
+      {:error, :not_found} ->
+        conn |> put_status(:not_found) |> json(%{error: "Mapping not found"})
+
+      {:error, :already_deleted} ->
+        conn |> put_status(:not_found) |> json(%{error: "Mapping already deleted"})
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  defp has_unique_constraint_error?(%Ecto.Changeset{errors: errors}) do
+    Enum.any?(errors, fn
+      {_field, {_msg, opts}} when is_list(opts) ->
+        Keyword.get(opts, :constraint) == :unique
+
+      _ ->
+        false
+    end)
+  end
+
+  defp render_mapping(%AcademicMentorshipMapping{} = mapping) do
+    %{
+      id: mapping.id,
+      mentor_id: mapping.mentor_id,
+      mentee_id: mapping.mentee_id,
+      academic_year: mapping.academic_year,
+      created_by: mapping.created_by,
+      updated_by: mapping.updated_by,
+      deleted_at: mapping.deleted_at,
+      inserted_at: mapping.inserted_at,
+      updated_at: mapping.updated_at
+    }
+  end
+
+  defp format_changeset_errors(%Ecto.Changeset{errors: errors}) do
+    Enum.map(errors, fn {field, {msg, _opts}} -> "#{field}: #{msg}" end)
+  end
+end

--- a/lib/dbservice_web/json/academic_mentorship_mapping_json.ex
+++ b/lib/dbservice_web/json/academic_mentorship_mapping_json.ex
@@ -1,0 +1,23 @@
+defmodule DbserviceWeb.AcademicMentorshipMappingJSON do
+  def index(%{mappings: mappings}) do
+    %{mappings: for(m <- mappings, do: render(m))}
+  end
+
+  def show(%{mapping: mapping}) do
+    %{mapping: render(mapping)}
+  end
+
+  defp render(mapping) do
+    %{
+      id: mapping.id,
+      mentor_id: mapping.mentor_id,
+      mentee_id: mapping.mentee_id,
+      academic_year: mapping.academic_year,
+      created_by: mapping.created_by,
+      updated_by: mapping.updated_by,
+      deleted_at: mapping.deleted_at,
+      inserted_at: mapping.inserted_at,
+      updated_at: mapping.updated_at
+    }
+  end
+end

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -151,6 +151,19 @@ defmodule DbserviceWeb.Router do
 
     resources("/cms-status", CmsStatusController, except: [:new, :edit])
 
+    get("/academic-mentorship-mapping", AcademicMentorshipMappingController, :index)
+    get("/academic-mentorship-mapping/:id", AcademicMentorshipMappingController, :show)
+    post("/academic-mentorship-mapping", AcademicMentorshipMappingController, :create)
+    post("/academic-mentorship-mapping/batch", AcademicMentorshipMappingController, :batch_create)
+
+    post(
+      "/academic-mentorship-mapping/reassign",
+      AcademicMentorshipMappingController,
+      :reassign
+    )
+
+    delete("/academic-mentorship-mapping/:id", AcademicMentorshipMappingController, :soft_delete)
+
     def swagger_info do
       source(["config/.env"])
 

--- a/lib/dbservice_web/swagger_schemas/academic_mentorship_mapping.ex
+++ b/lib/dbservice_web/swagger_schemas/academic_mentorship_mapping.ex
@@ -1,0 +1,53 @@
+defmodule DbserviceWeb.SwaggerSchema.AcademicMentorshipMapping do
+  @moduledoc false
+
+  use PhoenixSwagger
+
+  def academic_mentorship_mapping do
+    %{
+      AcademicMentorshipMapping:
+        swagger_schema do
+          title("AcademicMentorshipMapping")
+          description("A mentor-mentee mapping for academic mentorship")
+
+          properties do
+            id(:integer, "Mapping ID")
+            mentor_id(:integer, "The user_permission ID of the mentor")
+            mentee_id(:integer, "The user ID of the mentee")
+            academic_year(:string, "Academic year (e.g. 2025-2026)")
+            created_by(:string, "Email of the user who created this mapping")
+            updated_by(:string, "Email of the user who last modified this mapping")
+            deleted_at(:string, "Soft-delete timestamp (null if active)")
+            inserted_at(:string, "Creation timestamp")
+            updated_at(:string, "Last update timestamp")
+          end
+
+          example(%{
+            id: 1,
+            mentor_id: 42,
+            mentee_id: 100,
+            academic_year: "2025-2026",
+            created_by: "admin@example.com",
+            updated_by: nil,
+            deleted_at: nil,
+            inserted_at: "2025-06-01T12:00:00",
+            updated_at: "2025-06-01T12:00:00"
+          })
+        end
+    }
+  end
+
+  def academic_mentorship_mappings do
+    %{
+      AcademicMentorshipMappings:
+        swagger_schema do
+          title("AcademicMentorshipMappings")
+          description("List of academic mentorship mappings")
+
+          properties do
+            mappings(Schema.array(:AcademicMentorshipMapping), "List of mappings")
+          end
+        end
+    }
+  end
+end

--- a/priv/repo/migrations/20260601120000_create_academic_mentorship_mapping.exs
+++ b/priv/repo/migrations/20260601120000_create_academic_mentorship_mapping.exs
@@ -1,0 +1,26 @@
+defmodule Dbservice.Repo.Migrations.CreateAcademicMentorshipMapping do
+  use Ecto.Migration
+
+  def change do
+    create table(:academic_mentorship_mentor_mentee_mapping) do
+      add :mentor_id, references(:user_permission, on_delete: :nothing), null: false
+      add :mentee_id, references(:user, on_delete: :nothing), null: false
+      add :academic_year, :string, null: false
+      add :created_by, :string, null: false
+      add :updated_by, :string
+      add :deleted_at, :utc_datetime
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create index(:academic_mentorship_mentor_mentee_mapping, [:mentor_id])
+    create index(:academic_mentorship_mentor_mentee_mapping, [:academic_year])
+
+    create unique_index(
+             :academic_mentorship_mentor_mentee_mapping,
+             [:mentee_id, :academic_year],
+             where: "deleted_at IS NULL",
+             name: :active_mentee_academic_year_unique
+           )
+  end
+end

--- a/test/dbservice_web/controllers/academic_mentorship_mapping_controller_test.exs
+++ b/test/dbservice_web/controllers/academic_mentorship_mapping_controller_test.exs
@@ -1,0 +1,215 @@
+defmodule DbserviceWeb.AcademicMentorshipMappingControllerTest do
+  use DbserviceWeb.ConnCase
+
+  import Dbservice.AcademicMentorshipMappingFixtures
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index" do
+    test "lists active mappings", %{conn: conn} do
+      mapping = mapping_fixture()
+
+      conn =
+        get(
+          conn,
+          ~p"/api/academic-mentorship-mapping?mentor_ids=#{mapping.mentor_id}&academic_year=2025-2026"
+        )
+
+      resp = json_response(conn, 200)
+      assert length(resp["mappings"]) == 1
+      assert hd(resp["mappings"])["id"] == mapping.id
+    end
+
+    test "returns empty list when no mappings match", %{conn: conn} do
+      conn =
+        get(conn, ~p"/api/academic-mentorship-mapping?mentor_ids=99999&academic_year=2025-2026")
+
+      assert %{"mappings" => []} = json_response(conn, 200)
+    end
+
+    test "excludes soft-deleted mappings", %{conn: conn} do
+      mapping = mapping_fixture()
+
+      Dbservice.AcademicMentorshipMappings.soft_delete_mapping(
+        mapping.id,
+        "admin@example.com"
+      )
+
+      conn =
+        get(
+          conn,
+          ~p"/api/academic-mentorship-mapping?mentor_ids=#{mapping.mentor_id}&academic_year=2025-2026"
+        )
+
+      assert %{"mappings" => []} = json_response(conn, 200)
+    end
+  end
+
+  describe "show" do
+    test "returns mapping by id", %{conn: conn} do
+      mapping = mapping_fixture()
+      conn = get(conn, ~p"/api/academic-mentorship-mapping/#{mapping.id}")
+      resp = json_response(conn, 200)
+      assert resp["mapping"]["id"] == mapping.id
+      assert resp["mapping"]["academic_year"] == "2025-2026"
+    end
+
+    test "returns 404 for non-existent mapping", %{conn: conn} do
+      assert_error_sent 404, fn ->
+        get(conn, ~p"/api/academic-mentorship-mapping/999999")
+      end
+    end
+  end
+
+  describe "create" do
+    test "creates mapping with valid data", %{conn: conn} do
+      user = Dbservice.UsersFixtures.user_fixture()
+      permission = user_permission_fixture()
+
+      attrs = %{
+        mentor_id: permission.id,
+        mentee_id: user.id,
+        academic_year: "2025-2026",
+        created_by: "admin@example.com"
+      }
+
+      conn = post(conn, ~p"/api/academic-mentorship-mapping", attrs)
+      resp = json_response(conn, 201)
+      assert resp["mapping"]["mentor_id"] == permission.id
+      assert resp["mapping"]["mentee_id"] == user.id
+      assert resp["mapping"]["academic_year"] == "2025-2026"
+    end
+
+    test "returns 409 on duplicate active mapping", %{conn: conn} do
+      mapping = mapping_fixture()
+
+      attrs = %{
+        mentor_id: mapping.mentor_id,
+        mentee_id: mapping.mentee_id,
+        academic_year: mapping.academic_year,
+        created_by: "admin@example.com"
+      }
+
+      conn = post(conn, ~p"/api/academic-mentorship-mapping", attrs)
+      assert json_response(conn, 409)["error"] =~ "already has an active mentor"
+    end
+
+    test "returns 422 with invalid data", %{conn: conn} do
+      conn = post(conn, ~p"/api/academic-mentorship-mapping", %{mentor_id: nil})
+      assert json_response(conn, 422)
+    end
+  end
+
+  describe "batch_create" do
+    test "creates multiple mappings in one transaction", %{conn: conn} do
+      user1 = Dbservice.UsersFixtures.user_fixture()
+      user2 = Dbservice.UsersFixtures.user_fixture()
+      permission = user_permission_fixture()
+
+      attrs = %{
+        mappings: [
+          %{
+            mentor_id: permission.id,
+            mentee_id: user1.id,
+            academic_year: "2025-2026",
+            created_by: "admin@example.com"
+          },
+          %{
+            mentor_id: permission.id,
+            mentee_id: user2.id,
+            academic_year: "2025-2026",
+            created_by: "admin@example.com"
+          }
+        ]
+      }
+
+      conn = post(conn, ~p"/api/academic-mentorship-mapping/batch", attrs)
+      resp = json_response(conn, 201)
+      assert resp["created"] == 2
+      assert length(resp["mappings"]) == 2
+    end
+
+    test "returns 400 when mappings array missing", %{conn: conn} do
+      conn = post(conn, ~p"/api/academic-mentorship-mapping/batch", %{})
+      assert json_response(conn, 400)["error"] =~ "Missing required"
+    end
+  end
+
+  describe "reassign" do
+    test "atomically reassigns a mentee to a new mentor", %{conn: conn} do
+      mapping = mapping_fixture()
+      new_permission = user_permission_fixture()
+
+      attrs = %{
+        old_mapping_id: mapping.id,
+        new_mentor_id: new_permission.id,
+        updated_by: "admin@example.com"
+      }
+
+      conn = post(conn, ~p"/api/academic-mentorship-mapping/reassign", attrs)
+      resp = json_response(conn, 200)
+      assert resp["mapping"]["mentor_id"] == new_permission.id
+      assert resp["mapping"]["mentee_id"] == mapping.mentee_id
+    end
+
+    test "returns 404 for non-existent mapping", %{conn: conn} do
+      new_permission = user_permission_fixture()
+
+      attrs = %{
+        old_mapping_id: 999_999,
+        new_mentor_id: new_permission.id,
+        updated_by: "admin@example.com"
+      }
+
+      conn = post(conn, ~p"/api/academic-mentorship-mapping/reassign", attrs)
+      assert json_response(conn, 404)["error"] =~ "not found"
+    end
+
+    test "returns 400 when required fields missing", %{conn: conn} do
+      conn = post(conn, ~p"/api/academic-mentorship-mapping/reassign", %{})
+      assert json_response(conn, 400)["error"] =~ "Missing required"
+    end
+  end
+
+  describe "soft_delete" do
+    test "soft-deletes a mapping", %{conn: conn} do
+      mapping = mapping_fixture()
+
+      conn =
+        delete(conn, ~p"/api/academic-mentorship-mapping/#{mapping.id}", %{
+          updated_by: "admin@example.com"
+        })
+
+      resp = json_response(conn, 200)
+      assert resp["mapping"]["id"] == mapping.id
+      assert resp["mapping"]["deleted_at"] != nil
+    end
+
+    test "returns 404 for already-deleted mapping", %{conn: conn} do
+      mapping = mapping_fixture()
+
+      Dbservice.AcademicMentorshipMappings.soft_delete_mapping(
+        mapping.id,
+        "admin@example.com"
+      )
+
+      conn =
+        delete(conn, ~p"/api/academic-mentorship-mapping/#{mapping.id}", %{
+          updated_by: "admin@example.com"
+        })
+
+      assert json_response(conn, 404)["error"] =~ "already deleted"
+    end
+
+    test "returns 404 for non-existent mapping", %{conn: conn} do
+      conn =
+        delete(conn, ~p"/api/academic-mentorship-mapping/999999", %{
+          updated_by: "admin@example.com"
+        })
+
+      assert json_response(conn, 404)["error"] =~ "not found"
+    end
+  end
+end

--- a/test/support/fixtures/academic_mentorship_mapping_fixtures.ex
+++ b/test/support/fixtures/academic_mentorship_mapping_fixtures.ex
@@ -1,0 +1,51 @@
+defmodule Dbservice.AcademicMentorshipMappingFixtures do
+  @moduledoc """
+  Test helpers for creating academic mentorship mapping entities.
+  """
+
+  alias Dbservice.Repo
+
+  def user_permission_fixture(attrs \\ %{}) do
+    defaults = %{
+      email: "teacher-#{System.unique_integer([:positive])}@example.com",
+      level: 1,
+      school_codes: ["SCH001"],
+      regions: [],
+      read_only: false,
+      role: "teacher"
+    }
+
+    merged = Map.merge(defaults, Map.new(attrs))
+
+    {1, [permission]} =
+      Repo.insert_all(
+        "user_permission",
+        [
+          Map.merge(merged, %{
+            inserted_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
+            updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+          })
+        ],
+        returning: [:id, :email]
+      )
+
+    permission
+  end
+
+  def mapping_fixture(attrs \\ %{}) do
+    user = Dbservice.UsersFixtures.user_fixture()
+    permission = user_permission_fixture()
+
+    {:ok, mapping} =
+      attrs
+      |> Enum.into(%{
+        mentor_id: permission.id,
+        mentee_id: user.id,
+        academic_year: "2025-2026",
+        created_by: "admin@example.com"
+      })
+      |> Dbservice.AcademicMentorshipMappings.create_mapping()
+
+    mapping
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `academic_mentorship_mentor_mentee_mapping` table with migration, Ecto schema, context module, Phoenix controller, JSON serializer, Swagger docs, and full test suite
- Implements 6 REST endpoints for mentor-mentee mapping management used by the LMS Academic Mentorship feature
- All endpoints use Bearer token auth (same `DB_SERVICE_TOKEN` pattern as existing endpoints)

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/academic-mentorship-mapping` | List active mappings (filter by `mentor_ids`, `academic_year`) |
| GET | `/api/academic-mentorship-mapping/:id` | Get single mapping by ID |
| POST | `/api/academic-mentorship-mapping` | Create single mapping |
| POST | `/api/academic-mentorship-mapping/batch` | Bulk create (all-or-nothing transaction) |
| POST | `/api/academic-mentorship-mapping/reassign` | Atomic reassign (soft-delete old + create new) |
| DELETE | `/api/academic-mentorship-mapping/:id` | Soft delete (sets `deleted_at`) |

## Database Schema

Table `academic_mentorship_mentor_mentee_mapping`:
- `mentor_id` → FK to `user_permission.id` (ON DELETE NO ACTION)
- `mentee_id` → FK to `user.id` (ON DELETE NO ACTION)
- `academic_year` (e.g. "2025-2026"), `created_by`, `updated_by`, `deleted_at`
- Partial unique index: `UNIQUE(mentee_id, academic_year) WHERE deleted_at IS NULL`
- Indexes on `mentor_id` and `academic_year`

## Related

- **LMS Issue**: avantifellows/af_lms#50
- **LMS PR**: avantifellows/af_lms#69
- **PRD**: Full spec in `.ralph/workspaces/50/prd-draft.md` (sections §4-§5)

## Test plan

- [x] 16 controller tests pass (index, show, create, batch, reassign, soft_delete)
- [x] Tests cover: happy paths, 404s, 409 conflicts, soft-delete exclusion, batch validation
- [ ] Manual integration test with LMS after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)