### PR TITLE
feat(data-import): align program import columns with template

### DIFF
--- a/lib/dbservice/constants/mappings.ex
+++ b/lib/dbservice/constants/mappings.ex
@@ -703,47 +703,11 @@ defmodule Dbservice.Constants.Mappings do
       optional: ["program_addition"],
       type: :boolean
     },
-    "TPM" => %{
-      db_field: "program_tpm",
+    "config" => %{
+      db_field: "config",
       required: [],
       optional: ["program_addition"],
-      type: :string
-    },
-    "Existing in DB" => %{
-      db_field: "program_existing_in_db",
-      required: [],
-      optional: ["program_addition"],
-      type: :string
-    },
-    "Program in DB?" => %{
-      db_field: "program_in_db",
-      required: [],
-      optional: ["program_addition"],
-      type: :string
-    },
-    "If yes product in DB" => %{
-      db_field: "program_product_in_db",
-      required: [],
-      optional: ["program_addition"],
-      type: :string
-    },
-    "Is product in sheet and DB matching?" => %{
-      db_field: "program_product_matching",
-      required: [],
-      optional: ["program_addition"],
-      type: :string
-    },
-    "Remark" => %{
-      db_field: "program_remark",
-      required: [],
-      optional: ["program_addition"],
-      type: :string
-    },
-    "Previous Name" => %{
-      db_field: "program_previous_name",
-      required: [],
-      optional: ["program_addition"],
-      type: :string
+      type: :map
     },
     # Batch addition (sheet: Batch ID, Name, Contact hours per week, Parent Batch ID, Start Date, End Date, Is Parent Batch, Program Name, Auth Group)
     "Batch ID" => %{

--- a/lib/dbservice/utils/import_worker.ex
+++ b/lib/dbservice/utils/import_worker.ex
@@ -1232,6 +1232,7 @@ defmodule Dbservice.DataImport.ImportWorker do
         |> maybe_put_program("product_id", record["product_id"])
         |> maybe_put_program("model", record["model"] |> trim_str())
         |> maybe_put_program("is_current", record["is_current"])
+        |> maybe_put_program("config", parse_program_config(record["config"]))
 
       case Programs.get_program_by_name(name) do
         nil ->
@@ -1251,6 +1252,24 @@ defmodule Dbservice.DataImport.ImportWorker do
   defp maybe_put_program(attrs, _key, nil), do: attrs
   defp maybe_put_program(attrs, _key, ""), do: attrs
   defp maybe_put_program(attrs, key, value), do: Map.put(attrs, key, value)
+
+  # Parses the optional `config` column (JSON object) into a map for the program's config field.
+  defp parse_program_config(nil), do: nil
+
+  defp parse_program_config(raw) when is_binary(raw) do
+    case String.trim(raw) do
+      "" ->
+        nil
+
+      trimmed ->
+        case Jason.decode(trimmed) do
+          {:ok, %{} = m} -> m
+          _ -> nil
+        end
+    end
+  end
+
+  defp parse_program_config(_), do: nil
 
   defp process_batch_addition_record(record) do
     with {:ok, name} <- validate_batch_name(record["name"]),


### PR DESCRIPTION
## Context
From Slack (Dhyanesh): the program data import was rejecting uploads with "format is different" because the cleaned-up program sheet now has a `config` column (not in our mappings) and no longer has several legacy columns. Asked to update the template to include **only** the sheet's columns.

Target sheet headers:
`Program Name`, `Target Outreach`, `Donor`, `State/System`, `Product Code`, `program_model`, `is_current`, `config`

## Why uploads failed
Header validation flags any sheet column not present in the mappings as an "extra header" (`data_import.ex` → `validate_headers_against_schema`). The sheet's new `config` column wasn't mapped, so the whole upload was rejected. The generated CSV template (`generate_csv_template` → `get_all_headers`) also still emitted the removed columns.

## Changes (`lib/dbservice/constants/mappings.ex`, `lib/dbservice/utils/import_worker.ex`)
- **Add** `config` column for `program_addition`, parsed from a JSON object string into the program's `config` map field (the field already exists on the `Program` schema).
- **Remove** legacy columns no longer in the sheet that were never persisted anyway: `TPM`, `Existing in DB`, `Program in DB?`, `If yes product in DB`, `Is product in sheet and DB matching?`, `Remark`, `Previous Name`.

Both header validation and the downloadable template derive from these mappings, so the template now matches the sheet and uploads pass.

## Notes
- A `config` cell that is empty or not valid JSON is skipped (program keeps its default `%{}`), rather than failing the row.
- Confirmed the removed columns' db_fields had no references elsewhere in `lib/` or `test/`.

## Testing
- `mix test test/dbservice/data_import_test.exs` → 15 tests, 0 failures.
- Suggest a manual upload of Dhyanesh's sheet to confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)