### PR TITLE
fix(data-import): allow multi-line quoted CSV cells for config JSON

### DIFF
--- a/lib/dbservice/utils/import_worker.ex
+++ b/lib/dbservice/utils/import_worker.ex
@@ -11,6 +11,11 @@ defmodule Dbservice.DataImport.ImportWorker do
   """
   use Oban.Worker, queue: :imports, max_attempts: 3
 
+  # Max lines a single quoted CSV cell may span. Pretty-printed multi-line JSON
+  # (e.g. the program `config` column exported from Google Sheets) can span many
+  # lines; bounded to avoid buffering a whole file on a malformed/unterminated quote.
+  @csv_escape_max_lines 50
+
   alias Dbservice.DataImport
   alias Dbservice.Constants.Mappings
   alias Dbservice.Users
@@ -583,7 +588,7 @@ defmodule Dbservice.DataImport.ImportWorker do
           escape_character: ?",
           headers: true,
           validate_row_length: false,
-          escape_max_lines: 2
+          escape_max_lines: @csv_escape_max_lines
         )
         # First index: tracks position in decoded CSV (1 = first data row after header)
         |> Stream.with_index(1)
@@ -1667,7 +1672,7 @@ defmodule Dbservice.DataImport.ImportWorker do
           # This consumes row 1 as headers
           headers: true,
           validate_row_length: false,
-          escape_max_lines: 2
+          escape_max_lines: @csv_escape_max_lines
         )
         # At this point, index 1 = row 2, index 2 = row 3, etc.
         |> Stream.with_index(1)


### PR DESCRIPTION
## Problem
Uploading the program sheet fails during processing with:

```
Unexpected error during CSV processing: %CSV.EscapeSequenceError{...
  "Escape sequence started on line 11 ... did not terminate.
   Escape sequences are allowed to span up to 2 lines."}
```

## Root cause
The new `config` column (added in #540) holds pretty-printed JSON exported from Google Sheets, e.g.:

```json
"{
  ""gurukul_config"": {
    ""homeTabLabel"": ""Tests""
  }
 }"
```

Each such cell is a single quoted CSV field that spans several lines (the largest config spans ~9). Both `CSV.decode!` calls in the import worker used `escape_max_lines: 2`, so any config cell longer than 2 lines aborted the whole import with `CSV.EscapeSequenceError`.

## Fix
Raise the limit to **50**, stored in a shared `@csv_escape_max_lines` module attribute used by both decode calls (record parsing and row counting). 50 comfortably covers the largest config cell while still bounding memory on a genuinely malformed/unterminated quote (the reason the cap exists).

## Notes
- Follow-up to #540 (merged), which added the `config` column.

## Testing
- `mix test test/dbservice/data_import_test.exs` → 15 tests, 0 failures.
- Recommend a real upload of the program sheet (with multi-line config cells) to confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)