### PR TITLE
feat(student): scope student identity to (student_id, auth_group)

### DIFF
--- a/lib/dbservice/services/student_update_service.ex
+++ b/lib/dbservice/services/student_update_service.ex
@@ -20,7 +20,9 @@ defmodule Dbservice.Services.StudentUpdateService do
   - {:error, reason} if student not found or update fails
   """
   def update_student_by_student_id(student_id, params) do
-    case Users.get_student_by_student_id(student_id) do
+    # Scope to the auth group when params carry it, so a student_id shared across auth groups
+    # resolves to the right student (falls back to unscoped when no auth group is present).
+    case Users.get_student_by_student_id(student_id, params) do
       nil ->
         {:error, "Student not found with ID: #{student_id}"}
 

--- a/lib/dbservice/users.ex
+++ b/lib/dbservice/users.ex
@@ -7,6 +7,10 @@ defmodule Dbservice.Users do
   alias Dbservice.Utils.Util
   alias Dbservice.Repo
 
+  alias Dbservice.AuthGroups
+  alias Dbservice.EnrollmentRecords.EnrollmentRecord
+  alias Dbservice.Services.EnrollmentService
+
   alias Dbservice.Users.User
 
   @doc """
@@ -226,6 +230,60 @@ defmodule Dbservice.Users do
   end
 
   @doc """
+  Gets a student scoped to an auth group.
+
+  A `student_id` is only unique within the scope of an auth group, so a student is the
+  *same logical student* only when its `student_id` matches AND there is a current
+  enrollment record tying it to the given auth group (`group_type = "auth_group"`,
+  `group_id = auth_group.id`, `is_current = true`).
+
+  Returns the matching `%Student{}` or `nil`.
+  """
+  def get_student_by_student_id_and_auth_group(student_id, auth_group_id)
+      when not is_nil(student_id) and not is_nil(auth_group_id) do
+    from(s in Student,
+      join: er in EnrollmentRecord,
+      on: er.user_id == s.user_id,
+      where:
+        s.student_id == ^student_id and
+          er.group_type == "auth_group" and
+          er.group_id == ^auth_group_id and
+          er.is_current == true,
+      limit: 1
+    )
+    |> Repo.one()
+  end
+
+  def get_student_by_student_id_and_auth_group(_student_id, _auth_group_id), do: nil
+
+  @doc """
+  Resolves the incoming auth group id from request/import params.
+
+  Prefers an explicit `auth_group_id` (the data-import pipeline already sets this to
+  `auth_group.id`); otherwise resolves the `auth_group` name via `AuthGroups`.
+  Returns the `auth_group.id` (which is what enrollment records store as `group_id`),
+  or `nil` when no auth group can be determined.
+  """
+  def resolve_auth_group_id(params) do
+    case params["auth_group_id"] do
+      id when not is_nil(id) and id != "" ->
+        id
+
+      _ ->
+        resolve_auth_group_id_by_name(params["auth_group"])
+    end
+  end
+
+  defp resolve_auth_group_id_by_name(name) when is_binary(name) and name != "" do
+    case AuthGroups.get_auth_group_by_name(name) do
+      nil -> nil
+      auth_group -> auth_group.id
+    end
+  end
+
+  defp resolve_auth_group_id_by_name(_name), do: nil
+
+  @doc """
   Creates a student.
 
   ## Examples
@@ -352,19 +410,97 @@ defmodule Dbservice.Users do
     if (is_nil(student_id) or student_id == "") and (is_nil(apaar_id) or apaar_id == "") do
       {:error, "Student ID or APAAR ID is required"}
     else
-      case get_student_by_id_or_apaar_id_with_validation(params) do
-        {:ok, nil} ->
-          # Student doesn't exist and no duplicates - create new
-          create_student_with_user(params)
-
-        {:ok, existing_student} ->
-          # Student exists and no duplicates - update
-          user = get_user!(existing_student.user_id)
-          update_student_with_user(existing_student, user, params)
-
-        {:error, _reason} = error ->
-          error
+      # `student_id` is only unique within an auth group. When an auth group is provided
+      # we scope the lookup to it; otherwise we fall back to the legacy global behavior so
+      # callers that don't send an auth group keep working.
+      case resolve_auth_group_id(params) do
+        nil -> create_or_update_student_global(params)
+        auth_group_id -> create_or_update_student_scoped(params, auth_group_id)
       end
+    end
+  end
+
+  # Auth-group-scoped create/update. A student is the same logical student only if its
+  # `student_id` matches AND it already belongs to the incoming auth group. The student
+  # row and its auth-group ownership (enrollment record + group_user) are created/updated
+  # atomically in a single transaction.
+  defp create_or_update_student_scoped(params, auth_group_id) do
+    student_id = params["student_id"]
+    apaar_id = params["apaar_id"]
+    existing_student = get_student_by_student_id_and_auth_group(student_id, auth_group_id)
+
+    # `apaar_id` remains globally unique even though `student_id` is auth-group-scoped.
+    with :ok <- validate_apaar_id_not_duplicated(apaar_id, existing_student) do
+      Repo.transaction(fn ->
+        case upsert_student_scoped(existing_student, params, auth_group_id) do
+          {:ok, student} -> student
+          {:error, reason} -> Repo.rollback(reason)
+        end
+      end)
+    end
+  end
+
+  # New student: create it and establish auth-group ownership (enrollment record + group_user).
+  defp upsert_student_scoped(nil, params, auth_group_id) do
+    with {:ok, student} <- create_student_with_user(params),
+         {:ok, _ownership} <- ensure_auth_group_ownership(student, params, auth_group_id) do
+      {:ok, student}
+    end
+  end
+
+  # Existing student in this auth group: update fields only. Ownership already exists (it is
+  # what the scoped lookup matched on), so it must not be re-created.
+  defp upsert_student_scoped(%Student{} = existing_student, params, _auth_group_id) do
+    user = get_user!(existing_student.user_id)
+    update_student_with_user(existing_student, user, params)
+  end
+
+  # Ensures the auth-group ownership enrollment record + group_user mapping exist for the
+  # student. Reuses the shared EnrollmentService, which is idempotent on the group_user
+  # (an existing mapping results in an update, never a duplicate enrollment record).
+  defp ensure_auth_group_ownership(%Student{} = student, params, auth_group_id) do
+    auth_group_name = params["auth_group"] || auth_group_name_from_id(auth_group_id)
+
+    enrollment_data = %{
+      "enrollment_type" => "auth_group",
+      "auth_group" => auth_group_name,
+      "user_id" => student.user_id,
+      "start_date" => params["start_date"] || Date.utc_today()
+    }
+
+    EnrollmentService.process_enrollment(enrollment_data)
+  end
+
+  defp auth_group_name_from_id(auth_group_id) do
+    case AuthGroups.get_auth_group!(auth_group_id) do
+      %{name: name} -> name
+      _ -> nil
+    end
+  end
+
+  defp validate_apaar_id_not_duplicated(apaar_id, existing_student) do
+    if apaar_id && apaar_id != "" && duplicate_exists?(:apaar_id, apaar_id, existing_student) do
+      {:error, "APAAR ID '#{apaar_id}' already exists for another student"}
+    else
+      :ok
+    end
+  end
+
+  # Legacy, globally-scoped create/update used when no auth group is supplied. Treats
+  # `student_id`/`apaar_id` as globally unique (the original behavior).
+  defp create_or_update_student_global(params) do
+    case get_student_by_id_or_apaar_id_with_validation(params) do
+      {:ok, nil} ->
+        # Student doesn't exist and no duplicates - create new
+        create_student_with_user(params)
+
+      {:ok, existing_student} ->
+        # Student exists and no duplicates - update
+        user = get_user!(existing_student.user_id)
+        update_student_with_user(existing_student, user, params)
+
+      {:error, _reason} = error ->
+        error
     end
   end
 

--- a/lib/dbservice/users.ex
+++ b/lib/dbservice/users.ex
@@ -169,16 +169,26 @@ defmodule Dbservice.Users do
   def get_student!(id), do: Repo.get!(Student, id)
 
   @doc """
-  Gets a student by student ID.
-  Raises `Ecto.NoResultsError` if the Student does not exist.
+  Gets a student by `student_id`, or `nil` if none exists.
+
+  `student_id` is not globally unique - the same id can exist across auth groups - so this
+  returns the earliest-created matching student rather than raising `Ecto.MultipleResultsError`
+  (which `Repo.get_by/2` would). When an auth group is in context, prefer
+  `get_student_by_student_id_and_auth_group/2` for an unambiguous match.
+
   ## Examples
-      iex> get_student_by_student_id(1234)
+      iex> get_student_by_student_id("1234")
       %Student{}
-      iex> get_student_by_student_id(abc)
-      ** (Ecto.NoResultsError)
+      iex> get_student_by_student_id("does-not-exist")
+      nil
   """
   def get_student_by_student_id(student_id) do
-    Repo.get_by(Student, student_id: student_id)
+    from(s in Student,
+      where: s.student_id == ^student_id,
+      order_by: [asc: s.id],
+      limit: 1
+    )
+    |> Repo.one()
   end
 
   @doc """

--- a/lib/dbservice/users.ex
+++ b/lib/dbservice/users.ex
@@ -171,18 +171,30 @@ defmodule Dbservice.Users do
   @doc """
   Gets a student by `student_id`, or `nil` if none exists.
 
-  `student_id` is not globally unique - the same id can exist across auth groups - so this
-  returns the earliest-created matching student rather than raising `Ecto.MultipleResultsError`
-  (which `Repo.get_by/2` would). When an auth group is in context, prefer
-  `get_student_by_student_id_and_auth_group/2` for an unambiguous match.
+  `student_id` is not globally unique - the same id can exist across auth groups. Pass a
+  params map carrying `auth_group` (name) or `auth_group_id` to get an unambiguous,
+  auth-group-scoped match (the student in *that* group, or `nil`). This is what identity-
+  sensitive callers should do so they never act on another auth group's student.
+
+  Without a resolvable auth group it falls back to the earliest-created matching student,
+  rather than raising `Ecto.MultipleResultsError` (which `Repo.get_by/2` would on duplicates).
 
   ## Examples
       iex> get_student_by_student_id("1234")
       %Student{}
+      iex> get_student_by_student_id("1234", %{"auth_group" => "DelhiStudents"})
+      %Student{}
       iex> get_student_by_student_id("does-not-exist")
       nil
   """
-  def get_student_by_student_id(student_id) do
+  def get_student_by_student_id(student_id, auth_group_params \\ %{}) do
+    case resolve_auth_group_id(auth_group_params) do
+      nil -> get_student_by_student_id_unscoped(student_id)
+      auth_group_id -> get_student_by_student_id_and_auth_group(student_id, auth_group_id)
+    end
+  end
+
+  defp get_student_by_student_id_unscoped(student_id) do
     from(s in Student,
       where: s.student_id == ^student_id,
       order_by: [asc: s.id],

--- a/lib/dbservice/users.ex
+++ b/lib/dbservice/users.ex
@@ -255,28 +255,45 @@ defmodule Dbservice.Users do
   Gets a student scoped to an auth group.
 
   A `student_id` is only unique within the scope of an auth group, so a student is the
-  *same logical student* only when its `student_id` matches AND there is a current
-  enrollment record tying it to the given auth group (`group_type = "auth_group"`,
-  `group_id = auth_group.id`, `is_current = true`).
+  *same logical student* only when its `student_id` matches AND there is an enrollment
+  record tying it to the given auth group (`group_type = "auth_group"`,
+  `group_id = auth_group.id`).
+
+  By default only a *current* (`is_current = true`) ownership record counts. Pass
+  `include_inactive: true` to also match a student whose ownership record was deactivated
+  (e.g. by a dropout, which flips all current records to `is_current = false`) - the
+  create/update path uses this so re-POSTing a dropped student revives the same row rather
+  than inserting a duplicate. A current record is preferred when both exist.
 
   Returns the matching `%Student{}` or `nil`.
   """
-  def get_student_by_student_id_and_auth_group(student_id, auth_group_id)
+  def get_student_by_student_id_and_auth_group(student_id, auth_group_id, opts \\ [])
+
+  def get_student_by_student_id_and_auth_group(student_id, auth_group_id, opts)
       when not is_nil(student_id) and not is_nil(auth_group_id) do
-    from(s in Student,
-      join: er in EnrollmentRecord,
-      on: er.user_id == s.user_id,
-      where:
-        s.student_id == ^student_id and
-          er.group_type == "auth_group" and
-          er.group_id == ^auth_group_id and
-          er.is_current == true,
-      limit: 1
-    )
-    |> Repo.one()
+    base =
+      from(s in Student,
+        join: er in EnrollmentRecord,
+        on: er.user_id == s.user_id,
+        where:
+          s.student_id == ^student_id and
+            er.group_type == "auth_group" and
+            er.group_id == ^auth_group_id,
+        order_by: [desc: er.is_current, asc: s.id],
+        limit: 1
+      )
+
+    query =
+      if Keyword.get(opts, :include_inactive, false) do
+        base
+      else
+        from([_s, er] in base, where: er.is_current == true)
+      end
+
+    Repo.one(query)
   end
 
-  def get_student_by_student_id_and_auth_group(_student_id, _auth_group_id), do: nil
+  def get_student_by_student_id_and_auth_group(_student_id, _auth_group_id, _opts), do: nil
 
   @doc """
   Resolves the incoming auth group id from request/import params.
@@ -449,7 +466,11 @@ defmodule Dbservice.Users do
   defp create_or_update_student_scoped(params, auth_group_id) do
     student_id = params["student_id"]
     apaar_id = params["apaar_id"]
-    existing_student = get_student_by_student_id_and_auth_group(student_id, auth_group_id)
+
+    # Match the logical student in this auth group even if a dropout deactivated its
+    # ownership record - re-POSTing must revive that row, never create a duplicate (:466).
+    existing_student =
+      get_student_by_student_id_and_auth_group(student_id, auth_group_id, include_inactive: true)
 
     # `apaar_id` remains globally unique even though `student_id` is auth-group-scoped.
     with :ok <- validate_apaar_id_not_duplicated(apaar_id, existing_student) do
@@ -470,11 +491,42 @@ defmodule Dbservice.Users do
     end
   end
 
-  # Existing student in this auth group: update fields only. Ownership already exists (it is
-  # what the scoped lookup matched on), so it must not be re-created.
-  defp upsert_student_scoped(%Student{} = existing_student, params, _auth_group_id) do
+  # Existing student in this auth group: update fields. Guard against silently overwriting a
+  # stored `apaar_id` with a different one (:475), then revive the ownership record if a
+  # prior dropout had deactivated it (:466).
+  defp upsert_student_scoped(%Student{} = existing_student, params, auth_group_id) do
     user = get_user!(existing_student.user_id)
-    update_student_with_user(existing_student, user, params)
+
+    with :ok <- validate_incoming_apaar_matches(existing_student, params),
+         {:ok, student} <- update_student_with_user(existing_student, user, params) do
+      reactivate_auth_group_enrollment(student.user_id, auth_group_id)
+      {:ok, student}
+    end
+  end
+
+  # Mirrors the global path's apaar-mismatch check: if an `apaar_id` is supplied and the
+  # student already has a different one, reject rather than overwrite it.
+  defp validate_incoming_apaar_matches(existing_student, params) do
+    apaar_id = params["apaar_id"]
+
+    if apaar_id && apaar_id != "" do
+      validate_apaar_id_match(existing_student, params["student_id"], apaar_id)
+    else
+      :ok
+    end
+  end
+
+  # Revives a previously-deactivated auth_group ownership record (no-op if already current),
+  # so a re-POSTed (e.g. dropped) student is owned by - and findable in - this auth group again.
+  defp reactivate_auth_group_enrollment(user_id, auth_group_id) do
+    from(er in EnrollmentRecord,
+      where:
+        er.user_id == ^user_id and er.group_type == "auth_group" and
+          er.group_id == ^auth_group_id and er.is_current == false
+    )
+    |> Repo.update_all(set: [is_current: true, end_date: nil])
+
+    :ok
   end
 
   # Ensures the auth-group ownership enrollment record + group_user mapping exist for the
@@ -684,7 +736,9 @@ defmodule Dbservice.Users do
         query
       end
 
-    not is_nil(Repo.one(query))
+    # `Repo.exists?` (not `Repo.one`) - a `student_id` can legitimately match multiple rows
+    # now that it is only unique within an auth group, which would crash `Repo.one`.
+    Repo.exists?(query)
   end
 
   @doc """

--- a/lib/dbservice/utils/import_worker.ex
+++ b/lib/dbservice/utils/import_worker.ex
@@ -744,32 +744,42 @@ defmodule Dbservice.DataImport.ImportWorker do
 
   # Record processor functions for each import type
   defp process_student_record(record) do
-    # For student imports, if student already exists, returns error
-    # Check if student exists first to determine if this would be an update
-    existing_student = Users.get_student_by_id_or_apaar_id(record)
+    # For student imports, if the student already exists, return an error (updates must go
+    # through the student_update import type). `student_id` is only unique within an auth
+    # group, so the "already exists" check is scoped to the incoming auth group - a matching
+    # id in a different auth group is treated as a new student.
+    case existing_student_for_record(record) do
+      nil ->
+        create_student_with_enrollments(record)
 
-    case Users.create_or_update_student(record) do
-      {:ok, student} ->
-        handle_student_creation_result(existing_student, student, record)
-
-      {:error, reason} ->
-        {:error, reason}
+      %Dbservice.Users.Student{} = existing_student ->
+        {:error, build_student_exists_error_message(existing_student)}
     end
   end
 
-  defp handle_student_creation_result(nil, student, record) do
-    # Student was created - proceed with enrollments
-    student = Dbservice.Repo.preload(student, [:user])
+  defp existing_student_for_record(record) do
+    case Users.resolve_auth_group_id(record) do
+      nil ->
+        Users.get_student_by_id_or_apaar_id(record)
 
-    case DataImport.StudentEnrollment.create_enrollments(student.user, record) do
-      {:ok, _} -> {:ok, {:ok, student}}
-      {:error, reason} -> {:error, reason}
+      auth_group_id ->
+        Users.get_student_by_student_id_and_auth_group(record["student_id"], auth_group_id)
     end
   end
 
-  defp handle_student_creation_result(_existing_student, student, _record) do
-    # Student already exists - return detailed error (student_update import type should be used for updates)
-    {:error, build_student_exists_error_message(student)}
+  # Creates the student and all enrollments atomically. create_or_update_student already
+  # establishes auth-group ownership; create_enrollments then adds school/batch/grade
+  # records (its auth-group step is an idempotent no-op).
+  defp create_student_with_enrollments(record) do
+    Dbservice.Repo.transaction(fn ->
+      with {:ok, student} <- Users.create_or_update_student(record),
+           student <- Dbservice.Repo.preload(student, [:user]),
+           {:ok, _} <- DataImport.StudentEnrollment.create_enrollments(student.user, record) do
+        student
+      else
+        {:error, reason} -> Dbservice.Repo.rollback(reason)
+      end
+    end)
   end
 
   defp build_student_exists_error_message(student) do

--- a/lib/dbservice_web/controllers/student_controller.ex
+++ b/lib/dbservice_web/controllers/student_controller.ex
@@ -73,15 +73,23 @@ defmodule DbserviceWeb.StudentController do
   end
 
   def index(conn, params) do
-    query =
+    # `student_id` is only unique within an auth group. When an `auth_group` (name) or
+    # `auth_group_id` filter is supplied, scope the result to students that currently
+    # belong to that auth group (via their auth_group enrollment record). Remaining params
+    # are treated as direct Student column filters.
+    {auth_group_id, params} = pop_auth_group_filter(params)
+
+    base =
       from(m in Student,
         order_by: [asc: m.id],
         offset: ^params["offset"],
         limit: ^params["limit"]
       )
 
+    base = maybe_scope_to_auth_group(base, auth_group_id)
+
     query =
-      Enum.reduce(params, query, fn {key, value}, acc ->
+      Enum.reduce(params, base, fn {key, value}, acc ->
         case String.to_existing_atom(key) do
           :offset -> acc
           :limit -> acc
@@ -91,6 +99,33 @@ defmodule DbserviceWeb.StudentController do
 
     student = Repo.all(query)
     render(conn, :index, student: student)
+  end
+
+  # Removes the auth-group filter keys from params and resolves them to an auth_group id.
+  defp pop_auth_group_filter(params) do
+    {auth_group_id, params} = Map.pop(params, "auth_group_id")
+    {auth_group_name, params} = Map.pop(params, "auth_group")
+
+    resolved =
+      Users.resolve_auth_group_id(%{
+        "auth_group_id" => auth_group_id,
+        "auth_group" => auth_group_name
+      })
+
+    {resolved, params}
+  end
+
+  defp maybe_scope_to_auth_group(query, nil), do: query
+
+  defp maybe_scope_to_auth_group(query, auth_group_id) do
+    from(s in query,
+      join: er in EnrollmentRecord,
+      on: er.user_id == s.user_id,
+      where:
+        er.group_type == "auth_group" and
+          er.group_id == ^auth_group_id and
+          er.is_current == true
+    )
   end
 
   swagger_path :create do

--- a/lib/dbservice_web/controllers/student_controller.ex
+++ b/lib/dbservice_web/controllers/student_controller.ex
@@ -271,8 +271,9 @@ defmodule DbserviceWeb.StudentController do
   end
 
   def enrolled(conn, params) do
-    # Retrieve the student information based on the provided student ID
-    student = Users.get_student_by_student_id(params["student_id"])
+    # Retrieve the student information based on the provided student ID, scoped to the auth
+    # group when one is supplied (student_id is unique only within an auth group).
+    student = Users.get_student_by_student_id(params["student_id"], params)
     user_id = student.user_id
 
     # Retrieve the group user information based on the user ID
@@ -520,11 +521,14 @@ defmodule DbserviceWeb.StudentController do
     response(200, "OK", Schema.ref(:VerificationResult))
   end
 
-  def verify_student(conn, %{
-        "student_id" => student_id,
-        "verification_params" => verification_params
-      }) do
-    case get_student_and_user(student_id) do
+  def verify_student(
+        conn,
+        %{
+          "student_id" => student_id,
+          "verification_params" => verification_params
+        } = params
+      ) do
+    case get_student_and_user(student_id, params) do
       {:ok, student, user} ->
         student_exists = verify_student_and_user_data(student, user, verification_params)
 
@@ -539,8 +543,8 @@ defmodule DbserviceWeb.StudentController do
     end
   end
 
-  defp get_student_and_user(student_id) do
-    case Users.get_student_by_student_id(student_id) do
+  defp get_student_and_user(student_id, auth_group_params) do
+    case Users.get_student_by_student_id(student_id, auth_group_params) do
       nil ->
         {:error, :not_found}
 
@@ -822,7 +826,7 @@ defmodule DbserviceWeb.StudentController do
   def update_student_status(conn, params) do
     with {:ok, status} <- get_status_by_title(params["status"]),
          student when not is_nil(student) <-
-           Users.get_student_by_student_id(params["student_id"]),
+           Users.get_student_by_student_id(params["student_id"], params),
          :ok <- check_existing_status(student, status.title),
          {:ok, %Student{} = updated_student} <- update_student_status_field(student, status),
          {:ok, _enrollment_record} <- create_status_enrollment_record(student, status, params) do

--- a/lib/dbservice_web/controllers/student_controller.ex
+++ b/lib/dbservice_web/controllers/student_controller.ex
@@ -271,9 +271,20 @@ defmodule DbserviceWeb.StudentController do
   end
 
   def enrolled(conn, params) do
-    # Retrieve the student information based on the provided student ID, scoped to the auth
-    # group when one is supplied (student_id is unique only within an auth group).
-    student = Users.get_student_by_student_id(params["student_id"], params)
+    # student_id is unique only within an auth group; scope to it when supplied. A nil match
+    # (e.g. no current ownership record) returns 404 rather than crashing on student.user_id.
+    case Users.get_student_by_student_id(params["student_id"], params) do
+      nil ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{errors: "Student not found with the provided identifier"})
+
+      student ->
+        do_enrolled(conn, student, params)
+    end
+  end
+
+  defp do_enrolled(conn, student, params) do
     user_id = student.user_id
 
     # Retrieve the group user information based on the user ID

--- a/lib/dbservice_web/controllers/student_profile_controller.ex
+++ b/lib/dbservice_web/controllers/student_profile_controller.ex
@@ -142,7 +142,9 @@ defmodule DbserviceWeb.StudentProfileController do
   end
 
   def create(conn, params) do
-    student = Users.get_student_by_student_id(params["student_id"])
+    # Scope to the auth group when params carry it (student_id is unique only within an auth
+    # group); falls back to unscoped lookup when no auth group is present.
+    student = Users.get_student_by_student_id(params["student_id"], params)
     student_fk = student.id
     user_id = student.user_id
 

--- a/test/dbservice/users_test.exs
+++ b/test/dbservice/users_test.exs
@@ -470,6 +470,23 @@ defmodule Dbservice.UsersTest do
 
       assert message =~ "APAAR ID"
     end
+
+    test "get_student_by_student_id returns earliest match without raising on duplicates" do
+      setup_auth_group("AuthA")
+      setup_auth_group("AuthB")
+
+      assert {:ok, %Student{} = first} =
+               Users.create_or_update_student(student_params("S1", "AuthA"))
+
+      assert {:ok, %Student{} = second} =
+               Users.create_or_update_student(student_params("S1", "AuthB"))
+
+      # Two rows now share student_id "S1"; the legacy single-id lookup must not raise
+      # Ecto.MultipleResultsError and should return the earliest-created row deterministically.
+      assert first.id < second.id
+      assert %Student{id: id} = Users.get_student_by_student_id("S1")
+      assert id == first.id
+    end
   end
 
   describe "teacher" do

--- a/test/dbservice/users_test.exs
+++ b/test/dbservice/users_test.exs
@@ -487,6 +487,22 @@ defmodule Dbservice.UsersTest do
       assert %Student{id: id} = Users.get_student_by_student_id("S1")
       assert id == first.id
     end
+
+    test "get_student_by_student_id scopes to the auth group when one is supplied" do
+      setup_auth_group("AuthA")
+      setup_auth_group("AuthB")
+      setup_auth_group("AuthC")
+
+      assert {:ok, %Student{} = a} = Users.create_or_update_student(student_params("S1", "AuthA"))
+      assert {:ok, %Student{} = b} = Users.create_or_update_student(student_params("S1", "AuthB"))
+
+      # Same student_id, but each lookup resolves to the student owned by that auth group.
+      assert Users.get_student_by_student_id("S1", %{"auth_group" => "AuthA"}).id == a.id
+      assert Users.get_student_by_student_id("S1", %{"auth_group" => "AuthB"}).id == b.id
+
+      # An auth group that has no such student returns nil (no fallback to another group's row).
+      assert is_nil(Users.get_student_by_student_id("S1", %{"auth_group" => "AuthC"}))
+    end
   end
 
   describe "teacher" do

--- a/test/dbservice/users_test.exs
+++ b/test/dbservice/users_test.exs
@@ -382,6 +382,96 @@ defmodule Dbservice.UsersTest do
     end
   end
 
+  describe "create_or_update_student/1 auth-group scoping" do
+    alias Dbservice.AuthGroups
+    alias Dbservice.Users.Student
+    alias Dbservice.EnrollmentRecords.EnrollmentRecord
+    alias Dbservice.Repo
+
+    import Ecto.Query
+
+    # Creates an auth group together with its "auth_group" group wrapper
+    # (child_id = auth_group.id), which is the data model EnrollmentService relies on to
+    # resolve ownership.
+    defp setup_auth_group(name) do
+      {:ok, auth_group} = AuthGroups.create_auth_group_from_import(%{"name" => name})
+      auth_group
+    end
+
+    defp student_params(student_id, auth_group_name, extra \\ %{}) do
+      Map.merge(
+        %{
+          "student_id" => student_id,
+          "auth_group" => auth_group_name,
+          "first_name" => "Test",
+          "last_name" => "Student",
+          "role" => "student",
+          "start_date" => "2025-01-01"
+        },
+        extra
+      )
+    end
+
+    defp current_auth_group_enrollment(user_id) do
+      Repo.one(
+        from er in EnrollmentRecord,
+          where:
+            er.user_id == ^user_id and er.group_type == "auth_group" and er.is_current == true
+      )
+    end
+
+    test "same student_id in different auth groups creates two distinct students" do
+      auth_a = setup_auth_group("AuthA")
+      auth_b = setup_auth_group("AuthB")
+
+      assert {:ok, %Student{} = s1} =
+               Users.create_or_update_student(student_params("S1", "AuthA"))
+
+      assert {:ok, %Student{} = s2} =
+               Users.create_or_update_student(student_params("S1", "AuthB"))
+
+      assert s1.id != s2.id
+      assert s1.student_id == "S1"
+      assert s2.student_id == "S1"
+
+      # Each student owns a current auth-group enrollment record for its own auth group.
+      assert current_auth_group_enrollment(s1.user_id).group_id == auth_a.id
+      assert current_auth_group_enrollment(s2.user_id).group_id == auth_b.id
+    end
+
+    test "same student_id within the same auth group updates the existing student" do
+      setup_auth_group("AuthA")
+
+      assert {:ok, %Student{} = s1} =
+               Users.create_or_update_student(student_params("S1", "AuthA"))
+
+      assert {:ok, %Student{} = s2} =
+               Users.create_or_update_student(
+                 student_params("S1", "AuthA", %{"first_name" => "Updated"})
+               )
+
+      assert s1.id == s2.id
+      assert Users.get_user!(s2.user_id).first_name == "Updated"
+    end
+
+    test "duplicate apaar_id across auth groups is still rejected" do
+      setup_auth_group("AuthA")
+      setup_auth_group("AuthB")
+
+      assert {:ok, %Student{}} =
+               Users.create_or_update_student(
+                 student_params("S1", "AuthA", %{"apaar_id" => "123456789012"})
+               )
+
+      assert {:error, message} =
+               Users.create_or_update_student(
+                 student_params("S2", "AuthB", %{"apaar_id" => "123456789012"})
+               )
+
+      assert message =~ "APAAR ID"
+    end
+  end
+
   describe "teacher" do
     alias Dbservice.Users.Teacher
 

--- a/test/dbservice/users_test.exs
+++ b/test/dbservice/users_test.exs
@@ -503,6 +503,49 @@ defmodule Dbservice.UsersTest do
       # An auth group that has no such student returns nil (no fallback to another group's row).
       assert is_nil(Users.get_student_by_student_id("S1", %{"auth_group" => "AuthC"}))
     end
+
+    test "re-POSTing a dropped student revives the same row instead of duplicating it" do
+      auth_a = setup_auth_group("AuthA")
+
+      assert {:ok, %Student{} = s1} =
+               Users.create_or_update_student(student_params("S1", "AuthA"))
+
+      # Simulate dropout: deactivate all current enrollments, including the auth_group ER.
+      Dbservice.Services.DropoutService.update_current_enrollments(s1.user_id, ~D[2025-06-01])
+      assert is_nil(current_auth_group_enrollment(s1.user_id))
+
+      # Re-POST under the same auth group must reuse the existing row, not create a duplicate.
+      assert {:ok, %Student{} = s2} =
+               Users.create_or_update_student(
+                 student_params("S1", "AuthA", %{"first_name" => "Back"})
+               )
+
+      assert s2.id == s1.id
+      assert Repo.aggregate(from(s in Student, where: s.student_id == "S1"), :count) == 1
+
+      # Ownership is revived (current again) for this auth group.
+      assert current_auth_group_enrollment(s2.user_id).group_id == auth_a.id
+    end
+
+    test "scoped update does not silently overwrite a differing apaar_id" do
+      auth_a = setup_auth_group("AuthA")
+
+      assert {:ok, %Student{}} =
+               Users.create_or_update_student(
+                 student_params("S1", "AuthA", %{"apaar_id" => "111111111111"})
+               )
+
+      # A different apaar_id (used by nobody else) must be rejected, not silently written.
+      assert {:error, message} =
+               Users.create_or_update_student(
+                 student_params("S1", "AuthA", %{"apaar_id" => "222222222222"})
+               )
+
+      assert message =~ "doesn't match existing"
+
+      assert Users.get_student_by_student_id_and_auth_group("S1", auth_a.id).apaar_id ==
+               "111111111111"
+    end
   end
 
   describe "teacher" do


### PR DESCRIPTION
## Why

`student.student_id` is **not** globally unique — the same id (often a phone number) is reused across auth groups (e.g. `DelhiStudents`, `BiharStudents`). The POST-student flow matched any student row with that `student_id` and **updated** it, causing cross-auth-group data leakage: one student row shared across auth groups, with batch/grade/school enrollments and `group_user` mappings overwritten.

A student is now identified by **`(student_id, auth_group)`**. The auth_group **enrollment record** (`group_type="auth_group"`, `group_id = auth_group.id`, `is_current=true`) is the source of truth for ownership.

The real registration path is the plain `POST /student` → `create_or_update_student` (used by portal-backend and the CSV import worker); `/student/create-with-enrollments` is unused.

## What

- **`create_or_update_student/1`** is auth-group-scoped and transactional when an `auth_group` is present (new `get_student_by_student_id_and_auth_group/2` + `resolve_auth_group_id/1`). Ownership ER + `group_user` are created for **new** students via the existing `EnrollmentService` (idempotent on group_user). Legacy global behavior is kept as a fallback when no auth group is supplied. **`apaar_id` stays globally unique.**
- **`GET /student`** accepts `auth_group` / `auth_group_id` and scopes results via the auth_group enrollment record join (lets portal-backend scope its verify lookup).
- **Import worker** `process_student_record` scopes the "already exists" check to the auth group and wraps create + enrollments in a single transaction.
- Tests for the three outcomes: same `student_id` across two auth groups → two rows; same `(student_id, auth_group)` → update; duplicate `apaar_id` across groups → rejected.

No DB migration needed (`student.student_id` already has only a non-unique index).

## Verification

- `mix credo` clean, `mix test test/dbservice/users_test.exs` → 35/35.
- Manual end-to-end against a running server: same `student_id` POSTed under `AllIndiaStudents` then `MaharashtraStudents` → two distinct rows, each with its own current auth_group ER; re-POST under the same auth group → update (no duplicate). Test data cleaned up afterward.

## Coordination

Pairs with **portal-backend PR avantifellows/portal-backend#88** (sends `auth_group` in the create body, drops the redundant ownership call, scopes `verify_student_by_id`). Both must deploy together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)