### PR TITLE
fix(infra): authenticate Cloudflare via Global API Key, not scoped token

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -14,7 +14,7 @@ terraform/
 ├── ecr.tf             # Container registry
 ├── ecs.tf             # Cluster, task definition, service, auto-scaling
 ├── alb.tf             # Target group + listener rule on existing ALB
-├── dns.tf             # Route53 A-alias to the ALB
+├── dns.tf             # Cloudflare CNAME to the ALB
 ├── security.tf        # Security group for tasks
 ├── iam.tf             # Execution role, task role, optional CI user
 ├── logs.tf            # CloudWatch Logs group
@@ -30,7 +30,7 @@ Every resource is created with an `{environment}` suffix (e.g. `db-service-stagi
 `db-service-prod`). The two environments share **nothing** at the AWS level except:
 
 - The existing shared ALB (`af-load-balancer`) — we add a listener rule, not a new ALB.
-- The Route53 zone (`avantifellows.org`) — we add a record, not a new zone.
+- The Cloudflare zone (`avantifellows.org`) — we add a record, not a new zone.
 - The wildcard ACM cert — already attached to the ALB.
 - The Terraform state bucket (`111766607077-dbservice-test-terraform-state`) — separate
   state files keyed by `dbservice/{env}/terraform.tfstate`.
@@ -78,7 +78,7 @@ Order doesn't matter between environments — no shared TF resources to gate on.
 The first apply in each environment creates an ECR repo and an ECS service that
 references `image_tag = "latest"`. Until the Phase 4 CI pipeline pushes the first
 image, ECS will retry pulls and the target group will report unhealthy. The ALB
-listener rule + Route53 record will exist and resolve, but `db.avantifellows.org`
+listener rule + Cloudflare record will exist and resolve, but `db.avantifellows.org`
 will return 503 until a real image lands. This is expected.
 
 Subsequent deploys are driven by the GitHub Actions workflow registering a new task

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,5 +26,9 @@ provider "aws" {
 }
 
 provider "cloudflare" {
-  api_token = var.cloudflare_api_token
+  # Authenticates with a legacy Global API Key (account-wide) rather than a
+  # scoped API token. email is the key owner; api_key is the sensitive value,
+  # supplied via TF_VAR_cloudflare_api_key at apply time.
+  email   = var.cloudflare_email
+  api_key = var.cloudflare_api_key
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -185,12 +185,19 @@ variable "alb_https_listener_arn" {
 }
 
 variable "cloudflare_zone_id" {
-  description = "Cloudflare zone ID for avantifellows.org (zone overview in the Cloudflare dashboard)."
+  description = "Cloudflare zone ID for avantifellows.org. Same zone for staging and prod, so it's defaulted here rather than set per-env."
   type        = string
+  default     = "7f1dbe8fd33ebb03cbde59464bbcc042"
 }
 
-variable "cloudflare_api_token" {
-  description = "Cloudflare API token with DNS:Edit on the avantifellows.org zone. Set via TF_VAR_cloudflare_api_token at apply time; not needed by the deploy workflow."
+variable "cloudflare_email" {
+  description = "Cloudflare account email that owns the Global API Key. Same for all envs, so defaulted here."
+  type        = string
+  default     = "deepansh.mathur@avantifellows.org"
+}
+
+variable "cloudflare_api_key" {
+  description = "Cloudflare Global API Key (legacy, account-wide) paired with cloudflare_email. Sensitive — supply via TF_VAR_cloudflare_api_key at apply time; not needed by the deploy workflow."
   type        = string
   sensitive   = true
 }


### PR DESCRIPTION
## What

Switch the `cloudflare` provider auth from a scoped **API token** (`api_token`) to the legacy **Global API Key** (`email` + `api_key`), per team decision (we'll use Deepansh's account key).

## Changes
- **`main.tf`** — provider block now uses `email` + `api_key`.
- **`variables.tf`** — replaced `cloudflare_api_token` with `cloudflare_api_key` (sensitive). Added `cloudflare_email`. Both `cloudflare_zone_id` and `cloudflare_email` are now **defaulted** (same zone/account for staging and prod), so neither `envs/*.tfvars` needs them.
- **`README.md`** — fixed 3 stale "Route53" references left over from #519 (DNS is on Cloudflare).

## How to apply
The Global API Key is sensitive and is **not** committed — supply it at apply time:
```
export TF_VAR_cloudflare_api_key="<deepansh global api key>"
```
Nothing else needed; zone ID and email come from defaults.

## Validation
- `terraform validate` ✅
- `terraform plan` (staging) authenticates with the global key and resolves the defaults cleanly — `cloudflare_record.this` planned, no errors.
- Verified end-to-end in the 2026-06-01 staging Phase-4 test (build → migrate → deploy → smoke check green) using this exact auth.

## ⚠️ Security note
A Global API Key is **account-wide / full-access**, unlike a scoped DNS:Edit token. This is an intentional tradeoff chosen by the team for operational simplicity. The key itself is never committed (env var only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)