### PR TITLE
feat(program): add config column for Gurukul UI configuration

### DIFF
--- a/lib/dbservice/programs/program.ex
+++ b/lib/dbservice/programs/program.ex
@@ -15,6 +15,7 @@ defmodule Dbservice.Programs.Program do
     field :state, :string
     field :model, :string
     field :is_current, :boolean, default: true
+    field :config, :map, default: %{}
 
     belongs_to :product, Product
     has_many :group, Group, foreign_key: :child_id, where: [type: "program"]
@@ -36,7 +37,8 @@ defmodule Dbservice.Programs.Program do
       :state,
       :product_id,
       :model,
-      :is_current
+      :is_current,
+      :config
     ])
     |> validate_required([:name])
   end

--- a/lib/dbservice/services/gurukul_config_service.ex
+++ b/lib/dbservice/services/gurukul_config_service.ex
@@ -1,0 +1,109 @@
+defmodule Dbservice.Services.GurukulConfigService do
+  @moduledoc """
+  Resolves Gurukul UI configuration by merging config along the fallback chain:
+
+      defaultgroup  <-  program  <-  batch       (later layers win)
+
+  Storage locations for each layer:
+    * defaultgroup: the `auth_group` named "defaultgroup", under
+      `input_schema["gurukul_config"]`
+    * program:      `program.config`
+    * batch:        `batch.metadata["gurukul_config"]`
+
+  When a user belongs to multiple current batches (or programs), the oldest
+  enrollment (earliest `start_date`) wins, per the agreed resolution rule:
+  the older batch is most likely the student's primary one.
+
+  Each resolve function returns `{config, resolved_from}` where `resolved_from`
+  records which layer the config was resolved from, for observability.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Dbservice.Batches.Batch
+  alias Dbservice.EnrollmentRecords.EnrollmentRecord
+  alias Dbservice.Groups.AuthGroup
+  alias Dbservice.Programs.Program
+  alias Dbservice.Repo
+
+  @default_group_name "defaultgroup"
+  @config_key "gurukul_config"
+
+  @doc """
+  Resolves the merged Gurukul config for a user via their oldest current
+  batch (falling back to their oldest current program, then defaultgroup).
+  """
+  def resolve_for_user(user_id) do
+    base = default_config()
+
+    case oldest_current_enrollment(user_id, "batch") do
+      %EnrollmentRecord{group_id: batch_id} ->
+        resolve_from_batch(batch_id, base)
+
+      nil ->
+        case oldest_current_enrollment(user_id, "program") do
+          %EnrollmentRecord{group_id: program_id} -> resolve_from_program(program_id, base)
+          nil -> {base, %{source: "defaultgroup", batch_id: nil, program_id: nil}}
+        end
+    end
+  end
+
+  @doc """
+  Resolves config for a batch directly: batch <- program <- defaultgroup.
+  """
+  def resolve_for_batch(batch_id), do: resolve_from_batch(batch_id, default_config())
+
+  @doc """
+  Resolves config for a program directly: program <- defaultgroup.
+  """
+  def resolve_for_program(program_id), do: resolve_from_program(program_id, default_config())
+
+  defp resolve_from_batch(batch_id, base) do
+    case Repo.get(Batch, batch_id) do
+      nil ->
+        {base, %{source: "defaultgroup", batch_id: nil, program_id: nil}}
+
+      %Batch{} = batch ->
+        program_config =
+          case batch.program_id && Repo.get(Program, batch.program_id) do
+            %Program{config: config} -> config || %{}
+            _ -> %{}
+          end
+
+        batch_config = Map.get(batch.metadata || %{}, @config_key, %{})
+
+        merged = base |> Map.merge(program_config) |> Map.merge(batch_config)
+        {merged, %{source: "batch", batch_id: batch.id, program_id: batch.program_id}}
+    end
+  end
+
+  defp resolve_from_program(program_id, base) do
+    case Repo.get(Program, program_id) do
+      nil ->
+        {base, %{source: "defaultgroup", batch_id: nil, program_id: nil}}
+
+      %Program{} = program ->
+        {Map.merge(base, program.config || %{}),
+         %{source: "program", batch_id: nil, program_id: program.id}}
+    end
+  end
+
+  defp oldest_current_enrollment(user_id, group_type) do
+    from(e in EnrollmentRecord,
+      where: e.user_id == ^user_id and e.group_type == ^group_type and e.is_current == true,
+      order_by: [asc_nulls_last: e.start_date, asc: e.inserted_at],
+      limit: 1
+    )
+    |> Repo.one()
+  end
+
+  defp default_config do
+    case Repo.get_by(AuthGroup, name: @default_group_name) do
+      %AuthGroup{input_schema: input_schema} when is_map(input_schema) ->
+        Map.get(input_schema, @config_key, %{})
+
+      _ ->
+        %{}
+    end
+  end
+end

--- a/lib/dbservice/services/gurukul_config_service.ex
+++ b/lib/dbservice/services/gurukul_config_service.ex
@@ -4,10 +4,11 @@ defmodule Dbservice.Services.GurukulConfigService do
 
       defaultgroup  <-  program  <-  batch       (later layers win)
 
-  Storage locations for each layer:
-    * defaultgroup: the `auth_group` named "defaultgroup", under
-      `input_schema["gurukul_config"]`
-    * program:      `program.config`
+  Each layer namespaces its Gurukul config under the `"gurukul_config"` key so
+  the same column can hold config for other modules (CMS, LMS, etc.) without
+  collision:
+    * defaultgroup: `auth_group.input_schema["gurukul_config"]`
+    * program:      `program.config["gurukul_config"]`
     * batch:        `batch.metadata["gurukul_config"]`
 
   When a user belongs to multiple current batches (or programs), the oldest
@@ -66,11 +67,11 @@ defmodule Dbservice.Services.GurukulConfigService do
       %Batch{} = batch ->
         program_config =
           case batch.program_id && Repo.get(Program, batch.program_id) do
-            %Program{config: config} -> config || %{}
+            %Program{config: config} -> gurukul_section(config)
             _ -> %{}
           end
 
-        batch_config = Map.get(batch.metadata || %{}, @config_key, %{})
+        batch_config = gurukul_section(batch.metadata)
 
         merged = base |> Map.merge(program_config) |> Map.merge(batch_config)
         {merged, %{source: "batch", batch_id: batch.id, program_id: batch.program_id}}
@@ -83,7 +84,7 @@ defmodule Dbservice.Services.GurukulConfigService do
         {base, %{source: "defaultgroup", batch_id: nil, program_id: nil}}
 
       %Program{} = program ->
-        {Map.merge(base, program.config || %{}),
+        {Map.merge(base, gurukul_section(program.config)),
          %{source: "program", batch_id: nil, program_id: program.id}}
     end
   end
@@ -99,11 +100,13 @@ defmodule Dbservice.Services.GurukulConfigService do
 
   defp default_config do
     case Repo.get_by(AuthGroup, name: @default_group_name) do
-      %AuthGroup{input_schema: input_schema} when is_map(input_schema) ->
-        Map.get(input_schema, @config_key, %{})
-
-      _ ->
-        %{}
+      %AuthGroup{input_schema: input_schema} -> gurukul_section(input_schema)
+      _ -> %{}
     end
   end
+
+  # Reads the namespaced Gurukul config out of a column map (program.config,
+  # batch.metadata, auth_group.input_schema), leaving other modules' keys alone.
+  defp gurukul_section(map) when is_map(map), do: Map.get(map, @config_key, %{})
+  defp gurukul_section(_), do: %{}
 end

--- a/lib/dbservice_web/controllers/gurukul_config_controller.ex
+++ b/lib/dbservice_web/controllers/gurukul_config_controller.ex
@@ -46,12 +46,16 @@ defmodule DbserviceWeb.GurukulConfigController do
   defp resolve(:batch, id), do: GurukulConfigService.resolve_for_batch(id)
   defp resolve(:program, id), do: GurukulConfigService.resolve_for_program(id)
 
+  @scope_params [{"user_id", :user}, {"batch_id", :batch}, {"program_id", :program}]
+
   defp pick_scope(params) do
-    cond do
-      present?(params["user_id"]) -> {:ok, :user, params["user_id"]}
-      present?(params["batch_id"]) -> {:ok, :batch, params["batch_id"]}
-      present?(params["program_id"]) -> {:ok, :program, params["program_id"]}
-      true -> {:error, "One of user_id, batch_id or program_id is required"}
+    # The three params are mutually-exclusive ways to resolve config for a
+    # single entity, not filters to combine. Reject ambiguous requests rather
+    # than silently honouring one and ignoring the rest.
+    case Enum.filter(@scope_params, fn {key, _scope} -> present?(params[key]) end) do
+      [{key, scope}] -> {:ok, scope, params[key]}
+      [] -> {:error, "One of user_id, batch_id or program_id is required"}
+      _ -> {:error, "Provide only one of user_id, batch_id or program_id"}
     end
   end
 

--- a/lib/dbservice_web/controllers/gurukul_config_controller.ex
+++ b/lib/dbservice_web/controllers/gurukul_config_controller.ex
@@ -1,0 +1,68 @@
+defmodule DbserviceWeb.GurukulConfigController do
+  use DbserviceWeb, :controller
+
+  alias Dbservice.Services.GurukulConfigService
+
+  action_fallback(DbserviceWeb.FallbackController)
+
+  use PhoenixSwagger
+
+  swagger_path :show do
+    get("/api/gurukul-config")
+
+    description(
+      "Resolves the merged Gurukul UI configuration using the fallback chain " <>
+        "batch -> program -> defaultgroup. Provide exactly one of user_id, batch_id " <>
+        "or program_id. For user_id the oldest current batch/program is used."
+    )
+
+    parameters do
+      user_id(:query, :integer, "Resolve config for this user", required: false)
+      batch_id(:query, :integer, "Resolve config for this batch directly", required: false)
+      program_id(:query, :integer, "Resolve config for this program directly", required: false)
+    end
+
+    response(200, "Success")
+    response(400, "Bad Request")
+  end
+
+  def show(conn, params) do
+    with {:ok, scope, id} <- pick_scope(params),
+         {:ok, int_id} <- parse_int(id) do
+      {config, resolved_from} = resolve(scope, int_id)
+
+      conn
+      |> put_status(:ok)
+      |> render(:show, config: config, resolved_from: resolved_from)
+    else
+      {:error, message} ->
+        conn
+        |> put_status(:bad_request)
+        |> render(:error, error: message)
+    end
+  end
+
+  defp resolve(:user, id), do: GurukulConfigService.resolve_for_user(id)
+  defp resolve(:batch, id), do: GurukulConfigService.resolve_for_batch(id)
+  defp resolve(:program, id), do: GurukulConfigService.resolve_for_program(id)
+
+  defp pick_scope(params) do
+    cond do
+      present?(params["user_id"]) -> {:ok, :user, params["user_id"]}
+      present?(params["batch_id"]) -> {:ok, :batch, params["batch_id"]}
+      present?(params["program_id"]) -> {:ok, :program, params["program_id"]}
+      true -> {:error, "One of user_id, batch_id or program_id is required"}
+    end
+  end
+
+  defp parse_int(value) do
+    case Integer.parse(to_string(value)) do
+      {int, ""} -> {:ok, int}
+      _ -> {:error, "Identifier must be an integer"}
+    end
+  end
+
+  defp present?(nil), do: false
+  defp present?(""), do: false
+  defp present?(_), do: true
+end

--- a/lib/dbservice_web/json/gurukul_config_json.ex
+++ b/lib/dbservice_web/json/gurukul_config_json.ex
@@ -1,0 +1,12 @@
+defmodule DbserviceWeb.GurukulConfigJSON do
+  def show(%{config: config, resolved_from: resolved_from}) do
+    %{
+      config: config,
+      resolved_from: resolved_from
+    }
+  end
+
+  def error(%{error: message}) do
+    %{error: message}
+  end
+end

--- a/lib/dbservice_web/json/program_json.ex
+++ b/lib/dbservice_web/json/program_json.ex
@@ -16,7 +16,8 @@ defmodule DbserviceWeb.ProgramJSON do
       state: program.state,
       product_id: program.product_id,
       model: program.model,
-      is_current: program.is_current
+      is_current: program.is_current,
+      config: program.config
     }
   end
 end

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -83,6 +83,7 @@ defmodule DbserviceWeb.Router do
     resources("/product", ProductController)
     resources("/program", ProgramController, except: [:new, :edit])
     resources("/batch", BatchController, except: [:new, :edit])
+    get("/gurukul-config", GurukulConfigController, :show)
     resources("/group", GroupController, except: [:new, :edit])
     resources("/form-schema", FormSchemaController)
     resources("/group-user", GroupUserController)

--- a/lib/dbservice_web/swagger_schemas/program.ex
+++ b/lib/dbservice_web/swagger_schemas/program.ex
@@ -22,6 +22,7 @@ defmodule DbserviceWeb.SwaggerSchema.Program do
             model(:string, "Program Model")
             group_id(:integer, "ID of the group")
             is_current(:boolean, "Program is currently active/inactive")
+            config(:map, "Gurukul UI configuration for the program")
           end
 
           example(%{
@@ -36,7 +37,8 @@ defmodule DbserviceWeb.SwaggerSchema.Program do
             state: "Delhi",
             model: "Live Classes",
             group_id: 1,
-            is_current: true
+            is_current: true,
+            config: %{"showTests" => true, "testsSectionTitle" => "Live Test"}
           })
         end
     }

--- a/lib/dbservice_web/swagger_schemas/program.ex
+++ b/lib/dbservice_web/swagger_schemas/program.ex
@@ -22,7 +22,12 @@ defmodule DbserviceWeb.SwaggerSchema.Program do
             model(:string, "Program Model")
             group_id(:integer, "ID of the group")
             is_current(:boolean, "Program is currently active/inactive")
-            config(:map, "Gurukul UI configuration for the program")
+
+            config(
+              :map,
+              "Module configuration for the program, namespaced per module " <>
+                "(e.g. \"gurukul_config\" for Gurukul UI configuration)"
+            )
           end
 
           example(%{
@@ -38,7 +43,9 @@ defmodule DbserviceWeb.SwaggerSchema.Program do
             model: "Live Classes",
             group_id: 1,
             is_current: true,
-            config: %{"showTests" => true, "testsSectionTitle" => "Live Test"}
+            config: %{
+              "gurukul_config" => %{"showTests" => true, "testsSectionTitle" => "Live Test"}
+            }
           })
         end
     }

--- a/priv/repo/migrations/20260603113609_add_config_to_program.exs
+++ b/priv/repo/migrations/20260603113609_add_config_to_program.exs
@@ -1,0 +1,9 @@
+defmodule Dbservice.Repo.Migrations.AddConfigToProgram do
+  use Ecto.Migration
+
+  def change do
+    alter table(:program) do
+      add :config, :map, default: "{}"
+    end
+  end
+end

--- a/test/dbservice/services/gurukul_config_service_test.exs
+++ b/test/dbservice/services/gurukul_config_service_test.exs
@@ -68,7 +68,12 @@ defmodule Dbservice.Services.GurukulConfigServiceTest do
 
   describe "resolve_for_batch/1" do
     test "merges batch over program over defaultgroup (batch wins)" do
-      default_group_fixture(%{"showTests" => true, "homeTabLabel" => "Home", "showHomeTab" => true})
+      default_group_fixture(%{
+        "showTests" => true,
+        "homeTabLabel" => "Home",
+        "showHomeTab" => true
+      })
+
       program = program_fixture(%{"testsSectionTitle" => "NVS Live Test", "showHomeTab" => false})
       batch = batch_fixture(program, %{"gurukul_config" => %{"testsSectionTitle" => "CA Test"}})
 

--- a/test/dbservice/services/gurukul_config_service_test.exs
+++ b/test/dbservice/services/gurukul_config_service_test.exs
@@ -1,0 +1,150 @@
+defmodule Dbservice.Services.GurukulConfigServiceTest do
+  use Dbservice.DataCase
+
+  alias Dbservice.Repo
+  alias Dbservice.Services.GurukulConfigService
+  alias Dbservice.Groups.AuthGroup
+  alias Dbservice.Programs.Program
+  alias Dbservice.Batches.Batch
+  alias Dbservice.EnrollmentRecords.EnrollmentRecord
+
+  import Dbservice.UsersFixtures
+  import Dbservice.ProductsFixtures
+
+  defp default_group_fixture(config) do
+    Repo.insert!(%AuthGroup{name: "defaultgroup", input_schema: %{"gurukul_config" => config}})
+  end
+
+  defp program_fixture(config) do
+    product = product_fixture()
+
+    Repo.insert!(%Program{
+      name: "Program #{System.unique_integer([:positive])}",
+      product_id: product.id,
+      config: config
+    })
+  end
+
+  defp batch_fixture(program, metadata) do
+    Repo.insert!(%Batch{
+      name: "Batch #{System.unique_integer([:positive])}",
+      program_id: program && program.id,
+      metadata: metadata
+    })
+  end
+
+  defp enroll(user, group_type, group_id, start_date) do
+    Repo.insert!(%EnrollmentRecord{
+      user_id: user.id,
+      group_type: group_type,
+      group_id: group_id,
+      is_current: true,
+      academic_year: "2026-2027",
+      start_date: start_date
+    })
+  end
+
+  describe "resolve_for_program/1" do
+    test "merges program config over the defaultgroup base" do
+      default_group_fixture(%{"showTests" => false, "testsSectionTitle" => "Live Test"})
+      program = program_fixture(%{"testsSectionTitle" => "JEE Live Test"})
+
+      {config, resolved_from} = GurukulConfigService.resolve_for_program(program.id)
+
+      assert config == %{"showTests" => false, "testsSectionTitle" => "JEE Live Test"}
+      assert resolved_from.source == "program"
+      assert resolved_from.program_id == program.id
+    end
+
+    test "falls back to defaultgroup when the program does not exist" do
+      default_group_fixture(%{"showTests" => true})
+
+      {config, resolved_from} = GurukulConfigService.resolve_for_program(-1)
+
+      assert config == %{"showTests" => true}
+      assert resolved_from.source == "defaultgroup"
+    end
+  end
+
+  describe "resolve_for_batch/1" do
+    test "merges batch over program over defaultgroup (batch wins)" do
+      default_group_fixture(%{"showTests" => true, "homeTabLabel" => "Home", "showHomeTab" => true})
+      program = program_fixture(%{"testsSectionTitle" => "NVS Live Test", "showHomeTab" => false})
+      batch = batch_fixture(program, %{"gurukul_config" => %{"testsSectionTitle" => "CA Test"}})
+
+      {config, resolved_from} = GurukulConfigService.resolve_for_batch(batch.id)
+
+      assert config == %{
+               "showTests" => true,
+               "homeTabLabel" => "Home",
+               "showHomeTab" => false,
+               "testsSectionTitle" => "CA Test"
+             }
+
+      assert resolved_from.source == "batch"
+      assert resolved_from.batch_id == batch.id
+      assert resolved_from.program_id == program.id
+    end
+
+    test "works when the batch has no gurukul_config (program + default only)" do
+      default_group_fixture(%{"showTests" => true})
+      program = program_fixture(%{"testsSectionTitle" => "NVS Live Test"})
+      batch = batch_fixture(program, %{})
+
+      {config, _resolved_from} = GurukulConfigService.resolve_for_batch(batch.id)
+
+      assert config == %{"showTests" => true, "testsSectionTitle" => "NVS Live Test"}
+    end
+  end
+
+  describe "resolve_for_user/1" do
+    test "uses the oldest current batch when a user is in multiple batches" do
+      default_group_fixture(%{"showTests" => true})
+      old_program = program_fixture(%{"testsSectionTitle" => "Old"})
+      new_program = program_fixture(%{"testsSectionTitle" => "New"})
+      old_batch = batch_fixture(old_program, %{"gurukul_config" => %{"homeTabLabel" => "Older"}})
+      new_batch = batch_fixture(new_program, %{"gurukul_config" => %{"homeTabLabel" => "Newer"}})
+
+      user = user_fixture()
+      enroll(user, "batch", new_batch.id, ~D[2026-06-01])
+      enroll(user, "batch", old_batch.id, ~D[2025-06-01])
+
+      {config, resolved_from} = GurukulConfigService.resolve_for_user(user.id)
+
+      assert resolved_from.source == "batch"
+      assert resolved_from.batch_id == old_batch.id
+      assert config["testsSectionTitle"] == "Old"
+      assert config["homeTabLabel"] == "Older"
+    end
+
+    test "falls back to oldest current program when the user has no batch" do
+      default_group_fixture(%{"showTests" => true})
+      program = program_fixture(%{"testsSectionTitle" => "Program Title"})
+
+      user = user_fixture()
+      enroll(user, "program", program.id, ~D[2026-06-01])
+
+      {config, resolved_from} = GurukulConfigService.resolve_for_user(user.id)
+
+      assert resolved_from.source == "program"
+      assert resolved_from.program_id == program.id
+      assert config["testsSectionTitle"] == "Program Title"
+    end
+
+    test "returns the defaultgroup config when the user has no enrollments" do
+      default_group_fixture(%{"showTests" => true, "homeTabLabel" => "Home"})
+      user = user_fixture()
+
+      {config, resolved_from} = GurukulConfigService.resolve_for_user(user.id)
+
+      assert config == %{"showTests" => true, "homeTabLabel" => "Home"}
+      assert resolved_from.source == "defaultgroup"
+    end
+
+    test "returns an empty config when there is no defaultgroup and no enrollments" do
+      user = user_fixture()
+
+      assert {%{}, %{source: "defaultgroup"}} = GurukulConfigService.resolve_for_user(user.id)
+    end
+  end
+end

--- a/test/dbservice/services/gurukul_config_service_test.exs
+++ b/test/dbservice/services/gurukul_config_service_test.exs
@@ -21,7 +21,7 @@ defmodule Dbservice.Services.GurukulConfigServiceTest do
     Repo.insert!(%Program{
       name: "Program #{System.unique_integer([:positive])}",
       product_id: product.id,
-      config: config
+      config: %{"gurukul_config" => config}
     })
   end
 
@@ -99,6 +99,42 @@ defmodule Dbservice.Services.GurukulConfigServiceTest do
       {config, _resolved_from} = GurukulConfigService.resolve_for_batch(batch.id)
 
       assert config == %{"showTests" => true, "testsSectionTitle" => "NVS Live Test"}
+    end
+
+    test "ignores other modules' keys stored alongside gurukul_config" do
+      default_group_fixture(%{"showTests" => true})
+      product = product_fixture()
+
+      program =
+        Repo.insert!(%Program{
+          name: "Program #{System.unique_integer([:positive])}",
+          product_id: product.id,
+          config: %{
+            "gurukul_config" => %{"testsSectionTitle" => "NVS Live Test"},
+            "cms_config" => %{"someCmsKey" => true}
+          }
+        })
+
+      batch =
+        Repo.insert!(%Batch{
+          name: "Batch #{System.unique_integer([:positive])}",
+          program_id: program.id,
+          metadata: %{
+            "is_parent_batch" => false,
+            "gurukul_config" => %{"homeTabLabel" => "CoE Home"}
+          }
+        })
+
+      {config, _resolved_from} = GurukulConfigService.resolve_for_batch(batch.id)
+
+      assert config == %{
+               "showTests" => true,
+               "testsSectionTitle" => "NVS Live Test",
+               "homeTabLabel" => "CoE Home"
+             }
+
+      refute Map.has_key?(config, "cms_config")
+      refute Map.has_key?(config, "is_parent_batch")
     end
   end
 


### PR DESCRIPTION
## What

Adds a `config` jsonb column to the `program` table to store per-program Gurukul UI configuration.

This is **step 1 of 2** in moving Gurukul UI config from per-`auth_group` to per-program/batch, ahead of the AY26-27 launch (Gurukul going to all programs, not just PMU). The follow-up PR adds the resolution endpoint.

## Changes

- Migration `20260603113609_add_config_to_program` — adds `config :map` (jsonb, default `{}`)
- `Program` schema + changeset — casts `:config`
- `ProgramJSON` — exposes `config` in API responses
- Program swagger schema — documents the field

Batch needs **no change** — it reuses the existing `metadata` map under `metadata["gurukul_config"]`.

## Resolution model (context)

Config is resolved along the chain `batch → program → defaultgroup` (later wins). This PR only adds storage; the merge/fallback logic lands in the follow-up.

## Testing

- `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo` clean
- Migration applied locally; `config | jsonb | '{}'::jsonb` confirmed on the `program` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)