### PR TITLE
Add staff and centre_positions tables; make teacher_id optional and unique

### DIFF
--- a/lib/dbservice/users.ex
+++ b/lib/dbservice/users.ex
@@ -576,13 +576,20 @@ defmodule Dbservice.Users do
 
   @doc """
   Gets a Teacher by teacher ID.
-  Raises `Ecto.NoResultsError` if the Batch does not exist.
+  Returns nil when no teacher matches, or when the given teacher ID is
+  nil/blank (teacher_id is optional, so code-less teachers exist and
+  callers may pass through missing request/import values).
   ## Examples
-      iex> get_teacher_by_teacher_id(1234)
+      iex> get_teacher_by_teacher_id("AF123")
       %Teacher{}
-      iex> get_teacher_by_teacher_id(abc)
-      ** (Ecto.NoResultsError)
+      iex> get_teacher_by_teacher_id("no-such-code")
+      nil
+      iex> get_teacher_by_teacher_id(nil)
+      nil
   """
+  def get_teacher_by_teacher_id(teacher_id) when is_nil(teacher_id) or teacher_id == "",
+    do: nil
+
   def get_teacher_by_teacher_id(teacher_id) do
     Repo.get_by(Teacher, teacher_id: teacher_id)
   end

--- a/lib/dbservice/users/teacher.ex
+++ b/lib/dbservice/users/teacher.ex
@@ -12,6 +12,7 @@ defmodule Dbservice.Users.Teacher do
     field :designation, :string
     field :teacher_id, :string
     field :is_af_teacher, :boolean
+    field :exit_date, :date
 
     belongs_to :user, User
     has_one :teacher_profile, TeacherProfile
@@ -28,8 +29,10 @@ defmodule Dbservice.Users.Teacher do
       :designation,
       :teacher_id,
       :subject_id,
-      :is_af_teacher
+      :is_af_teacher,
+      :exit_date
     ])
-    |> validate_required([:user_id, :teacher_id])
+    |> validate_required([:user_id])
+    |> unique_constraint(:teacher_id, name: :teacher_teacher_id_unique)
   end
 end

--- a/lib/dbservice/utils/import_worker.ex
+++ b/lib/dbservice/utils/import_worker.ex
@@ -899,6 +899,18 @@ defmodule Dbservice.DataImport.ImportWorker do
   end
 
   defp process_teacher_record(record) do
+    teacher_id = record["teacher_id"]
+
+    if is_nil(teacher_id) or teacher_id == "" do
+      # Bulk import stays strict: code-less teachers are created deliberately
+      # (LMS backfill / admin UI), never as an import side effect.
+      {:error, "teacher_id is required for teacher import rows"}
+    else
+      do_process_teacher_record(record)
+    end
+  end
+
+  defp do_process_teacher_record(record) do
     case Users.get_teacher_by_teacher_id(record["teacher_id"]) do
       nil ->
         with {:ok, teacher} <- Users.create_teacher_with_user(record),

--- a/lib/dbservice_web/json/teacher_json.ex
+++ b/lib/dbservice_web/json/teacher_json.ex
@@ -19,6 +19,7 @@ defmodule DbserviceWeb.TeacherJSON do
       teacher_id: teacher.teacher_id,
       subject_id: teacher.subject_id,
       is_af_teacher: teacher.is_af_teacher,
+      exit_date: teacher.exit_date,
       user_id: teacher.user_id,
       user: if(teacher.user, do: UserJSON.render(teacher.user), else: nil)
     }

--- a/lib/dbservice_web/swagger_schemas/teacher.ex
+++ b/lib/dbservice_web/swagger_schemas/teacher.ex
@@ -16,6 +16,7 @@ defmodule DbserviceWeb.SwaggerSchema.Teacher do
             teacher_id(:string, "Unique teacher ID")
             subject_id(:integer, "Subject ID associated with the teacher")
             is_af_teacher(:boolean, "Indicates whether the teacher is an AF teacher or not")
+            exit_date(:string, "Date the teacher exited; null while active", format: "date")
             user_id(:integer, "User ID for the teacher")
             user(:object, "User details associated with the teacher")
           end

--- a/priv/repo/migrations/20260612110000_make_teacher_id_optional_and_unique.exs
+++ b/priv/repo/migrations/20260612110000_make_teacher_id_optional_and_unique.exs
@@ -1,0 +1,28 @@
+defmodule Dbservice.Repo.Migrations.MakeTeacherIdOptionalAndUnique do
+  use Ecto.Migration
+
+  def up do
+    # "Not Permanent" is a placeholder meaning "no code"; NULL expresses that
+    # now that teacher_id is optional, and clears the way for the unique index.
+    execute("UPDATE teacher SET teacher_id = NULL WHERE teacher_id = 'Not Permanent'")
+
+    alter table(:teacher) do
+      add :exit_date, :date
+    end
+
+    # teacher_id is the Gurukul/Portal login identifier; admin-entered codes
+    # must never collide. NULLs (code not yet assigned) are exempt. The
+    # unique index supersedes the plain lookup index from 20250825075810.
+    drop index(:teacher, [:teacher_id])
+    create unique_index(:teacher, [:teacher_id], name: :teacher_teacher_id_unique)
+  end
+
+  def down do
+    drop index(:teacher, [:teacher_id], name: :teacher_teacher_id_unique)
+    create index(:teacher, [:teacher_id])
+
+    alter table(:teacher) do
+      remove :exit_date
+    end
+  end
+end

--- a/priv/repo/migrations/20260612110100_create_staff.exs
+++ b/priv/repo/migrations/20260612110100_create_staff.exs
@@ -1,0 +1,22 @@
+defmodule Dbservice.Repo.Migrations.CreateStaff do
+  use Ecto.Migration
+
+  def change do
+    # Non-teaching AF staff (program managers, APCs, future ops roles).
+    # Teachers remain fully modelled by the teacher table.
+    create table(:staff) do
+      add :user_id, references(:user, on_delete: :nothing), null: false
+      add :employee_code, :string, null: false
+      add :staff_type, :string, null: false
+      add :designation, :string
+      add :exit_date, :date
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create unique_index(:staff, [:employee_code])
+    # One non-teaching employment record per person.
+    create unique_index(:staff, [:user_id])
+    create index(:staff, [:staff_type])
+  end
+end

--- a/priv/repo/migrations/20260612110200_create_centre_positions.exs
+++ b/priv/repo/migrations/20260612110200_create_centre_positions.exs
@@ -1,0 +1,27 @@
+defmodule Dbservice.Repo.Migrations.CreateCentrePositions do
+  use Ecto.Migration
+
+  def change do
+    create table(:centre_positions) do
+      add :centre_id, references(:centres, on_delete: :nothing), null: false
+      add :role, :string, null: false
+      add :user_id, references(:user, on_delete: :nothing)
+      add :hr_code, :string
+      add :notes, :text
+      add :deleted_at, :naive_datetime
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create index(:centre_positions, [:centre_id])
+    create index(:centre_positions, [:user_id])
+
+    # A person can hold at most one ACTIVE seat per (centre, role). Vacant
+    # seats (user_id NULL) and soft-deleted history rows are exempt, so a
+    # centre may carry several open vacancies for the same role.
+    create unique_index(:centre_positions, [:centre_id, :role, :user_id],
+             where: "deleted_at IS NULL AND user_id IS NOT NULL",
+             name: :centre_positions_active_assignment_unique
+           )
+  end
+end

--- a/priv/repo/migrations/20260612110300_add_user_id_and_revoked_at_to_user_permission.exs
+++ b/priv/repo/migrations/20260612110300_add_user_id_and_revoked_at_to_user_permission.exs
@@ -1,0 +1,16 @@
+defmodule Dbservice.Repo.Migrations.AddUserIdAndRevokedAtToUserPermission do
+  use Ecto.Migration
+
+  def change do
+    alter table(:user_permission) do
+      # Explicit person link; the email join is fragile (user.email is
+      # nullable and unverified-unique).
+      add :user_id, references(:user, on_delete: :nothing)
+      # Access revocation (distinct from employment exit) — replaces the
+      # current hard-delete flow for offboarding.
+      add :revoked_at, :naive_datetime
+    end
+
+    create index(:user_permission, [:user_id])
+  end
+end

--- a/test/dbservice/staff_positions_schema_test.exs
+++ b/test/dbservice/staff_positions_schema_test.exs
@@ -1,0 +1,184 @@
+defmodule Dbservice.StaffPositionsSchemaTest do
+  use Dbservice.DataCase, async: true
+
+  describe "staff / centre_positions / teacher / user_permission schema" do
+    test "exposes staff and centre position tables with required constraints" do
+      assert Map.keys(columns("staff")) |> Enum.sort() == [
+               "designation",
+               "employee_code",
+               "exit_date",
+               "id",
+               "inserted_at",
+               "staff_type",
+               "updated_at",
+               "user_id"
+             ]
+
+      assert Map.keys(columns("centre_positions")) |> Enum.sort() == [
+               "centre_id",
+               "deleted_at",
+               "hr_code",
+               "id",
+               "inserted_at",
+               "notes",
+               "role",
+               "updated_at",
+               "user_id"
+             ]
+
+      assert_required_columns("staff", [
+        "id",
+        "user_id",
+        "employee_code",
+        "staff_type",
+        "inserted_at",
+        "updated_at"
+      ])
+
+      assert_required_columns("centre_positions", [
+        "id",
+        "centre_id",
+        "role",
+        "inserted_at",
+        "updated_at"
+      ])
+
+      assert columns("staff")["designation"].nullable?
+      assert columns("staff")["exit_date"].nullable?
+      assert columns("centre_positions")["user_id"].nullable?
+      assert columns("centre_positions")["hr_code"].nullable?
+      assert columns("centre_positions")["deleted_at"].nullable?
+
+      assert ["employee_code"] in unique_indexes("staff")
+      assert ["user_id"] in unique_indexes("staff")
+      assert indexes("staff") |> Enum.any?(&(&1 == ["staff_type"]))
+
+      assert indexes("centre_positions") |> Enum.any?(&(&1 == ["centre_id"]))
+      assert indexes("centre_positions") |> Enum.any?(&(&1 == ["user_id"]))
+      assert ["centre_id", "role", "user_id"] in unique_indexes("centre_positions")
+
+      # The active-assignment uniqueness is PARTIAL: vacant seats (user_id
+      # NULL) and soft-deleted history rows must not collide.
+      assert {:ok, %{rows: [[true]]}} =
+               Repo.query(
+                 """
+                 SELECT pg_get_indexdef(i.oid) ILIKE '%WHERE %deleted_at IS NULL%user_id IS NOT NULL%'
+                 FROM pg_class i
+                 WHERE i.relname = 'centre_positions_active_assignment_unique'
+                 """,
+                 []
+               )
+
+      assert foreign_keys("staff") == [{"user_id", "user", "id"}]
+
+      assert foreign_keys("centre_positions") == [
+               {"centre_id", "centres", "id"},
+               {"user_id", "user", "id"}
+             ]
+    end
+
+    test "teacher_id is optional, unique, and teacher gains exit_date" do
+      assert columns("teacher")["teacher_id"].nullable?
+      assert columns("teacher")["exit_date"].nullable?
+      assert ["teacher_id"] in unique_indexes("teacher")
+    end
+
+    test "user_permission links to user and supports revocation" do
+      assert columns("user_permission")["user_id"].nullable?
+      assert columns("user_permission")["revoked_at"].nullable?
+      assert indexes("user_permission") |> Enum.any?(&(&1 == ["user_id"]))
+
+      assert {"user_id", "user", "id"} in foreign_keys("user_permission")
+    end
+  end
+
+  defp assert_required_columns(table, names) do
+    table_columns = columns(table)
+
+    for name <- names do
+      refute table_columns[name].nullable?, "#{table}.#{name} should be NOT NULL"
+    end
+  end
+
+  defp columns(table) do
+    {:ok, result} =
+      Repo.query(
+        """
+        SELECT column_name, is_nullable
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = $1
+        ORDER BY column_name
+        """,
+        [table]
+      )
+
+    Map.new(result.rows, fn [name, nullable] ->
+      {name, %{nullable?: nullable == "YES"}}
+    end)
+  end
+
+  defp indexes(table) do
+    table
+    |> index_rows()
+    |> Enum.map(fn {_name, _unique?, columns} -> columns end)
+  end
+
+  defp unique_indexes(table) do
+    table
+    |> index_rows()
+    |> Enum.filter(fn {_name, unique?, _columns} -> unique? end)
+    |> Enum.map(fn {_name, _unique?, columns} -> columns end)
+  end
+
+  defp index_rows(table) do
+    {:ok, result} =
+      Repo.query(
+        """
+        SELECT
+          i.relname,
+          ix.indisunique,
+          array_agg(a.attname ORDER BY array_position(ix.indkey::int[], a.attnum)) AS columns
+        FROM pg_class t
+        JOIN pg_index ix ON t.oid = ix.indrelid
+        JOIN pg_class i ON i.oid = ix.indexrelid
+        JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
+        WHERE t.relname = $1
+        GROUP BY i.relname, ix.indisunique
+        ORDER BY i.relname
+        """,
+        [table]
+      )
+
+    Enum.map(result.rows, fn [name, unique?, columns] ->
+      {name, unique?, columns}
+    end)
+  end
+
+  defp foreign_keys(table) do
+    {:ok, result} =
+      Repo.query(
+        """
+        SELECT
+          kcu.column_name,
+          ccu.table_name AS foreign_table_name,
+          ccu.column_name AS foreign_column_name
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu
+          ON tc.constraint_name = kcu.constraint_name
+          AND tc.table_schema = kcu.table_schema
+        JOIN information_schema.constraint_column_usage ccu
+          ON ccu.constraint_name = tc.constraint_name
+          AND ccu.table_schema = tc.table_schema
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+          AND tc.table_schema = 'public'
+          AND tc.table_name = $1
+        ORDER BY kcu.column_name
+        """,
+        [table]
+      )
+
+    Enum.map(result.rows, fn [column, foreign_table, foreign_column] ->
+      {column, foreign_table, foreign_column}
+    end)
+  end
+end

--- a/test/dbservice/users_test.exs
+++ b/test/dbservice/users_test.exs
@@ -457,6 +457,13 @@ defmodule Dbservice.UsersTest do
       assert Users.get_teacher_by_teacher_id(teacher.teacher_id) == teacher
     end
 
+    test "get_teacher_by_teacher_id/1 returns nil for nil or blank teacher_id" do
+      {_user, _teacher} = teacher_fixture()
+
+      assert Users.get_teacher_by_teacher_id(nil) == nil
+      assert Users.get_teacher_by_teacher_id("") == nil
+    end
+
     test "create_teacher_with_user/1 creates a user and then a teacher" do
       valid_attrs = %{
         designation: "some designation",

--- a/test/dbservice_web/controllers/teacher_controller_test.exs
+++ b/test/dbservice_web/controllers/teacher_controller_test.exs
@@ -17,7 +17,10 @@ defmodule DbserviceWeb.TeacherControllerTest do
     designation: nil,
     teacher_id: nil,
     is_af_teacher: nil,
-    user_id: nil
+    user_id: nil,
+    # teacher_id is optional since 20260612110000, so an invalid payload
+    # must fail elsewhere: the user changeset rejects non-numeric phones.
+    phone: "not-a-phone"
   }
 
   setup %{conn: conn} do

--- a/test/dbservice_web/controllers/teacher_controller_test.exs
+++ b/test/dbservice_web/controllers/teacher_controller_test.exs
@@ -6,7 +6,8 @@ defmodule DbserviceWeb.TeacherControllerTest do
   @create_attrs %{
     designation: "some designation",
     teacher_id: "some teacher id",
-    is_af_teacher: false
+    is_af_teacher: false,
+    exit_date: "2026-05-31"
   }
   @update_attrs %{
     designation: "some updated designation",
@@ -52,6 +53,7 @@ defmodule DbserviceWeb.TeacherControllerTest do
       assert %{
                "id" => ^id,
                "designation" => "some designation",
+               "exit_date" => "2026-05-31",
                "teacher_id" => "some teacher id"
              } = json_response(conn, 200)
     end


### PR DESCRIPTION
## Summary

Schema groundwork for managing AF staff (teachers, PMs, APCs) and centre seat assignments from the LMS. Four migrations + one changeset change:

1. **`teacher` changes**
   - `teacher_id` becomes **optional** (changeset-level; the column was already nullable). Teachers backfilled from the LMS may not have a confirmed AF employee ID yet — admins assign codes later via the upcoming Staff Management UI. A code-less teacher simply cannot log in via Portal `/teacher/verify` until the code is set (today they have no row at all, so this is strictly additive).
   - `teacher_id` becomes **unique** (`teacher_teacher_id_unique`, supersedes the plain lookup index from 20250825075810; NULLs exempt). `teacher_id` is the Gurukul/Portal login identifier — admin-entered codes must never collide. The three rows holding the `"Not Permanent"` placeholder are nulled out first (that is what the placeholder meant).
   - New `exit_date` (date, NULL = active), exposed through the existing teacher API.
2. **`staff` (new)** — NON-teaching AF staff (program managers, APCs, future ops roles): unique `employee_code` (AF###), unique `user_id`, `staff_type`, `designation`, `exit_date`. Teachers remain fully modelled by `teacher` (single source for their code = login id; no mirroring/sync). A person may hold rows in both tables (e.g. teacher promoted to APC), same code by app-level convention.
3. **`centre_positions` (new)** — seats at centres: `centre_id`, `role` (physics/chemistry/maths/biology/apc/pm), nullable occupant `user_id` (**NULL = vacant/TBH**), `hr_code` (MT###/TBH### reference into HR systems), notes, soft delete. Partial unique index on active assignments `(centre_id, role, user_id)` — multiple vacancies per role allowed; PMs may hold seats at many centres.
4. **`user_permission`** — explicit `user_id` FK (the email join is fragile: `user.email` is nullable/unverified-unique) and `revoked_at` (access revocation as a soft state instead of today's hard-delete offboarding).

Also reworks the teacher controller invalid-payload fixtures to stay invalid (via the user phone-format validation) now that `teacher_id` is optional, and adds a schema-contract test (`staff_positions_schema_test.exs`) covering all of the above.

## Design context

- Occupancy is keyed on `user_id` (not `teacher_id`) so the same mechanism covers teachers, PMs, and APCs.
- Vacancies in HR data are placeholder "TBH" employees; here they are simply unoccupied position rows.
- `staff` and `centre_positions` are LMS-written tables (like `centres`); no Ecto contexts/APIs are added for them. Teacher writes continue through the existing teacher REST API.
- Full design narrative: `af_lms/docs/ai/teacher-staff/2026-06-12-centres-and-staff-handoff.md`.

## Verification

- `mix format --check-formatted`
- `mix test test/dbservice/staff_positions_schema_test.exs test/dbservice/centre_schema_test.exs test/dbservice/users_test.exs test/dbservice_web/controllers/teacher_controller_test.exs` — 43 tests, 0 failures (fresh test DB)
- Full `mix test`: 389 tests, 8 failures — identical to origin/main baseline (same pre-existing unrelated failures noted on #533/#543)

## Deployment notes

- Staging: gated "Run Staging Migrations" workflow on this PR.
- Production: next `main` → `release` push (can ride together with #543).
- The "Not Permanent" null-out touches 3 rows; the unique index creation will fail loudly if any real duplicate codes exist at migration time (none do today: 3,007 rows, all codes distinct apart from the placeholder).

Refs avantifellows/af_lms#105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)