### PR TITLE
feat(student): drop unused family_income column

### DIFF
--- a/lib/dbservice/constants/mappings.ex
+++ b/lib/dbservice/constants/mappings.ex
@@ -128,12 +128,6 @@ defmodule Dbservice.Constants.Mappings do
       optional: ["student_update", "alumni_addition"],
       type: :string
     },
-    "student_family_income" => %{
-      db_field: "family_income",
-      required: ["student"],
-      optional: ["student_update", "alumni_addition"],
-      type: :string
-    },
     "student_father_profession" => %{
       db_field: "father_profession",
       required: ["student"],

--- a/lib/dbservice/users/student.ex
+++ b/lib/dbservice/users/student.ex
@@ -31,7 +31,6 @@ defmodule Dbservice.Users.Student do
     field(:stream, :string)
     field(:physically_handicapped, :boolean)
     field(:physically_handicapped_certificate, :string)
-    field(:family_income, :string)
     field(:annual_family_income, :string)
     field(:monthly_family_income, :string)
     field(:time_of_device_availability, :string)
@@ -89,7 +88,6 @@ defmodule Dbservice.Users.Student do
       :stream,
       :physically_handicapped,
       :physically_handicapped_certificate,
-      :family_income,
       :annual_family_income,
       :monthly_family_income,
       :time_of_device_availability,

--- a/lib/dbservice_web/json/student_json.ex
+++ b/lib/dbservice_web/json/student_json.ex
@@ -43,7 +43,6 @@ defmodule DbserviceWeb.StudentJSON do
       stream: student.stream,
       physically_handicapped: student.physically_handicapped,
       physically_handicapped_certificate: student.physically_handicapped_certificate,
-      family_income: student.family_income,
       annual_family_income: student.annual_family_income,
       monthly_family_income: student.monthly_family_income,
       time_of_device_availability: student.time_of_device_availability,

--- a/lib/dbservice_web/swagger_schemas/student.ex
+++ b/lib/dbservice_web/swagger_schemas/student.ex
@@ -20,7 +20,6 @@ defmodule DbserviceWeb.SwaggerSchema.Student do
             stream(:string, "Stream")
             user_id(:integer, "User ID for the student")
             physically_handicapped(:boolean, "Physically hadicapped")
-            family_income(:string, "Annual income of family")
             father_profession(:string, "Father's profession")
             mother_profession(:String, "Mother's profession")
             mother_education_level(:string, "Mother's education level")
@@ -49,7 +48,6 @@ defmodule DbserviceWeb.SwaggerSchema.Student do
             stream: "PCB",
             user_id: 1,
             physically_handicapped: false,
-            family_income: "3LPA-6LPA",
             father_profession: "Unemployed",
             father_education_level: "UG",
             mother_profession: "Housewife",

--- a/priv/repo/migrations/20260605061904_remove_family_income_from_student.exs
+++ b/priv/repo/migrations/20260605061904_remove_family_income_from_student.exs
@@ -1,0 +1,11 @@
+defmodule Dbservice.Repo.Migrations.RemoveFamilyIncomeFromStudent do
+  use Ecto.Migration
+
+  def change do
+    alter table(:student) do
+      # Consolidated onto annual_family_income; family_income is no longer used.
+      # Typed remove keeps the migration reversible (rollback re-adds the column).
+      remove :family_income, :string
+    end
+  end
+end

--- a/test/dbservice/users_test.exs
+++ b/test/dbservice/users_test.exs
@@ -211,7 +211,6 @@ defmodule Dbservice.UsersTest do
         mother_phone: "some mother_phone",
         stream: "medical",
         physically_handicapped: false,
-        family_income: "some family income",
         annual_family_income: "some annual family income",
         father_profession: "some father profession",
         father_education_level: "some father education level",
@@ -232,7 +231,6 @@ defmodule Dbservice.UsersTest do
       assert student.mother_phone == "some mother_phone"
       assert student.stream == "medical"
       assert student.physically_handicapped == false
-      assert student.family_income == "some family income"
       assert student.annual_family_income == "some annual family income"
       assert student.father_profession == "some father profession"
       assert student.father_education_level == "some father education level"
@@ -261,7 +259,6 @@ defmodule Dbservice.UsersTest do
         mother_phone: "some updated mother_phone",
         stream: "pcm",
         physically_handicapped: false,
-        family_income: "some updated family income",
         annual_family_income: "some updated annual family income",
         father_profession: "some updated father profession",
         father_education_level: "some updated father education level",
@@ -281,7 +278,6 @@ defmodule Dbservice.UsersTest do
       assert student.mother_phone == "some updated mother_phone"
       assert student.stream == "pcm"
       assert student.physically_handicapped == false
-      assert student.family_income == "some updated family income"
       assert student.annual_family_income == "some updated annual family income"
       assert student.father_profession == "some updated father profession"
       assert student.father_education_level == "some updated father education level"

--- a/test/dbservice_web/controllers/student_controller_test.exs
+++ b/test/dbservice_web/controllers/student_controller_test.exs
@@ -12,7 +12,6 @@ defmodule DbserviceWeb.StudentControllerTest do
     stream: "medical",
     student_id: "some student id",
     physically_handicapped: false,
-    family_income: "some family income",
     annual_family_income: "some annual family income",
     father_profession: "some father profession",
     father_education_level: "some father education level",
@@ -31,7 +30,6 @@ defmodule DbserviceWeb.StudentControllerTest do
     stream: "pcm",
     student_id: "some updated student id",
     physically_handicapped: false,
-    family_income: "some updated family income",
     annual_family_income: "some updated annual family income",
     father_profession: "some updated father profession",
     father_education_level: "some updated father education level",
@@ -118,7 +116,6 @@ defmodule DbserviceWeb.StudentControllerTest do
       assert resp["category"] == "OBC"
       assert resp["father_name"] == "some updated father name"
       assert resp["stream"] == "pcm"
-      assert resp["family_income"] == "some updated family income"
       assert resp["annual_family_income"] == "some updated annual family income"
       assert is_integer(resp["user"]["id"])
     end


### PR DESCRIPTION
## Summary

Consolidates the student income field onto `annual_family_income` and drops the now-unused `student.family_income` column. Companion to the LMS change (af_lms PR #101), where the edit-student UI was moved to write `annual_family_income`.

## Changes

- **Migration** `20260605061904_remove_family_income_from_student` — removes `student.family_income` (typed `remove`, so it's reversible)
- **Schema** (`users/student.ex`) — drop the `:family_income` field + changeset cast
- **JSON view** (`json/student_json.ex`) — remove `family_income` from the serialized response
- **Swagger** (`swagger_schemas/student.ex`) — remove the property + example entry
- **Import mappings** (`constants/mappings.ex`) — remove the `student_family_income` mapping (`student_annual_family_income` → `annual_family_income` stays)
- **Tests** — drop `family_income` from `student_controller_test` and `users_test`

## Not touched

- `demographic_profile.family_income` is a **separate table/column** and is intentionally left as-is.

## Testing

- `MIX_ENV=test mix ecto.migrate` applies cleanly
- `mix test` on the affected files: same result as `main` (2 pre-existing failures in the `create student` tests — they assert HTTP 201 while the controller returns 200; unrelated to this change, verified by re-running on a clean `main`)
- `mix phx.swagger.generate` regenerates `swagger.json` with the student `family_income` entries gone (gitignored, regenerated on deploy)

## Rollout note

This is a destructive column drop. Anything still reading `student.family_income` outside this repo will break on deploy (accepted trade-off — "fix fast"). db-service's own references are all cleaned up here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)