### PR TITLE
fix(staging): harden ECS service against load-test failures

### DIFF
--- a/lib/dbservice_web/controllers/health_controller.ex
+++ b/lib/dbservice_web/controllers/health_controller.ex
@@ -3,7 +3,21 @@ defmodule DbserviceWeb.HealthController do
 
   alias Dbservice.Repo
 
+  # Liveness probe used by the ALB target group. Intentionally does NOT touch
+  # the database: under load the DB pool can be momentarily exhausted by slow
+  # queries, and if liveness depended on a free connection the busy-but-alive
+  # task would fail its health check and get recycled — removing capacity right
+  # when it's needed and (with a small task count) dropping the service to zero
+  # healthy targets. Keep this cheap; use /api/health/ready for DB connectivity.
   def index(conn, _params) do
+    conn
+    |> put_status(:ok)
+    |> json(%{status: "ok"})
+  end
+
+  # Readiness probe — verifies DB connectivity. Use this for deep monitoring
+  # (dashboards/alarms), NOT as the ALB liveness check.
+  def ready(conn, _params) do
     case Ecto.Adapters.SQL.query(Repo, "SELECT 1", []) do
       {:ok, _} ->
         conn

--- a/lib/dbservice_web/controllers/health_controller.ex
+++ b/lib/dbservice_web/controllers/health_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.HealthController do
   use DbserviceWeb, :controller
 
+  require Logger
+
   alias Dbservice.Repo
 
   # Liveness probe used by the ALB target group. Intentionally does NOT touch
@@ -25,9 +27,13 @@ defmodule DbserviceWeb.HealthController do
         |> json(%{status: "ok"})
 
       {:error, reason} ->
+        # This endpoint is public (see AuthenticationMiddlewarePlug @public_paths),
+        # so don't leak DB internals to the caller — log them server-side instead.
+        Logger.error("Readiness check failed: #{inspect(reason)}")
+
         conn
         |> put_status(:service_unavailable)
-        |> json(%{status: "error", reason: inspect(reason)})
+        |> json(%{status: "error"})
     end
   end
 end

--- a/lib/dbservice_web/plugs/authentication_middleware_plug.ex
+++ b/lib/dbservice_web/plugs/authentication_middleware_plug.ex
@@ -15,8 +15,9 @@ defmodule DbserviceWeb.AuthenticationMiddleware do
 
   # Public endpoints exempt from bearer-token auth. The ALB target group
   # health check has no way to inject an auth header, so /api/health must
-  # respond on plain GETs.
-  @public_paths ["/api/health"]
+  # respond on plain GETs; /api/health/ready is the DB-readiness probe used by
+  # external monitors, which likewise can't inject a token.
+  @public_paths ["/api/health", "/api/health/ready"]
 
   def call(conn, _opts) do
     source(["config/.env", System.get_env()])

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -51,6 +51,7 @@ defmodule DbserviceWeb.Router do
     pipe_through(:api)
 
     get("/health", HealthController, :index)
+    get("/health/ready", HealthController, :ready)
 
     resources("/auth-group", AuthGroupController, except: [:new, :edit])
     post("/group/:id/update-users", GroupController, :update_users)

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -10,12 +10,18 @@ resource "aws_lb_target_group" "this" {
   vpc_id      = var.vpc_id
 
   health_check {
-    path                = "/api/health"
-    matcher             = "200"
+    path    = "/api/health"
+    matcher = "200"
+    # /api/health is a cheap liveness probe (no DB) — see HealthController. A
+    # task that's merely busy under load must not be deregistered: that pulls
+    # capacity exactly when it's needed and, with a small task count, can drop
+    # the service to zero healthy targets. Generous timeout/threshold keeps a
+    # slow-but-alive task in rotation; a genuinely dead task still fails out
+    # after 5 × 30s.
     interval            = 30
-    timeout             = 5
+    timeout             = 10
     healthy_threshold   = 2
-    unhealthy_threshold = 3
+    unhealthy_threshold = 5
   }
 
   # Pin LiveView clients to the same task for the WebSocket upgrade. Without

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -5,7 +5,7 @@ resource "cloudflare_record" "this" {
   zone_id = var.cloudflare_zone_id
   name    = var.domain_prefix
   type    = "CNAME"
-  value   = data.aws_lb.shared.dns_name
+  content = data.aws_lb.shared.dns_name
   proxied = var.dns_proxied
   ttl     = 1 # 1 = "auto"; required when proxied, harmless when not
 }

--- a/terraform/envs/staging.tfvars
+++ b/terraform/envs/staging.tfvars
@@ -7,6 +7,17 @@ listener_rule_priority = 200
 # Mirror what's currently set in the EC2 .env for staging; adjust as needed.
 whitelisted_domains = "staging-database.avantifellows.org,localhost"
 
+# Capacity/scaling — tuned after the 2026-06-21 load test (1000 users / ~174 RPS)
+# saturated a single 0.5-vCPU task: CPU pinned ~100%, /api/health timed out, the
+# lone task got recycled, and with min=1 that left 0 healthy targets → 502/503/504
+# bursts. min_capacity=2 removes the single-task outage window; the bigger task
+# raises the per-task ceiling; target=60 scales out sooner.
+cpu                    = 1024 # 1 vCPU (was 512)
+memory                 = 2048 # 2 GiB (was 1024)
+min_capacity           = 2    # was 1 — always keep a healthy target during recycle/deploy
+max_capacity           = 4    # was 3
+target_cpu_utilization = 60   # was 70 — scale out before tasks fall over
+
 # Sensitive variables (database_url, secret_key_base, bearer_token,
 # google_credentials_json, dashboard_user, dashboard_pass) MUST be supplied
 # via TF_VAR_* env vars. See ../README.md.


### PR DESCRIPTION
## Why
The 2026-06-21 staging load test (1000 users / ~174 RPS) produced a **~36% error rate** in bursts of **502/503/504**. The failures lined up exactly with ECS task replacements.

**Root cause:** a single 0.5-vCPU task saturated (CPU ~100%); its `/api/health` probe — which ran `SELECT 1` — timed out against an exhausted DB pool; ECS marked the lone task unhealthy and replaced it; and with `min_capacity = 1` that left **zero healthy targets for ~30–60s each cycle** → mass 503s, plus 502 (connection killed mid-drain) and 504 (timeouts while CPU pinned). Autoscaling never helped — `DesiredTaskCount` stayed at 1 the whole time.

## Changes
**Redundancy + capacity (`envs/staging.tfvars` — scoped to staging, prod sizing untouched):**
- `min_capacity` 1 → **2** — always keep a healthy target during recycle/deploy (this alone removes the outage window)
- `cpu` 512 → **1024**, `memory` 1024 → **2048** — raise per-task ceiling
- `max_capacity` 3 → **4**, `target_cpu_utilization` 70 → **60** — scale out sooner

**Stop recycling busy-but-alive tasks:**
- `alb.tf` health check: `timeout` 5 → **10s**, `unhealthy_threshold` 3 → **5**
- `HealthController`: `/api/health` is now a **cheap liveness probe (no DB)**; DB connectivity moves to a new **`/api/health/ready`** readiness route (for dashboards/alarms, not the ALB)

**Housekeeping:**
- `dns.tf`: `cloudflare_record` `value` → `content` (clears the provider deprecation warning)

## Deploy notes
- `terraform apply -var-file=envs/staging.tfvars` applies the capacity/health-check changes. Because the ECS service has `ignore_changes = [task_definition]`, the **cpu/memory bump only takes effect via the GitHub Actions deploy** (which renders a new task def) — so apply Terraform **and** run a deploy.
- Stop any active load test first; let the service reach steady state (`running = desired`, targets healthy) before re-testing.

## Verification done
- `terraform validate` ✓, `terraform fmt` ✓
- `mix format` ✓, `mix compile --warnings-as-errors` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)