### PR TITLE
fix(resources): populate topic_id in test problems API

### DIFF
--- a/lib/dbservice/resources.ex
+++ b/lib/dbservice/resources.ex
@@ -94,15 +94,31 @@ defmodule Dbservice.Resources do
       )
       |> Repo.all()
 
+    # topic_id lives on the resource_topic join table, not on the resource
+    # itself, so fetch the mapping separately and attach it per problem.
+    resource_topic_by_resource_id = resource_topics_by_resource_id(problem_ids)
+
     Enum.map(problems, fn resource ->
       problem_lang = Enum.find(resource.problem_language, &(&1.lang_id == lang_id))
 
       %{
         resource: resource,
+        resource_topic: Map.get(resource_topic_by_resource_id, resource.id, %{}),
         resource_curriculums: resource.resource_curriculum,
         problem_lang: problem_lang || %{},
         requested_curriculum_id: curriculum_id
       }
+    end)
+  end
+
+  # Returns a map of resource_id => resource_topic record for the given
+  # resources. A problem maps to a single topic in the response, so the first
+  # resource_topic per resource is kept.
+  defp resource_topics_by_resource_id(resource_ids) do
+    from(rt in ResourceTopic, where: rt.resource_id in ^resource_ids)
+    |> Repo.all()
+    |> Enum.reduce(%{}, fn rt, acc ->
+      Map.put_new(acc, rt.resource_id, rt)
     end)
   end
 


### PR DESCRIPTION
## What

`GET /api/resource/test/:id/problems` returned `topic_id: null` for **every** problem. This fetches the topic mapping so `topic_id` resolves correctly.

## Root cause

`topic_id` doesn't live on the `resource` row — it comes from the `resource_topic` join table. The other fields that came back fine (`chapter_id`, `subject_id`, `grade_id`, `curriculum_id`) are all preloaded/selected in the query, but `fetch_and_format_problems` never fetched `resource_topic`. So the serializer's `Map.get(resource_topic, :topic_id, nil)` always hit the `nil` default.

The existing `/api/problems` endpoint already joins `resource_topic` and selects `topic_id` — the test-problems query just never got that.

## Fix

In `Dbservice.Resources.fetch_and_format_problems`, fetch the `resource_topic` rows for the problem ids (one query), build a `resource_id => resource_topic` map, and attach it per problem. A problem maps to a single `topic_id` in this response, so the first `resource_topic` per resource is kept.

## Testing

Ran the function against the dev DB for test 515:
- **Before:** `topic_id` was `null` for all 25 problems.
- **After:** `topic_id` resolves to real values (e.g. `443`) for all problems.

`mix compile --warnings-as-errors` and `mix format` clean. (Pre-existing credo alias-ordering nits in this file are left untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)