### PR TITLE
Add Academic Mentorship Main DB migrations

### DIFF
--- a/priv/repo/migrations/20260616100000_create_academic_mentorship_tables.exs
+++ b/priv/repo/migrations/20260616100000_create_academic_mentorship_tables.exs
@@ -1,0 +1,602 @@
+defmodule Dbservice.Repo.Migrations.CreateAcademicMentorshipTables do
+  use Ecto.Migration
+
+  def change do
+    create table(:acad_mentorship_runtime_settings, primary_key: false) do
+      add :id, :string, primary_key: true, default: "global"
+      add :provider, :string
+      add :model, :string
+      add :scoring_model, :string
+      add :concurrency, :integer
+      add :timeout_seconds, :float
+      add :validation_timeout_seconds, :float
+      add :pi_version, :string
+      add :pi_output_mode, :string
+      add :pi_thinking_level, :string
+      add :pi_tool_allowlist, :map
+
+      created_updated_timestamps()
+    end
+
+    create constraint(:acad_mentorship_runtime_settings, :am_runtime_settings_singleton_check,
+             check: "id = 'global'"
+           )
+
+    create constraint(:acad_mentorship_runtime_settings, :am_runtime_settings_numeric_check,
+             check:
+               "(concurrency IS NULL OR concurrency >= 1) AND (timeout_seconds IS NULL OR timeout_seconds >= 0) AND (validation_timeout_seconds IS NULL OR validation_timeout_seconds >= 0)"
+           )
+
+    create table(:acad_mentorship_prompt_versions, primary_key: false) do
+      identity_primary_key()
+
+      add :prompt_type, :string, null: false
+      add :version_number, :integer, null: false
+      add :title, :string
+      add :description, :text
+      add :content, :text, null: false
+      add :is_active, :boolean, default: true, null: false
+      add :deleted_at, :utc_datetime
+
+      created_updated_timestamps()
+    end
+
+    create constraint(:acad_mentorship_prompt_versions, :am_prompt_versions_type_check,
+             check: "prompt_type IN ('pipeline', 'validation', 'scoring')"
+           )
+
+    create constraint(:acad_mentorship_prompt_versions, :am_prompt_versions_version_check,
+             check: "version_number >= 1"
+           )
+
+    create unique_index(:acad_mentorship_prompt_versions, [:prompt_type, :version_number],
+             name: :am_prompt_versions_type_version_unique
+           )
+
+    create unique_index(:acad_mentorship_prompt_versions, [:prompt_type],
+             where: "is_active IS TRUE AND deleted_at IS NULL",
+             name: :am_prompt_versions_one_active
+           )
+
+    create table(:acad_mentorship_tests_to_consider, primary_key: false) do
+      identity_primary_key()
+
+      add :program_id, references(:program, on_delete: :nothing), null: false
+      add :test_id, :string, null: false
+      add :test_name, :string
+      add :deleted_at, :utc_datetime
+
+      created_updated_timestamps()
+    end
+
+    create index(:acad_mentorship_tests_to_consider, [:program_id],
+             name: :am_tests_to_consider_program_idx
+           )
+
+    create index(:acad_mentorship_tests_to_consider, [:test_id],
+             name: :am_tests_to_consider_test_idx
+           )
+
+    create unique_index(:acad_mentorship_tests_to_consider, [:program_id, :test_id],
+             where: "deleted_at IS NULL",
+             name: :am_tests_to_consider_active_unique
+           )
+
+    create table(:acad_mentorship_teacher_feedback, primary_key: false) do
+      identity_primary_key()
+
+      add :student_id, references(:student, on_delete: :nothing), null: false
+      add :program_id, references(:program, on_delete: :nothing), null: false
+      add :test_id, :string, null: false
+      add :test_name, :string
+      add :mentor_user_id, references(:user, on_delete: :nothing)
+      add :mentor_name_text, :string
+      add :feedback, :map, null: false
+      add :deleted_at, :utc_datetime
+
+      created_updated_timestamps()
+    end
+
+    create index(:acad_mentorship_teacher_feedback, [:student_id],
+             name: :am_teacher_feedback_student_idx
+           )
+
+    create index(:acad_mentorship_teacher_feedback, [:program_id],
+             name: :am_teacher_feedback_program_idx
+           )
+
+    create index(:acad_mentorship_teacher_feedback, [:test_id],
+             name: :am_teacher_feedback_test_idx
+           )
+
+    create index(:acad_mentorship_teacher_feedback, [:mentor_user_id],
+             name: :am_teacher_feedback_mentor_idx
+           )
+
+    create unique_index(:acad_mentorship_teacher_feedback, [:student_id, :program_id, :test_id],
+             where: "deleted_at IS NULL",
+             name: :am_teacher_feedback_active_unique
+           )
+
+    create table(:acad_mentorship_cutoff_rows, primary_key: false) do
+      identity_primary_key()
+
+      add :category, :string, null: false
+      add :exam, :string, null: false
+      add :qualification_cutoff, :integer, null: false
+      add :nit_cutoff, :integer, null: false
+
+      created_updated_timestamps()
+    end
+
+    create constraint(:acad_mentorship_cutoff_rows, :am_cutoff_rows_scores_check,
+             check: "qualification_cutoff >= 0 AND nit_cutoff >= 0"
+           )
+
+    create unique_index(:acad_mentorship_cutoff_rows, [:category, :exam],
+             name: :am_cutoff_rows_category_exam_unique
+           )
+
+    create table(:acad_mentorship_benchmark_students, primary_key: false) do
+      identity_primary_key()
+
+      add :student_id, references(:student, on_delete: :nothing), null: false
+      add :program_id, references(:program, on_delete: :nothing), null: false
+      add :reason, :text
+      add :benchmark_label, :string
+      add :is_active, :boolean, default: true, null: false
+
+      created_updated_timestamps()
+    end
+
+    create index(:acad_mentorship_benchmark_students, [:student_id],
+             name: :am_benchmark_students_student_idx
+           )
+
+    create index(:acad_mentorship_benchmark_students, [:program_id],
+             name: :am_benchmark_students_program_idx
+           )
+
+    create unique_index(:acad_mentorship_benchmark_students, [:student_id, :program_id],
+             where: "is_active IS TRUE",
+             name: :am_benchmark_students_active_unique
+           )
+
+    create table(:acad_mentorship_reference_reports, primary_key: false) do
+      identity_primary_key()
+
+      add :benchmark_student_id,
+          references(:acad_mentorship_benchmark_students, on_delete: :nothing),
+          null: false
+
+      add :version_number, :integer, null: false
+      add :s3_key, :text, null: false
+      add :status, :string, default: "draft", null: false
+      add :approved_at, :utc_datetime
+
+      created_updated_timestamps()
+    end
+
+    create constraint(:acad_mentorship_reference_reports, :am_reference_reports_status_check,
+             check: "status IN ('draft', 'approved', 'archived')"
+           )
+
+    create constraint(:acad_mentorship_reference_reports, :am_reference_reports_version_check,
+             check: "version_number >= 1"
+           )
+
+    create index(:acad_mentorship_reference_reports, [:benchmark_student_id],
+             name: :am_reference_reports_benchmark_idx
+           )
+
+    create unique_index(
+             :acad_mentorship_reference_reports,
+             [:benchmark_student_id, :version_number],
+             name: :am_reference_reports_benchmark_version_unique
+           )
+
+    create unique_index(:acad_mentorship_reference_reports, [:s3_key],
+             name: :am_reference_reports_s3_key_unique
+           )
+
+    create unique_index(:acad_mentorship_reference_reports, [:benchmark_student_id],
+             where: "status = 'approved'",
+             name: :am_reference_reports_one_approved
+           )
+
+    create table(:acad_mentorship_inference_sessions, primary_key: false) do
+      identity_primary_key()
+
+      add :program_id, references(:program, on_delete: :nothing)
+      add :status, :string, default: "created", null: false
+      add :is_eval, :boolean, default: false, null: false
+
+      add :pipeline_prompt_version_id,
+          references(:acad_mentorship_prompt_versions,
+            on_delete: :nothing,
+            name: :am_sessions_pipeline_prompt_fkey
+          )
+
+      add :validation_prompt_version_id,
+          references(:acad_mentorship_prompt_versions,
+            on_delete: :nothing,
+            name: :am_sessions_validation_prompt_fkey
+          )
+
+      add :config_snapshot_json, :text
+      add :error_type, :string
+      add :error_message, :text
+      add :started_at, :utc_datetime
+      add :cancel_requested_at, :utc_datetime
+      add :completed_at, :utc_datetime
+      add :deleted_at, :utc_datetime
+
+      created_updated_timestamps()
+    end
+
+    create constraint(:acad_mentorship_inference_sessions, :am_sessions_status_check,
+             check:
+               "status IN ('created', 'running', 'completed', 'completed_with_errors', 'errored', 'cancelled')"
+           )
+
+    create index(:acad_mentorship_inference_sessions, [:program_id],
+             name: :am_sessions_program_idx
+           )
+
+    create index(:acad_mentorship_inference_sessions, [:status], name: :am_sessions_status_idx)
+
+    create index(:acad_mentorship_inference_sessions, [:is_eval], name: :am_sessions_is_eval_idx)
+
+    create index(:acad_mentorship_inference_sessions, [:created_at, :id],
+             name: :am_sessions_created_id_idx
+           )
+
+    create index(:acad_mentorship_inference_sessions, [:pipeline_prompt_version_id],
+             name: :am_sessions_pipeline_prompt_idx
+           )
+
+    create index(:acad_mentorship_inference_sessions, [:validation_prompt_version_id],
+             name: :am_sessions_validation_prompt_idx
+           )
+
+    create table(:acad_mentorship_inference_items, primary_key: false) do
+      identity_primary_key()
+
+      add :session_id,
+          references(:acad_mentorship_inference_sessions, on_delete: :nothing),
+          null: false
+
+      add :student_id, references(:student, on_delete: :nothing), null: false
+      add :status, :string, default: "created", null: false
+      add :current_step, :string
+      add :latest_test_id, :string
+      add :selected_test_ids, :map
+      add :pipeline_prompt_tokens, :integer, default: 0, null: false
+      add :pipeline_completion_tokens, :integer, default: 0, null: false
+      add :pipeline_total_tokens, :integer, default: 0, null: false
+      add :validation_prompt_tokens, :integer, default: 0, null: false
+      add :validation_completion_tokens, :integer, default: 0, null: false
+      add :validation_total_tokens, :integer, default: 0, null: false
+      add :pipeline_cost_usd, :float, default: 0.0, null: false
+      add :validation_cost_usd, :float, default: 0.0, null: false
+      add :validation_verdict, :string
+      add :error_message, :text
+      add :error_type, :string
+      add :no_data_reason, :string
+      add :is_retry, :boolean, default: false, null: false
+      add :retry_of_item_id, references(:acad_mentorship_inference_items, on_delete: :nothing)
+      add :duration_ms, :integer
+      add :started_at, :utc_datetime
+      add :last_progress_at, :utc_datetime
+      add :completed_at, :utc_datetime
+
+      created_updated_timestamps()
+    end
+
+    create constraint(:acad_mentorship_inference_items, :am_items_status_check,
+             check:
+               "status IN ('created', 'running', 'completed', 'errored', 'no_data', 'validation_failed', 'cancelled')"
+           )
+
+    create constraint(:acad_mentorship_inference_items, :am_items_validation_verdict_check,
+             check:
+               "validation_verdict IS NULL OR validation_verdict IN ('PASS', 'FAIL', 'PASS WITH WARNINGS')"
+           )
+
+    create constraint(:acad_mentorship_inference_items, :am_items_token_counts_check,
+             check:
+               "pipeline_prompt_tokens >= 0 AND pipeline_completion_tokens >= 0 AND pipeline_total_tokens >= 0 AND validation_prompt_tokens >= 0 AND validation_completion_tokens >= 0 AND validation_total_tokens >= 0"
+           )
+
+    create constraint(:acad_mentorship_inference_items, :am_items_costs_check,
+             check: "pipeline_cost_usd >= 0 AND validation_cost_usd >= 0"
+           )
+
+    create constraint(:acad_mentorship_inference_items, :am_items_duration_check,
+             check: "duration_ms IS NULL OR duration_ms >= 0"
+           )
+
+    create index(:acad_mentorship_inference_items, [:session_id], name: :am_items_session_idx)
+
+    create index(:acad_mentorship_inference_items, [:student_id], name: :am_items_student_idx)
+
+    create index(:acad_mentorship_inference_items, [:status], name: :am_items_status_idx)
+
+    create index(:acad_mentorship_inference_items, [:latest_test_id],
+             name: :am_items_latest_test_idx
+           )
+
+    create index(:acad_mentorship_inference_items, [:retry_of_item_id],
+             name: :am_items_retry_of_idx
+           )
+
+    create index(:acad_mentorship_inference_items, [:created_at, :id],
+             name: :am_items_created_id_idx
+           )
+
+    create unique_index(:acad_mentorship_inference_items, [:session_id, :student_id],
+             where: "is_retry IS FALSE",
+             name: :am_items_original_student_unique
+           )
+
+    create table(:acad_mentorship_inference_item_files, primary_key: false) do
+      identity_primary_key()
+
+      add :item_id,
+          references(:acad_mentorship_inference_items, on_delete: :delete_all),
+          null: false
+
+      add :logical_path, :text, null: false
+      add :file_kind, :string, default: "workspace_file", null: false
+      add :s3_key, :text, null: false
+      add :mime_type, :string, null: false
+      add :byte_size, :bigint, null: false
+      add :sha256, :string
+      add :uploaded_at, :utc_datetime, default: fragment("now()"), null: false
+    end
+
+    create constraint(:acad_mentorship_inference_item_files, :am_item_files_byte_size_check,
+             check: "byte_size >= 0"
+           )
+
+    create index(:acad_mentorship_inference_item_files, [:item_id], name: :am_item_files_item_idx)
+
+    create index(:acad_mentorship_inference_item_files, [:logical_path],
+             name: :am_item_files_logical_path_idx
+           )
+
+    create index(:acad_mentorship_inference_item_files, [:file_kind],
+             name: :am_item_files_file_kind_idx
+           )
+
+    create index(:acad_mentorship_inference_item_files, [:item_id, :file_kind],
+             name: :am_item_files_item_kind_idx
+           )
+
+    create unique_index(:acad_mentorship_inference_item_files, [:item_id, :logical_path],
+             name: :am_item_files_item_path_unique
+           )
+
+    create unique_index(:acad_mentorship_inference_item_files, [:s3_key],
+             name: :am_item_files_s3_key_unique
+           )
+
+    create table(:acad_mentorship_scoring_criteria, primary_key: false) do
+      identity_primary_key()
+
+      add :criterion_key, :string, null: false
+      add :version_number, :integer, default: 1, null: false
+      add :name, :string, null: false
+      add :description, :text, null: false
+      add :weight, :float, default: 1.0, null: false
+      add :sort_order, :integer, default: 0, null: false
+      add :is_active, :boolean, default: true, null: false
+
+      created_updated_timestamps()
+    end
+
+    create constraint(:acad_mentorship_scoring_criteria, :am_scoring_criteria_values_check,
+             check: "version_number >= 1 AND weight >= 0"
+           )
+
+    create unique_index(:acad_mentorship_scoring_criteria, [:criterion_key, :version_number],
+             name: :am_scoring_criteria_key_version_unique
+           )
+
+    create unique_index(:acad_mentorship_scoring_criteria, [:criterion_key],
+             where: "is_active IS TRUE",
+             name: :am_scoring_criteria_one_active
+           )
+
+    create index(:acad_mentorship_scoring_criteria, [:sort_order],
+             name: :am_scoring_criteria_sort_order_idx
+           )
+
+    create table(:acad_mentorship_eval_runs, primary_key: false) do
+      identity_primary_key()
+
+      add :session_id,
+          references(:acad_mentorship_inference_sessions, on_delete: :nothing),
+          null: false
+
+      add :status, :string, default: "created", null: false
+
+      add :scoring_prompt_version_id,
+          references(:acad_mentorship_prompt_versions, on_delete: :nothing)
+
+      add :config_snapshot_json, :text
+      add :error_type, :string
+      add :error_message, :text
+      add :completed_at, :utc_datetime
+
+      created_updated_timestamps()
+    end
+
+    create constraint(:acad_mentorship_eval_runs, :am_eval_runs_status_check,
+             check:
+               "status IN ('created', 'pipeline_running', 'scoring', 'completed', 'completed_with_errors', 'errored', 'cancelled')"
+           )
+
+    create unique_index(:acad_mentorship_eval_runs, [:session_id],
+             name: :am_eval_runs_session_unique
+           )
+
+    create index(:acad_mentorship_eval_runs, [:status], name: :am_eval_runs_status_idx)
+
+    create index(:acad_mentorship_eval_runs, [:created_at, :id],
+             name: :am_eval_runs_created_id_idx
+           )
+
+    create index(:acad_mentorship_eval_runs, [:scoring_prompt_version_id],
+             name: :am_eval_runs_scoring_prompt_idx
+           )
+
+    create table(:acad_mentorship_eval_run_benchmarks, primary_key: false) do
+      identity_primary_key()
+
+      add :eval_run_id, references(:acad_mentorship_eval_runs, on_delete: :delete_all),
+        null: false
+
+      add :benchmark_student_id,
+          references(:acad_mentorship_benchmark_students, on_delete: :nothing),
+          null: false
+
+      add :reference_report_id,
+          references(:acad_mentorship_reference_reports, on_delete: :nothing)
+
+      add :scored_item_id, references(:acad_mentorship_inference_items, on_delete: :nothing)
+      add :scoring_status, :string, default: "pending", null: false
+      add :scoring_error, :text
+      add :scoring_attempt_count, :integer, default: 0, null: false
+      add :scoring_prompt_tokens, :integer, default: 0, null: false
+      add :scoring_completion_tokens, :integer, default: 0, null: false
+      add :scoring_total_tokens, :integer, default: 0, null: false
+      add :scoring_cost_usd, :float, default: 0.0, null: false
+      add :scoring_started_at, :utc_datetime
+      add :scoring_completed_at, :utc_datetime
+
+      created_updated_timestamps()
+    end
+
+    create constraint(:acad_mentorship_eval_run_benchmarks, :am_eval_benchmarks_status_check,
+             check: "scoring_status IN ('pending', 'scored', 'skipped', 'errored')"
+           )
+
+    create constraint(:acad_mentorship_eval_run_benchmarks, :am_eval_benchmarks_counts_check,
+             check:
+               "scoring_attempt_count >= 0 AND scoring_prompt_tokens >= 0 AND scoring_completion_tokens >= 0 AND scoring_total_tokens >= 0 AND scoring_cost_usd >= 0"
+           )
+
+    create unique_index(
+             :acad_mentorship_eval_run_benchmarks,
+             [:eval_run_id, :benchmark_student_id],
+             name: :am_eval_benchmarks_run_student_unique
+           )
+
+    create index(:acad_mentorship_eval_run_benchmarks, [:eval_run_id],
+             name: :am_eval_benchmarks_run_idx
+           )
+
+    create index(:acad_mentorship_eval_run_benchmarks, [:benchmark_student_id],
+             name: :am_eval_benchmarks_student_idx
+           )
+
+    create index(:acad_mentorship_eval_run_benchmarks, [:reference_report_id],
+             name: :am_eval_benchmarks_reference_idx
+           )
+
+    create index(:acad_mentorship_eval_run_benchmarks, [:scored_item_id],
+             name: :am_eval_benchmarks_item_idx
+           )
+
+    create index(:acad_mentorship_eval_run_benchmarks, [:scoring_status],
+             name: :am_eval_benchmarks_status_idx
+           )
+
+    create table(:acad_mentorship_eval_run_scoring_criteria, primary_key: false) do
+      identity_primary_key()
+
+      add :eval_run_id, references(:acad_mentorship_eval_runs, on_delete: :delete_all),
+        null: false
+
+      add :scoring_criterion_id,
+          references(:acad_mentorship_scoring_criteria,
+            on_delete: :nothing,
+            name: :am_eval_run_criteria_criterion_fkey
+          ),
+          null: false
+
+      add :created_at, :utc_datetime, default: fragment("now()"), null: false
+    end
+
+    create unique_index(
+             :acad_mentorship_eval_run_scoring_criteria,
+             [:eval_run_id, :scoring_criterion_id],
+             name: :am_eval_run_criteria_unique
+           )
+
+    create index(:acad_mentorship_eval_run_scoring_criteria, [:eval_run_id],
+             name: :am_eval_run_criteria_run_idx
+           )
+
+    create index(:acad_mentorship_eval_run_scoring_criteria, [:scoring_criterion_id],
+             name: :am_eval_run_criteria_criterion_idx
+           )
+
+    create table(:acad_mentorship_eval_scores, primary_key: false) do
+      identity_primary_key()
+
+      add :eval_run_benchmark_id,
+          references(:acad_mentorship_eval_run_benchmarks, on_delete: :delete_all),
+          null: false
+
+      add :eval_run_id, references(:acad_mentorship_eval_runs, on_delete: :delete_all)
+      add :item_id, references(:acad_mentorship_inference_items, on_delete: :nothing), null: false
+
+      add :scoring_criterion_id,
+          references(:acad_mentorship_scoring_criteria, on_delete: :nothing),
+          null: false
+
+      add :score, :integer, null: false
+      add :justification, :text, null: false
+      add :human_score, :integer
+      add :human_justification, :text
+      add :is_superseded, :boolean, default: false, null: false
+
+      created_updated_timestamps()
+    end
+
+    create constraint(:acad_mentorship_eval_scores, :am_eval_scores_score_check,
+             check:
+               "score BETWEEN 1 AND 5 AND (human_score IS NULL OR human_score BETWEEN 1 AND 5)"
+           )
+
+    create index(:acad_mentorship_eval_scores, [:eval_run_benchmark_id],
+             name: :am_eval_scores_benchmark_idx
+           )
+
+    create index(:acad_mentorship_eval_scores, [:eval_run_id], name: :am_eval_scores_run_idx)
+
+    create index(:acad_mentorship_eval_scores, [:item_id], name: :am_eval_scores_item_idx)
+
+    create index(:acad_mentorship_eval_scores, [:scoring_criterion_id],
+             name: :am_eval_scores_criterion_idx
+           )
+
+    create unique_index(
+             :acad_mentorship_eval_scores,
+             [:eval_run_benchmark_id, :scoring_criterion_id],
+             where: "is_superseded IS FALSE",
+             name: :am_eval_scores_active_unique
+           )
+  end
+
+  defp identity_primary_key do
+    add :id, :identity, primary_key: true
+  end
+
+  defp created_updated_timestamps do
+    add :created_at, :utc_datetime, default: fragment("now()"), null: false
+    add :updated_at, :utc_datetime, default: fragment("now()"), null: false
+  end
+end

--- a/priv/repo/migrations/20260616100000_create_academic_mentorship_tables.exs
+++ b/priv/repo/migrations/20260616100000_create_academic_mentorship_tables.exs
@@ -27,6 +27,15 @@ defmodule Dbservice.Repo.Migrations.CreateAcademicMentorshipTables do
                "(concurrency IS NULL OR concurrency >= 1) AND (timeout_seconds IS NULL OR timeout_seconds >= 0) AND (validation_timeout_seconds IS NULL OR validation_timeout_seconds >= 0)"
            )
 
+    execute(
+      """
+      INSERT INTO acad_mentorship_runtime_settings (id, created_at, updated_at)
+      VALUES ('global', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+      ON CONFLICT (id) DO NOTHING
+      """,
+      "DELETE FROM acad_mentorship_runtime_settings WHERE id = 'global'"
+    )
+
     create table(:acad_mentorship_prompt_versions, primary_key: false) do
       identity_primary_key()
 

--- a/priv/repo/migrations/20260616173000_allow_scoring_status_in_eval_run_benchmarks.exs
+++ b/priv/repo/migrations/20260616173000_allow_scoring_status_in_eval_run_benchmarks.exs
@@ -1,0 +1,29 @@
+defmodule Dbservice.Repo.Migrations.AllowScoringStatusInEvalRunBenchmarks do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    ALTER TABLE acad_mentorship_eval_run_benchmarks
+    DROP CONSTRAINT IF EXISTS am_eval_benchmarks_status_check
+    """)
+
+    execute("""
+    ALTER TABLE acad_mentorship_eval_run_benchmarks
+    ADD CONSTRAINT am_eval_benchmarks_status_check
+    CHECK (scoring_status IN ('pending', 'scoring', 'scored', 'skipped', 'errored'))
+    """)
+  end
+
+  def down do
+    execute("""
+    ALTER TABLE acad_mentorship_eval_run_benchmarks
+    DROP CONSTRAINT IF EXISTS am_eval_benchmarks_status_check
+    """)
+
+    execute("""
+    ALTER TABLE acad_mentorship_eval_run_benchmarks
+    ADD CONSTRAINT am_eval_benchmarks_status_check
+    CHECK (scoring_status IN ('pending', 'scored', 'skipped', 'errored'))
+    """)
+  end
+end

--- a/test/dbservice/academic_mentorship_schema_test.exs
+++ b/test/dbservice/academic_mentorship_schema_test.exs
@@ -160,6 +160,9 @@ defmodule Dbservice.AcademicMentorshipSchemaTest do
                "acad_mentorship_eval_run_benchmarks"
              )
 
+      assert check_def("acad_mentorship_eval_run_benchmarks", "am_eval_benchmarks_status_check") =~
+               "'scoring'::character varying"
+
       assert "am_eval_scores_score_check" in check_names("acad_mentorship_eval_scores")
     end
 
@@ -271,6 +274,23 @@ defmodule Dbservice.AcademicMentorshipSchemaTest do
       [table]
     ).rows
     |> Enum.map(fn [name] -> name end)
+  end
+
+  defp check_def(table, constraint_name) do
+    Repo.query!(
+      """
+      SELECT pg_get_constraintdef(c.oid)
+      FROM pg_constraint c
+      JOIN pg_class t ON t.oid = c.conrelid
+      JOIN pg_namespace n ON n.oid = t.relnamespace
+      WHERE n.nspname = 'public'
+        AND t.relname = $1
+        AND c.conname = $2
+      """,
+      [table, constraint_name]
+    ).rows
+    |> List.first()
+    |> then(fn [definition] -> definition end)
   end
 
   defp foreign_keys(table) do

--- a/test/dbservice/academic_mentorship_schema_test.exs
+++ b/test/dbservice/academic_mentorship_schema_test.exs
@@ -47,6 +47,20 @@ defmodule Dbservice.AcademicMentorshipSchemaTest do
              |> Enum.member?("am_runtime_settings_singleton_check")
     end
 
+    test "seeds the singleton runtime settings row" do
+      result =
+        Repo.query!(
+          """
+          SELECT id
+          FROM acad_mentorship_runtime_settings
+          WHERE id = 'global'
+          """,
+          []
+        )
+
+      assert result.rows == [["global"]]
+    end
+
     test "exposes core workflow columns expected by AI Mentorship Guide" do
       assert_required_columns("acad_mentorship_inference_sessions", [
         "id",

--- a/test/dbservice/academic_mentorship_schema_test.exs
+++ b/test/dbservice/academic_mentorship_schema_test.exs
@@ -1,0 +1,287 @@
+defmodule Dbservice.AcademicMentorshipSchemaTest do
+  use Dbservice.DataCase, async: true
+
+  @tables [
+    "acad_mentorship_runtime_settings",
+    "acad_mentorship_prompt_versions",
+    "acad_mentorship_tests_to_consider",
+    "acad_mentorship_teacher_feedback",
+    "acad_mentorship_cutoff_rows",
+    "acad_mentorship_benchmark_students",
+    "acad_mentorship_reference_reports",
+    "acad_mentorship_inference_sessions",
+    "acad_mentorship_inference_items",
+    "acad_mentorship_inference_item_files",
+    "acad_mentorship_scoring_criteria",
+    "acad_mentorship_eval_runs",
+    "acad_mentorship_eval_run_benchmarks",
+    "acad_mentorship_eval_run_scoring_criteria",
+    "acad_mentorship_eval_scores"
+  ]
+
+  @identity_tables @tables -- ["acad_mentorship_runtime_settings"]
+
+  describe "Academic Mentorship schema" do
+    test "creates the full phase-1 table set" do
+      existing_tables = table_names()
+
+      for table <- @tables do
+        assert table in existing_tables
+      end
+    end
+
+    test "uses identity bigint primary keys for workflow tables" do
+      for table <- @identity_tables do
+        id = columns(table)["id"]
+
+        assert id.type == "bigint", "#{table}.id should be bigint"
+        assert id.identity?, "#{table}.id should be generated identity"
+        refute id.nullable?, "#{table}.id should be required"
+      end
+
+      runtime_id = columns("acad_mentorship_runtime_settings")["id"]
+      assert runtime_id.type == "character varying"
+      refute runtime_id.nullable?
+
+      assert check_names("acad_mentorship_runtime_settings")
+             |> Enum.member?("am_runtime_settings_singleton_check")
+    end
+
+    test "exposes core workflow columns expected by AI Mentorship Guide" do
+      assert_required_columns("acad_mentorship_inference_sessions", [
+        "id",
+        "status",
+        "is_eval",
+        "created_at",
+        "updated_at"
+      ])
+
+      assert Map.keys(columns("acad_mentorship_inference_items")) |> Enum.sort() == [
+               "completed_at",
+               "created_at",
+               "current_step",
+               "duration_ms",
+               "error_message",
+               "error_type",
+               "id",
+               "is_retry",
+               "last_progress_at",
+               "latest_test_id",
+               "no_data_reason",
+               "pipeline_completion_tokens",
+               "pipeline_cost_usd",
+               "pipeline_prompt_tokens",
+               "pipeline_total_tokens",
+               "retry_of_item_id",
+               "selected_test_ids",
+               "session_id",
+               "started_at",
+               "status",
+               "student_id",
+               "updated_at",
+               "validation_completion_tokens",
+               "validation_cost_usd",
+               "validation_prompt_tokens",
+               "validation_total_tokens",
+               "validation_verdict"
+             ]
+
+      assert_required_columns("acad_mentorship_inference_items", [
+        "id",
+        "session_id",
+        "student_id",
+        "status",
+        "is_retry",
+        "pipeline_cost_usd",
+        "validation_cost_usd",
+        "created_at",
+        "updated_at"
+      ])
+
+      assert columns("acad_mentorship_teacher_feedback")["feedback"].type == "jsonb"
+      assert columns("acad_mentorship_inference_items")["selected_test_ids"].type == "jsonb"
+      assert columns("acad_mentorship_inference_item_files")["byte_size"].type == "bigint"
+    end
+
+    test "adds foreign keys between existing Main DB tables and mentorship tables" do
+      assert {"program_id", "program", "id"} in foreign_keys("acad_mentorship_inference_sessions")
+      assert {"student_id", "student", "id"} in foreign_keys("acad_mentorship_inference_items")
+
+      assert {"session_id", "acad_mentorship_inference_sessions", "id"} in foreign_keys(
+               "acad_mentorship_inference_items"
+             )
+
+      assert {"item_id", "acad_mentorship_inference_items", "id"} in foreign_keys(
+               "acad_mentorship_inference_item_files"
+             )
+
+      assert {"benchmark_student_id", "acad_mentorship_benchmark_students", "id"} in foreign_keys(
+               "acad_mentorship_reference_reports"
+             )
+
+      assert {"eval_run_id", "acad_mentorship_eval_runs", "id"} in foreign_keys(
+               "acad_mentorship_eval_run_benchmarks"
+             )
+
+      assert {"scoring_criterion_id", "acad_mentorship_scoring_criteria", "id"} in foreign_keys(
+               "acad_mentorship_eval_scores"
+             )
+    end
+
+    test "adds the required status, range, and lifecycle check constraints" do
+      assert "am_sessions_status_check" in check_names("acad_mentorship_inference_sessions")
+      assert "am_items_status_check" in check_names("acad_mentorship_inference_items")
+      assert "am_items_validation_verdict_check" in check_names("acad_mentorship_inference_items")
+      assert "am_items_token_counts_check" in check_names("acad_mentorship_inference_items")
+      assert "am_items_costs_check" in check_names("acad_mentorship_inference_items")
+      assert "am_prompt_versions_type_check" in check_names("acad_mentorship_prompt_versions")
+
+      assert "am_reference_reports_status_check" in check_names(
+               "acad_mentorship_reference_reports"
+             )
+
+      assert "am_eval_runs_status_check" in check_names("acad_mentorship_eval_runs")
+
+      assert "am_eval_benchmarks_status_check" in check_names(
+               "acad_mentorship_eval_run_benchmarks"
+             )
+
+      assert "am_eval_scores_score_check" in check_names("acad_mentorship_eval_scores")
+    end
+
+    test "adds active-row and lookup indexes" do
+      assert index_def("am_tests_to_consider_active_unique") =~ "WHERE (deleted_at IS NULL)"
+      assert index_def("am_teacher_feedback_active_unique") =~ "WHERE (deleted_at IS NULL)"
+      assert index_def("am_prompt_versions_one_active") =~ "WHERE"
+      assert index_def("am_benchmark_students_active_unique") =~ "WHERE (is_active IS TRUE)"
+      assert index_def("am_reference_reports_one_approved") =~ "WHERE"
+      assert index_def("am_items_original_student_unique") =~ "WHERE (is_retry IS FALSE)"
+      assert index_def("am_eval_scores_active_unique") =~ "WHERE (is_superseded IS FALSE)"
+
+      assert ["session_id"] in indexes("acad_mentorship_inference_items")
+      assert ["student_id"] in indexes("acad_mentorship_inference_items")
+      assert ["item_id", "file_kind"] in indexes("acad_mentorship_inference_item_files")
+      assert ["status"] in indexes("acad_mentorship_eval_runs")
+      assert ["scoring_status"] in indexes("acad_mentorship_eval_run_benchmarks")
+    end
+  end
+
+  defp assert_required_columns(table, names) do
+    table_columns = columns(table)
+
+    for name <- names do
+      refute table_columns[name].nullable?, "#{table}.#{name} should be NOT NULL"
+    end
+  end
+
+  defp table_names do
+    Repo.query!(
+      """
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_schema = 'public'
+      """,
+      []
+    ).rows
+    |> Enum.map(fn [name] -> name end)
+  end
+
+  defp columns(table) do
+    Repo.query!(
+      """
+      SELECT column_name, is_nullable, data_type, udt_name, is_identity
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = $1
+      ORDER BY column_name
+      """,
+      [table]
+    ).rows
+    |> Map.new(fn [name, nullable, type, udt_name, identity] ->
+      type_name = if type == "USER-DEFINED", do: udt_name, else: type
+
+      {name, %{nullable?: nullable == "YES", type: type_name, identity?: identity == "YES"}}
+    end)
+  end
+
+  defp indexes(table) do
+    table
+    |> index_rows()
+    |> Enum.map(fn {_name, _unique?, columns} -> columns end)
+  end
+
+  defp index_rows(table) do
+    Repo.query!(
+      """
+      SELECT
+        i.relname,
+        ix.indisunique,
+        array_agg(a.attname ORDER BY array_position(ix.indkey::int[], a.attnum)) AS columns
+      FROM pg_class t
+      JOIN pg_index ix ON t.oid = ix.indrelid
+      JOIN pg_class i ON i.oid = ix.indexrelid
+      JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
+      WHERE t.relname = $1
+      GROUP BY i.relname, ix.indisunique
+      ORDER BY i.relname
+      """,
+      [table]
+    ).rows
+    |> Enum.map(fn [name, unique?, columns] ->
+      {name, unique?, columns}
+    end)
+  end
+
+  defp index_def(index_name) do
+    Repo.query!(
+      """
+      SELECT indexdef
+      FROM pg_indexes
+      WHERE schemaname = 'public' AND indexname = $1
+      """,
+      [index_name]
+    ).rows
+    |> List.first()
+    |> then(fn [definition] -> definition end)
+  end
+
+  defp check_names(table) do
+    Repo.query!(
+      """
+      SELECT tc.constraint_name
+      FROM information_schema.table_constraints tc
+      WHERE tc.constraint_type = 'CHECK'
+        AND tc.table_schema = 'public'
+        AND tc.table_name = $1
+      ORDER BY tc.constraint_name
+      """,
+      [table]
+    ).rows
+    |> Enum.map(fn [name] -> name end)
+  end
+
+  defp foreign_keys(table) do
+    Repo.query!(
+      """
+      SELECT
+        kcu.column_name,
+        ccu.table_name AS foreign_table_name,
+        ccu.column_name AS foreign_column_name
+      FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+        ON tc.constraint_name = kcu.constraint_name
+        AND tc.table_schema = kcu.table_schema
+      JOIN information_schema.constraint_column_usage ccu
+        ON ccu.constraint_name = tc.constraint_name
+        AND ccu.table_schema = tc.table_schema
+      WHERE tc.constraint_type = 'FOREIGN KEY'
+        AND tc.table_schema = 'public'
+        AND tc.table_name = $1
+      ORDER BY kcu.column_name
+      """,
+      [table]
+    ).rows
+    |> Enum.map(fn [column, foreign_table, foreign_column] ->
+      {column, foreign_table, foreign_column}
+    end)
+  end
+end


### PR DESCRIPTION
## Summary

- Adds the phase-1 Academic Mentorship `acad_mentorship_*` table migrations for Main DB storage.
- Adds FKs to existing `program`, `student`, and `user` tables plus FKs across the new mentorship workflow/config/eval tables.
- Adds status/range checks, partial active-row unique indexes, file/eval lookup indexes, and generated identity bigint IDs for workflow tables.
- Keeps `acad_mentorship_runtime_settings.id = 'global'` as a singleton text primary key to match the merged AI Mentorship Guide app contract.
- Adds a schema-level test covering tables, identity PKs, required columns, FKs, checks, and partial indexes.

## Related

Closes #552
Refs avantifellows/ai-mentorship-guide#86
Refs avantifellows/ai-mentorship-guide#99

## Test plan

- [x] `mix test test/dbservice/academic_mentorship_schema_test.exs`
- [x] `MIX_ENV=test mix ecto.rollback --step 1 && MIX_ENV=test mix ecto.migrate`
- [x] `mix format --check-formatted`
- [x] `mix check`
- [ ] `mix test` full suite currently has 8 pre-existing failures unrelated to this migration: error JSON 422 text, group update not-found message expectations, student controller response status expectations, and enrollment service existing-school behavior.