### PR TITLE
fix(resources): persist and return problem difficulty_level on update

### DIFF
--- a/lib/dbservice/resources.ex
+++ b/lib/dbservice/resources.ex
@@ -731,10 +731,13 @@ defmodule Dbservice.Resources do
     end
   end
 
-  # When only `difficulty_level` is sent (no `curriculum_grades`), `update_resource_curriculums`
-  # is skipped — but difficulty_level lives on resource_curriculum, so we update existing rows here.
+  # difficulty_level lives on resource_curriculum, so update existing rows whenever it is sent.
+  # This also covers the case where `curriculum_grades` is present but unchanged (so
+  # `update_resource_curriculums` skips the replace): only the difficulty changed and must
+  # still be applied. When rows were replaced above, they already carry the new difficulty,
+  # so the `!=` guard below makes this a no-op.
   defp update_resource_curriculum_difficulty_level(resource, params) do
-    if Map.has_key?(params, "difficulty_level") and not Map.has_key?(params, "curriculum_grades") do
+    if Map.has_key?(params, "difficulty_level") do
       difficulty_level = Map.get(params, "difficulty_level")
 
       resource.id

--- a/lib/dbservice_web/json/resource_json.ex
+++ b/lib/dbservice_web/json/resource_json.ex
@@ -59,6 +59,13 @@ defmodule DbserviceWeb.ResourceJSON do
         }
       end)
 
+    # difficulty_level is global across a resource's curriculum rows, so take it from the first.
+    difficulty_level =
+      case resource_curriculums do
+        [rc | _] -> rc.difficulty_level
+        [] -> nil
+      end
+
     base_map = %{
       id: resource.id,
       name: resource.name,
@@ -77,7 +84,8 @@ defmodule DbserviceWeb.ResourceJSON do
       cms_status_id: resource.cms_status_id,
       exam_ids: resource.exam_ids,
       exam_details: exam_details,
-      curriculum_grades: curriculum_grades
+      curriculum_grades: curriculum_grades,
+      difficulty_level: difficulty_level
     }
 
     # Add curriculum data if it exists


### PR DESCRIPTION
## Problem
Editing a problem's difficulty (e.g. medium → hard) via `PATCH /api/resource/:id` returned **200 but did not persist the change**, and `difficulty_level` was **missing entirely from the API response**.

## Root cause
`difficulty_level` lives on the `resource_curriculum` table, not the `resource` struct.

1. **Not persisted** — The problem editor submits `curriculum_grades` together with `difficulty_level`. When only the difficulty changed (curriculum/grade/subject unchanged):
   - `update_resource_curriculums` saw the curriculum set was unchanged and skipped the row replace.
   - `update_resource_curriculum_difficulty_level` was gated on `not Map.has_key?(params, "curriculum_grades")`, so it was skipped too.
   - Result: difficulty fell through both paths and was never written.

2. **Missing from response** — `ResourceJSON.render/1` only added `difficulty_level` when the `%Resource{}` struct had that key, which it never does (the field lives on `resource_curriculum`).

## Fix
- `resources.ex`: the in-place difficulty update now runs whenever `difficulty_level` is sent. When rows were also replaced, the existing `!=` guard makes it a no-op.
- `resource_json.ex`: `render/1` now reads `difficulty_level` from the resource's curriculum rows and always includes it in the response.

## Testing
Recommend verifying locally: PATCH a problem changing difficulty medium → hard, confirm it persists in `resource_curriculum` and appears in the response body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)