### PR TITLE
feat(gurukul-config): add auth_group layer to resolution chain

### DIFF
--- a/lib/dbservice/services/gurukul_config_service.ex
+++ b/lib/dbservice/services/gurukul_config_service.ex
@@ -2,14 +2,20 @@ defmodule Dbservice.Services.GurukulConfigService do
   @moduledoc """
   Resolves Gurukul UI configuration by merging config along the fallback chain:
 
-      defaultgroup  <-  program  <-  batch       (later layers win)
+      defaultgroup  <-  auth_group  <-  program  <-  batch    (later layers win)
 
   Each layer namespaces its Gurukul config under the `"gurukul_config"` key so
   the same column can hold config for other modules (CMS, LMS, etc.) without
   collision:
     * defaultgroup: the `DefaultGroup` auth_group's `locale_data["gurukul_config"]`
+    * auth_group:   the user's current auth_group's `locale_data["gurukul_config"]` (e.g. EnableSchools)
     * program:      `program.config["gurukul_config"]`
     * batch:        `batch.metadata["gurukul_config"]`
+
+  The `auth_group` layer only applies when resolving for a user: a user enrolled
+  in an auth group (but no batch/program) picks up that group's config instead of
+  falling straight through to defaultgroup. `resolve_for_batch/1` and
+  `resolve_for_program/1` have no user context, so they skip this layer.
 
   When a user belongs to multiple current batches (or programs), the oldest
   enrollment (earliest `start_date`) wins, per the agreed resolution rule:
@@ -35,34 +41,62 @@ defmodule Dbservice.Services.GurukulConfigService do
   batch (falling back to their oldest current program, then defaultgroup).
   """
   def resolve_for_user(user_id) do
-    base = default_config()
+    {base, auth_group_id} = user_base_config(user_id)
 
     case oldest_current_enrollment(user_id, "batch") do
       %EnrollmentRecord{group_id: batch_id} ->
-        resolve_from_batch(batch_id, base)
+        resolve_from_batch(batch_id, base, auth_group_id)
 
       nil ->
         case oldest_current_enrollment(user_id, "program") do
-          %EnrollmentRecord{group_id: program_id} -> resolve_from_program(program_id, base)
-          nil -> {base, %{source: "defaultgroup", batch_id: nil, program_id: nil}}
+          %EnrollmentRecord{group_id: program_id} ->
+            resolve_from_program(program_id, base, auth_group_id)
+
+          nil ->
+            {base, base_resolved_from(auth_group_id)}
         end
     end
   end
 
   @doc """
   Resolves config for a batch directly: batch <- program <- defaultgroup.
+
+  No user context, so the auth_group layer is skipped.
   """
-  def resolve_for_batch(batch_id), do: resolve_from_batch(batch_id, default_config())
+  def resolve_for_batch(batch_id), do: resolve_from_batch(batch_id, default_config(), nil)
 
   @doc """
   Resolves config for a program directly: program <- defaultgroup.
-  """
-  def resolve_for_program(program_id), do: resolve_from_program(program_id, default_config())
 
-  defp resolve_from_batch(batch_id, base) do
+  No user context, so the auth_group layer is skipped.
+  """
+  def resolve_for_program(program_id), do: resolve_from_program(program_id, default_config(), nil)
+
+  # Builds the base config for a user: defaultgroup overlaid with the user's
+  # current auth_group config (e.g. EnableSchools). Returns {config, auth_group_id}
+  # where auth_group_id is nil when the user has no current auth_group enrollment.
+  defp user_base_config(user_id) do
+    base = default_config()
+
+    case oldest_current_enrollment(user_id, "auth_group") do
+      %EnrollmentRecord{group_id: auth_group_id} ->
+        case Repo.get(AuthGroup, auth_group_id) do
+          %AuthGroup{locale_data: locale_data} ->
+            {Map.merge(base, gurukul_section(locale_data)), auth_group_id}
+
+          _ ->
+            {base, nil}
+        end
+
+      nil ->
+        {base, nil}
+    end
+  end
+
+  defp resolve_from_batch(batch_id, base, auth_group_id) do
     case Repo.get(Batch, batch_id) do
       nil ->
-        {base, %{source: "defaultgroup", batch_id: nil, program_id: nil}}
+        {base, base_resolved_from(auth_group_id)}
 
       %Batch{} = batch ->
         program_config =
@@ -74,20 +108,35 @@ defmodule Dbservice.Services.GurukulConfigService do
         batch_config = gurukul_section(batch.metadata)
 
         merged = base |> Map.merge(program_config) |> Map.merge(batch_config)
-        {merged, %{source: "batch", batch_id: batch.id, program_id: batch.program_id}}
+
+        {merged,
+         %{
+           source: "batch",
+           batch_id: batch.id,
+           program_id: batch.program_id,
+           auth_group_id: auth_group_id
+         }}
     end
   end
 
-  defp resolve_from_program(program_id, base) do
+  defp resolve_from_program(program_id, base, auth_group_id) do
     case Repo.get(Program, program_id) do
       nil ->
-        {base, %{source: "defaultgroup", batch_id: nil, program_id: nil}}
+        {base, base_resolved_from(auth_group_id)}
 
       %Program{} = program ->
         {Map.merge(base, gurukul_section(program.config)),
-         %{source: "program", batch_id: nil, program_id: program.id}}
+         %{source: "program", batch_id: nil, program_id: program.id, auth_group_id: auth_group_id}}
     end
   end
+
+  # The resolved_from for the base layer: reports "auth_group" when the user's
+  # auth_group config contributed, otherwise "defaultgroup".
+  defp base_resolved_from(nil),
+    do: %{source: "defaultgroup", batch_id: nil, program_id: nil, auth_group_id: nil}
+
+  defp base_resolved_from(auth_group_id),
+    do: %{source: "auth_group", batch_id: nil, program_id: nil, auth_group_id: auth_group_id}
 
   defp oldest_current_enrollment(user_id, group_type) do
     from(e in EnrollmentRecord,
@@ -105,8 +154,8 @@ defmodule Dbservice.Services.GurukulConfigService do
     end
   end
 
-  # Reads the namespaced Gurukul config out of a column map (program.config,
-  # batch.metadata, auth_group.input_schema), leaving other modules' keys alone.
+  # Reads the namespaced Gurukul config out of a column map (auth_group.locale_data,
+  # program.config, batch.metadata), leaving other modules' keys alone.
   defp gurukul_section(map) when is_map(map), do: Map.get(map, @config_key, %{})
   defp gurukul_section(_), do: %{}
 end

--- a/lib/dbservice_web/controllers/gurukul_config_controller.ex
+++ b/lib/dbservice_web/controllers/gurukul_config_controller.ex
@@ -12,8 +12,10 @@ defmodule DbserviceWeb.GurukulConfigController do
 
     description(
       "Resolves the merged Gurukul UI configuration using the fallback chain " <>
-        "batch -> program -> defaultgroup. Provide exactly one of user_id, batch_id " <>
-        "or program_id. For user_id the oldest current batch/program is used."
+        "batch -> program -> auth_group -> defaultgroup. Provide exactly one of " <>
+        "user_id, batch_id or program_id. For user_id the oldest current " <>
+        "batch/program is used, and the user's current auth_group config is " <>
+        "applied as a base layer (batch_id/program_id skip the auth_group layer)."
     )
 
     parameters do

--- a/test/dbservice/services/gurukul_config_service_test.exs
+++ b/test/dbservice/services/gurukul_config_service_test.exs
@@ -15,6 +15,10 @@ defmodule Dbservice.Services.GurukulConfigServiceTest do
     Repo.insert!(%AuthGroup{name: "DefaultGroup", locale_data: %{"gurukul_config" => config}})
   end
 
+  defp auth_group_fixture(name, config) do
+    Repo.insert!(%AuthGroup{name: name, locale_data: %{"gurukul_config" => config}})
+  end
+
   defp program_fixture(config) do
     product = product_fixture()
 
@@ -186,6 +190,87 @@ defmodule Dbservice.Services.GurukulConfigServiceTest do
       user = user_fixture()
 
       assert {%{}, %{source: "defaultgroup"}} = GurukulConfigService.resolve_for_user(user.id)
+    end
+
+    test "merges the user's auth_group config over defaultgroup when there is no batch/program" do
+      default_group_fixture(%{
+        "showTests" => true,
+        "showClassLibrary" => true,
+        "homeTabLabel" => "Home"
+      })
+
+      auth_group =
+        auth_group_fixture("EnableSchools", %{
+          "showClassLibrary" => false,
+          "testsSectionTitle" => "School Test"
+        })
+
+      user = user_fixture()
+      enroll(user, "auth_group", auth_group.id, ~D[2024-07-27])
+
+      {config, resolved_from} = GurukulConfigService.resolve_for_user(user.id)
+
+      assert config == %{
+               "showTests" => true,
+               "showClassLibrary" => false,
+               "homeTabLabel" => "Home",
+               "testsSectionTitle" => "School Test"
+             }
+
+      assert resolved_from.source == "auth_group"
+      assert resolved_from.auth_group_id == auth_group.id
+      assert resolved_from.batch_id == nil
+      assert resolved_from.program_id == nil
+    end
+
+    test "reports auth_group source even when the auth_group has no gurukul_config" do
+      default_group_fixture(%{"showTests" => true})
+      auth_group = Repo.insert!(%AuthGroup{name: "EnableSchools", locale_data: %{}})
+
+      user = user_fixture()
+      enroll(user, "auth_group", auth_group.id, ~D[2024-07-27])
+
+      {config, resolved_from} = GurukulConfigService.resolve_for_user(user.id)
+
+      assert config == %{"showTests" => true}
+      assert resolved_from.source == "auth_group"
+      assert resolved_from.auth_group_id == auth_group.id
+    end
+
+    test "batch wins over auth_group over defaultgroup" do
+      default_group_fixture(%{
+        "showTests" => true,
+        "showClassLibrary" => true,
+        "homeTabLabel" => "Home"
+      })
+
+      auth_group =
+        auth_group_fixture("EnableSchools", %{
+          "showClassLibrary" => false,
+          "homeTabLabel" => "School Home"
+        })
+
+      program = program_fixture(%{"testsSectionTitle" => "Program Test"})
+      batch = batch_fixture(program, %{"gurukul_config" => %{"homeTabLabel" => "Batch Home"}})
+
+      user = user_fixture()
+      enroll(user, "auth_group", auth_group.id, ~D[2024-07-27])
+      enroll(user, "batch", batch.id, ~D[2025-06-01])
+
+      {config, resolved_from} = GurukulConfigService.resolve_for_user(user.id)
+
+      assert config == %{
+               "showTests" => true,
+               # auth_group overrides defaultgroup
+               "showClassLibrary" => false,
+               # batch overrides auth_group
+               "homeTabLabel" => "Batch Home",
+               "testsSectionTitle" => "Program Test"
+             }
+
+      assert resolved_from.source == "batch"
+      assert resolved_from.batch_id == batch.id
+      assert resolved_from.auth_group_id == auth_group.id
     end
   end
 end


### PR DESCRIPTION
## Problem

`GET /api/gurukul-config?user_id=` resolves config via the chain `batch → program → defaultgroup`, but `resolve_for_user/1` only ever consulted **batch** and **program** enrollments. Users enrolled only in a `grade` + `auth_group` — which is how EnableSchools school students are set up — therefore **always** fell through to the `DefaultGroup` base, regardless of their auth group.

Concrete case: user `130659` (a school under code 14049, auth group EnableSchools) resolved to `source: "defaultgroup"` because their only current enrollments are `grade` and `auth_group` (id 10 = EnableSchools) — neither of which the resolver reads.

## Change

Insert an **auth_group** layer between `defaultgroup` and `program`:

```
defaultgroup  <-  auth_group  <-  program  <-  batch    (later wins)
```

- `resolve_for_user/1` reads the user's current `auth_group` enrollment and overlays that auth group's `locale_data["gurukul_config"]` as a base layer — consistent with how the `DefaultGroup` base is read (`locale_data`, not `input_schema`).
- `enrollment_record.group_id` for an `auth_group` row is the `AuthGroup.id` directly (`enrollment_service` sets `group.child_id`), so it resolves via `Repo.get(AuthGroup, group_id)`.
- `resolved_from` gains an `auth_group_id` key and a new `source: "auth_group"`.
- `resolve_for_batch/1` and `resolve_for_program/1` have no user context, so they **skip** this layer (pass `auth_group_id: nil`).
- `source` is reported as `"auth_group"` whenever an auth_group enrollment exists, **even when its `gurukul_config` is empty** — a useful signal that the group still needs config populated.

### Precedence note
The `auth_group` layer is **lower** priority than program/batch — a broad per-auth-group default that specific programs/batches override. If EnableSchools config should instead override batch/program, that ordering is the one knob to flip.

## Effect on user 130659
After deploy this user resolves `source: "auth_group", auth_group_id: 10`. Whether the values change depends on EnableSchools' `locale_data` — if auth_group 10 has no `gurukul_config`, the config stays at defaults but `source` flips to `auth_group`, signalling that EnableSchools' `locale_data["gurukul_config"]` needs populating.

## Tests
3 new cases in `gurukul_config_service_test.exs` (auth_group merges over defaultgroup; reports `auth_group` source with empty config; batch wins over auth_group wins over defaultgroup). All 12 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)