### PR TITLE
fix(problems): sort fetch_problems results by code ascending

### DIFF
--- a/lib/dbservice_web/controllers/resource_controller.ex
+++ b/lib/dbservice_web/controllers/resource_controller.ex
@@ -1072,6 +1072,7 @@ defmodule DbserviceWeb.ResourceController do
       where: rc.curriculum_id == ^curriculum_id,
       where: l.code == ^lang_code,
       where: r.type == "problem",
+      order_by: [asc: r.code],
       select: %{
         resource: r,
         resource_topic: rt,


### PR DESCRIPTION
## Problem

The `/api/problems` endpoint (e.g. `?topic_id=619&curriculum_id=1&lang_code=en`) returned problems in **no specific order**. The underlying Ecto query in `ResourceController.problems_base_query/2` had no `order_by`, so PostgreSQL returned rows in arbitrary (effectively insertion/heap) order.

## Fix

Add `order_by: [asc: r.code]` to the shared `problems_base_query/2`. This sorts results by problem `code` ascending (e.g. `P0005020`, `P0005021`, `P0005022`, …). Because both `problems_query/3` and `paragraph_siblings_query/3` build on this base query, the default topic-problems response is now fully sorted by code.

## Testing

- `mix format` passes.
- Note: full `mix compile` is currently blocked locally by a pre-existing `mix.lock` mismatch unrelated to this change; CI will compile against the locked deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)