### PR TITLE
Add program_id to centres with type-based backfill

### DIFF
--- a/priv/repo/migrations/20260612090000_add_program_id_to_centres.exs
+++ b/priv/repo/migrations/20260612090000_add_program_id_to_centres.exs
@@ -1,0 +1,38 @@
+defmodule Dbservice.Repo.Migrations.AddProgramIdToCentres do
+  use Ecto.Migration
+
+  def up do
+    alter table(:centres) do
+      add :program_id, references(:program, on_delete: :nothing)
+    end
+
+    create index(:centres, [:program_id])
+
+    # Backfill from the stable Centre type codes. Matching programs by name
+    # keeps the migration environment-safe (program ids are not guaranteed
+    # to match across staging and production).
+    execute("""
+    UPDATE centres
+    SET program_id = program.id
+    FROM program
+    WHERE program.name = 'JNV CoE'
+      AND centres.type_code = 'coe'
+      AND centres.program_id IS NULL
+    """)
+
+    execute("""
+    UPDATE centres
+    SET program_id = program.id
+    FROM program
+    WHERE program.name = 'JNV Nodal'
+      AND centres.type_code = 'nodal'
+      AND centres.program_id IS NULL
+    """)
+  end
+
+  def down do
+    alter table(:centres) do
+      remove :program_id
+    end
+  end
+end

--- a/test/dbservice/centre_schema_test.exs
+++ b/test/dbservice/centre_schema_test.exs
@@ -31,6 +31,7 @@ defmodule Dbservice.CentreSchemaTest do
                "is_active",
                "is_physical",
                "name",
+               "program_id",
                "school_id",
                "stream_codes",
                "sub_category_code",
@@ -70,6 +71,7 @@ defmodule Dbservice.CentreSchemaTest do
       ])
 
       assert columns("centres")["school_id"].nullable?
+      assert columns("centres")["program_id"].nullable?
       assert columns("centres")["type_code"].nullable?
       assert columns("centres")["category_code"].nullable?
       assert columns("centres")["sub_category_code"].nullable?
@@ -90,6 +92,7 @@ defmodule Dbservice.CentreSchemaTest do
 
       assert indexes("centre_options") |> Enum.any?(&(&1 == ["option_set_id"]))
       assert indexes("centres") |> Enum.any?(&(&1 == ["school_id"]))
+      assert indexes("centres") |> Enum.any?(&(&1 == ["program_id"]))
       assert indexes("centres") |> Enum.any?(&(&1 == ["type_code"]))
       assert indexes("centres") |> Enum.any?(&(&1 == ["category_code"]))
       assert indexes("centres") |> Enum.any?(&(&1 == ["sub_category_code"]))
@@ -100,6 +103,7 @@ defmodule Dbservice.CentreSchemaTest do
              ]
 
       assert foreign_keys("centres") == [
+               {"program_id", "program", "id"},
                {"school_id", "school", "id"}
              ]
     end


### PR DESCRIPTION
## Summary

- Adds a nullable, indexed `centres.program_id` foreign key referencing `program(id)`.
- Backfills the column from the stable Centre type codes in the same migration: `type_code = 'coe'` → program "JNV CoE", `type_code = 'nodal'` → program "JNV Nodal". Programs are matched **by name**, not id, so the migration is environment-safe across staging and production.
- Extends the Centre schema-contract test to cover the new column (nullability, index, FK boundary).

## Context

Centres were imported to staging and production from the finance cost-centre export (af_lms#114 / #533). Teachers in `user_permission` carry `program_ids`, and program is the natural differentiator where one school hosts multiple centres (currently JNV Adilabad: CoE + Nodal). Putting `program_id` on the centre makes that relationship explicit and prepares for teacher↔centre mapping (deliberately **not** in this PR — teachers need to become full db-service users first).

The af_lms side (program search + selector in the Centre edit modal, card display) follows in a separate LMS PR gated on this schema.

## Verification

- `mix format --check-formatted`
- `mix test test/dbservice/centre_schema_test.exs` (1 test, 0 failures — test DB runs the new migration)

## Deployment notes

- Staging: the gated "Run Staging Migrations" workflow on this PR applies it.
- Production: lands with the next `main` → `release` push.
- Backfill affects 47 of 54 rows in prod (36 coe + 11 nodal by type); centres with other/no types keep `program_id = NULL`.

Refs avantifellows/af_lms#105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
