### PR TITLE
fix(gurukul-config): read DefaultGroup base config from locale_data

### DIFF
--- a/lib/dbservice/services/gurukul_config_service.ex
+++ b/lib/dbservice/services/gurukul_config_service.ex
@@ -7,7 +7,7 @@ defmodule Dbservice.Services.GurukulConfigService do
   Each layer namespaces its Gurukul config under the `"gurukul_config"` key so
   the same column can hold config for other modules (CMS, LMS, etc.) without
   collision:
-    * defaultgroup: the `DefaultGroup` auth_group's `input_schema["gurukul_config"]`
+    * defaultgroup: the `DefaultGroup` auth_group's `locale_data["gurukul_config"]`
     * program:      `program.config["gurukul_config"]`
     * batch:        `batch.metadata["gurukul_config"]`
 
@@ -100,7 +100,7 @@ defmodule Dbservice.Services.GurukulConfigService do
 
   defp default_config do
     case Repo.get_by(AuthGroup, name: @default_group_name) do
-      %AuthGroup{input_schema: input_schema} -> gurukul_section(input_schema)
+      %AuthGroup{locale_data: locale_data} -> gurukul_section(locale_data)
       _ -> %{}
     end
   end

--- a/test/dbservice/services/gurukul_config_service_test.exs
+++ b/test/dbservice/services/gurukul_config_service_test.exs
@@ -12,7 +12,7 @@ defmodule Dbservice.Services.GurukulConfigServiceTest do
   import Dbservice.ProductsFixtures
 
   defp default_group_fixture(config) do
-    Repo.insert!(%AuthGroup{name: "DefaultGroup", input_schema: %{"gurukul_config" => config}})
+    Repo.insert!(%AuthGroup{name: "DefaultGroup", locale_data: %{"gurukul_config" => config}})
   end
 
   defp program_fixture(config) do


### PR DESCRIPTION
## Problem

`/api/gurukul-config` was returning a near-empty config for users whose base config should have come from the `DefaultGroup` auth_group. On staging, user 309050 (a CoE student) resolved to only:

```json
"config": { "showContentLibrary": false, "showLibraryTab": false }
```

Because `Map.merge` can only add/override keys (never remove them), a 2-key response proves the **base layer was empty** — the batch contributed those two keys and nothing else came through.

## Root cause

The resolver's base layer reads the `DefaultGroup` auth_group's `gurukul_config`, but `default_config/0` looked it up under `input_schema`:

```elixir
%AuthGroup{input_schema: input_schema} -> gurukul_section(input_schema)
```

…while the config is actually stored in the **`locale_data`** column. So `input_schema["gurukul_config"]` was absent, `default_config/0` returned `%{}`, and the batch/program merge had no baseline.

Downstream, every key the backend didn't send fell through to the Gurukul frontend's hardcoded `EnableStudents` defaults, so the CoE student saw **NVS** labels (e.g. "There is no NVS live test for today!").

## Fix

Point the DefaultGroup lookup at `locale_data`, where the config lives:

```elixir
%AuthGroup{locale_data: locale_data} -> gurukul_section(locale_data)
```

- Updated the moduledoc to document `locale_data["gurukul_config"]` as the DefaultGroup source.
- Updated the test fixture to seed `locale_data`.
- No data migration needed — the staging/prod rows already hold the config in `locale_data`.

Program and batch layers are unchanged (they read `program.config` / `batch.metadata`).

## Testing

`mix test test/dbservice/services/gurukul_config_service_test.exs` → 9 tests, 0 failures.

## Follow-ups (not in this PR)

- This restores the **DefaultGroup baseline** (generic "Live Test"). Actual **CoE** branding still needs `gurukul_config` populated on batch 605 / program 1.
- A companion Gurukul frontend change stops the client from filling missing keys with a token-group's hardcoded branding (defense-in-depth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)