### PR TITLE
feat(resources): reject duplicate test code on resource create

### DIFF
--- a/lib/dbservice_web/controllers/resource_controller.ex
+++ b/lib/dbservice_web/controllers/resource_controller.ex
@@ -82,13 +82,8 @@ defmodule DbserviceWeb.ResourceController do
     code = params["code"]
 
     case Resources.get_resource_by_code(code) do
-      nil ->
-        create_new_resource(conn, params)
-
-      _existing_resource ->
-        conn
-        |> put_status(:unprocessable_entity)
-        |> json(%{error: "This test code has already been used."})
+      nil -> create_new_resource(conn, params)
+      _existing_resource -> {:error, "This test code has already been used."}
     end
   end
 

--- a/lib/dbservice_web/controllers/resource_controller.ex
+++ b/lib/dbservice_web/controllers/resource_controller.ex
@@ -82,8 +82,13 @@ defmodule DbserviceWeb.ResourceController do
     code = params["code"]
 
     case Resources.get_resource_by_code(code) do
-      nil -> create_new_resource(conn, params)
-      existing_resource -> update_existing_resource(conn, existing_resource, params)
+      nil ->
+        create_new_resource(conn, params)
+
+      _existing_resource ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: "This test code has already been used."})
     end
   end
 


### PR DESCRIPTION
## Summary
New requirement for the create resource endpoint (`POST /api/resource`): when `type='test'` and the test `code` in the request body already exists in the database, the API now returns an error instead of updating the existing test resource.

## Changes
- `handle_test_resource/2` in `resource_controller.ex` now returns `422 Unprocessable Entity` with `{"error": "This test code has already been used."}` when a resource with the given test code already exists.
- New test codes (no existing match) still create a new resource as before.

## Notes
- If `code` is missing/`nil`, behavior is unchanged (falls through to creation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)