### PR TITLE
Reduce import halt polling queries

### DIFF
--- a/lib/dbservice/utils/import_worker.ex
+++ b/lib/dbservice/utils/import_worker.ex
@@ -39,6 +39,12 @@ defmodule Dbservice.DataImport.ImportWorker do
   alias Dbservice.Batches
   alias Dbservice.Schools
 
+  @halt_check_interval 50
+
+  def halt_check_due?(index) when is_integer(index) and index > 0 do
+    index == 1 or rem(index, @halt_check_interval) == 0
+  end
+
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"id" => import_id}}) do
     import_record = DataImport.get_import!(import_id)
@@ -631,10 +637,7 @@ defmodule Dbservice.DataImport.ImportWorker do
 
     result =
       Enum.reduce_while(records, initial_acc, fn {record, index}, {:ok, processed_records} ->
-        # Check if import has been halted before processing each record
-        current_import = DataImport.get_import!(import_record.id)
-
-        if current_import.status == "stopped" do
+        if halt_check_due?(index) and import_stopped?(import_record.id) do
           {:halt, {:ok, Enum.reverse(processed_records)}}
         else
           handle_record_processing(
@@ -651,6 +654,10 @@ defmodule Dbservice.DataImport.ImportWorker do
       {:ok, processed_records} -> {:ok, Enum.reverse(processed_records)}
       error -> error
     end
+  end
+
+  defp import_stopped?(import_id) do
+    DataImport.get_import!(import_id).status == "stopped"
   end
 
   # Helper function to handle individual record processing within the reduce_while loop

--- a/test/dbservice/utils/import_worker_test.exs
+++ b/test/dbservice/utils/import_worker_test.exs
@@ -29,6 +29,17 @@ defmodule Dbservice.DataImport.ImportWorkerTest do
     }
   end
 
+  describe "halt polling cadence" do
+    test "checks the halt flag on the first row and every 50 rows" do
+      assert ImportWorker.halt_check_due?(1)
+      refute ImportWorker.halt_check_due?(2)
+      refute ImportWorker.halt_check_due?(49)
+      assert ImportWorker.halt_check_due?(50)
+      refute ImportWorker.halt_check_due?(51)
+      assert ImportWorker.halt_check_due?(100)
+    end
+  end
+
   describe "perform/1" do
     test "processes a successful student import", %{
       auth_group_id: auth_group_id,


### PR DESCRIPTION
Refs #486.

## Summary
- checks the import halt flag on row 1 and then every 50 rows instead of before every row
- keeps stop responsiveness bounded while reducing a 5,000-row import from 5,000 halt SELECTs to about 100
- extracts the cadence into `ImportWorker.halt_check_due?/1` and adds regression coverage for the polling boundaries

## Validation
- `git diff --check`

## Local validation blocker
- `mix` / `elixir` are not installed in this environment, so I could not run `mix format` or the focused ExUnit test locally.
- Docker is installed, but the daemon is not running (`Cannot connect to the Docker daemon at .../docker.sock`), so I could not run a containerized Elixir check either.