### PR TITLE
chore(gurukul-config): rename default auth_group to DefaultGroup

### DIFF
--- a/lib/dbservice/services/gurukul_config_service.ex
+++ b/lib/dbservice/services/gurukul_config_service.ex
@@ -7,7 +7,7 @@ defmodule Dbservice.Services.GurukulConfigService do
   Each layer namespaces its Gurukul config under the `"gurukul_config"` key so
   the same column can hold config for other modules (CMS, LMS, etc.) without
   collision:
-    * defaultgroup: `auth_group.input_schema["gurukul_config"]`
+    * defaultgroup: the `DefaultGroup` auth_group's `input_schema["gurukul_config"]`
     * program:      `program.config["gurukul_config"]`
     * batch:        `batch.metadata["gurukul_config"]`
 
@@ -27,7 +27,7 @@ defmodule Dbservice.Services.GurukulConfigService do
   alias Dbservice.Programs.Program
   alias Dbservice.Repo
 
-  @default_group_name "defaultgroup"
+  @default_group_name "DefaultGroup"
   @config_key "gurukul_config"
 
   @doc """

--- a/test/dbservice/services/gurukul_config_service_test.exs
+++ b/test/dbservice/services/gurukul_config_service_test.exs
@@ -12,7 +12,7 @@ defmodule Dbservice.Services.GurukulConfigServiceTest do
   import Dbservice.ProductsFixtures
 
   defp default_group_fixture(config) do
-    Repo.insert!(%AuthGroup{name: "defaultgroup", input_schema: %{"gurukul_config" => config}})
+    Repo.insert!(%AuthGroup{name: "DefaultGroup", input_schema: %{"gurukul_config" => config}})
   end
 
   defp program_fixture(config) do


### PR DESCRIPTION
## What

Renames the auth_group that holds the base Gurukul UI config from **`defaultgroup`** to **`DefaultGroup`**.

The resolver (`GurukulConfigService`) looks up the base layer by `auth_group.name`. Every other auth_group uses PascalCase (e.g. `GujaratStudents`, `GujaratTeachers` from the seeds), so `defaultgroup` was the odd one out — this aligns it with the convention.

Follow-up to #529 / #530, ahead of seeding the actual `DefaultGroup` row + populating real configs.

## Changes

- `@default_group_name "defaultgroup"` → `"DefaultGroup"` (the name the resolver looks up)
- Updated moduledoc to name the `DefaultGroup` auth_group explicitly
- Test fixture now inserts `%AuthGroup{name: "DefaultGroup", ...}`

## Deliberately unchanged

The `source` label in `resolved_from` stays lowercase (`"defaultgroup"`) — it's a resolution-layer identifier sitting next to `"batch"` / `"program"`, not the auth_group name.

## Note for whoever seeds the row

The base config row must now be named **`DefaultGroup`**:

```sql
INSERT INTO auth_group (name, input_schema, ...)
VALUES ('DefaultGroup', '{"gurukul_config": { ... }}'::jsonb, ...);
```

## Testing

- `mix test test/dbservice/services/gurukul_config_service_test.exs` — 9/9 pass
- `mix format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)