### PR TITLE
fix(resource): allow CRUD without grade_id except for problem/test

### DIFF
--- a/lib/dbservice/resources.ex
+++ b/lib/dbservice/resources.ex
@@ -487,33 +487,55 @@ defmodule Dbservice.Resources do
       - "difficulty_level": The difficulty_level to use for all entries (global for this resource).
 
   Each ResourceCurriculum will be created with the same subject_id and difficulty_level.
+
+  `grade_id` is optional for most resource types: resources under grade-less curricula
+  (e.g. CA, CLAT) are created without a grade. It stays mandatory only for `problem` and
+  `test` resources (see `@grade_required_resource_types`).
   """
   def create_resource_curriculums_for_resource(resource, params) when is_map(params) do
     curriculum_grades = Map.get(params, "curriculum_grades", [])
     subject_id = Map.get(params, "subject_id")
     difficulty_level = Map.get(params, "difficulty_level")
 
-    Enum.reduce_while(curriculum_grades, :ok, fn %{
-                                                   "curriculum_id" => curriculum_id,
-                                                   "grade_id" => grade_id
-                                                 },
-                                                 _acc ->
-      attrs = %{
-        resource_id: resource.id,
-        curriculum_id: curriculum_id,
-        grade_id: grade_id,
-        subject_id: subject_id,
-        difficulty_level: difficulty_level
-      }
+    with :ok <- validate_grade_required_for_type(resource, curriculum_grades) do
+      Enum.reduce_while(curriculum_grades, :ok, fn cg, _acc ->
+        attrs = %{
+          resource_id: resource.id,
+          curriculum_id: cg["curriculum_id"] || cg[:curriculum_id],
+          grade_id: cg["grade_id"] || cg[:grade_id],
+          subject_id: subject_id,
+          difficulty_level: difficulty_level
+        }
 
-      case Dbservice.ResourceCurriculums.create_resource_curriculum(attrs) do
-        {:ok, _} -> {:cont, :ok}
-        {:error, reason} -> {:halt, {:error, reason}}
-      end
-    end)
+        case Dbservice.ResourceCurriculums.create_resource_curriculum(attrs) do
+          {:ok, _} -> {:cont, :ok}
+          {:error, reason} -> {:halt, {:error, reason}}
+        end
+      end)
+    end
   end
 
   def create_resource_curriculums_for_resource(_resource, _params), do: :ok
+
+  # Resource types that must always carry a grade. Every other type may be created or
+  # updated without a `grade_id` (resources under grade-less curricula like CA / CLAT).
+  @grade_required_resource_types ["problem", "test"]
+
+  defp validate_grade_required_for_type(%{type: type}, curriculum_grades)
+       when type in @grade_required_resource_types do
+    if Enum.all?(curriculum_grades, &grade_present?/1) do
+      :ok
+    else
+      {:error, "grade_id is required for #{type} resources"}
+    end
+  end
+
+  defp validate_grade_required_for_type(_resource, _curriculum_grades), do: :ok
+
+  defp grade_present?(cg) do
+    grade_id = cg["grade_id"] || cg[:grade_id]
+    not is_nil(grade_id) and grade_id != ""
+  end
 
   @doc """
   Generates a resource code in the format P{7digitcode} (e.g., P0000024) using the resource's ID.

--- a/test/dbservice/resources_test.exs
+++ b/test/dbservice/resources_test.exs
@@ -1,0 +1,95 @@
+defmodule Dbservice.ResourcesTest do
+  use Dbservice.DataCase
+
+  alias Dbservice.Resources
+  alias Dbservice.ResourceCurriculums
+
+  import Dbservice.GradesFixtures
+
+  describe "create_resource_curriculums_for_resource/2 grade requirement" do
+    defp curriculum_fixture do
+      {:ok, curriculum} =
+        Dbservice.Curriculums.create_curriculum(%{"name" => "CLAT", "code" => "CLAT"})
+
+      curriculum
+    end
+
+    defp resource_fixture(type) do
+      {:ok, resource} =
+        Resources.create_resource(%{"type" => type, "type_params" => %{}})
+
+      resource
+    end
+
+    test "creates a curriculum entry for a non-problem/test resource without a grade_id" do
+      resource = resource_fixture("video")
+      curriculum = curriculum_fixture()
+
+      params = %{
+        "curriculum_grades" => [%{"curriculum_id" => curriculum.id}],
+        "subject_id" => nil
+      }
+
+      assert :ok = Resources.create_resource_curriculums_for_resource(resource, params)
+
+      [rc] = ResourceCurriculums.list_resource_curriculums_by_resource_id(resource.id)
+      assert rc.curriculum_id == curriculum.id
+      assert is_nil(rc.grade_id)
+    end
+
+    test "creates a curriculum entry for a non-problem/test resource with a grade_id" do
+      resource = resource_fixture("video")
+      curriculum = curriculum_fixture()
+      grade = grade_fixture()
+
+      params = %{
+        "curriculum_grades" => [%{"curriculum_id" => curriculum.id, "grade_id" => grade.id}]
+      }
+
+      assert :ok = Resources.create_resource_curriculums_for_resource(resource, params)
+
+      [rc] = ResourceCurriculums.list_resource_curriculums_by_resource_id(resource.id)
+      assert rc.grade_id == grade.id
+    end
+
+    test "rejects a problem resource whose curriculum entry has no grade_id" do
+      resource = resource_fixture("problem")
+      curriculum = curriculum_fixture()
+
+      params = %{"curriculum_grades" => [%{"curriculum_id" => curriculum.id}]}
+
+      assert {:error, message} =
+               Resources.create_resource_curriculums_for_resource(resource, params)
+
+      assert message =~ "grade_id is required"
+      assert ResourceCurriculums.list_resource_curriculums_by_resource_id(resource.id) == []
+    end
+
+    test "rejects a test resource whose curriculum entry has no grade_id" do
+      resource = resource_fixture("test")
+      curriculum = curriculum_fixture()
+
+      params = %{"curriculum_grades" => [%{"curriculum_id" => curriculum.id}]}
+
+      assert {:error, message} =
+               Resources.create_resource_curriculums_for_resource(resource, params)
+
+      assert message =~ "grade_id is required"
+    end
+
+    test "allows a problem resource when grade_id is present" do
+      resource = resource_fixture("problem")
+      curriculum = curriculum_fixture()
+      grade = grade_fixture()
+
+      params = %{
+        "curriculum_grades" => [%{"curriculum_id" => curriculum.id, "grade_id" => grade.id}]
+      }
+
+      assert :ok = Resources.create_resource_curriculums_for_resource(resource, params)
+
+      [rc] = ResourceCurriculums.list_resource_curriculums_by_resource_id(resource.id)
+      assert rc.grade_id == grade.id
+    end
+  end
+end


### PR DESCRIPTION
Closes #550

## Why

Resources under grade-less curricula like **CA**, **CLAT**, etc. don't map to a specific grade. But `create_resource_curriculums_for_resource/2` pattern-matched `"grade_id"` on every `curriculum_grades` entry:

```elixir
Enum.reduce_while(curriculum_grades, :ok, fn %{
  "curriculum_id" => curriculum_id,
  "grade_id" => grade_id
}, _acc -> ...
```

So creating (or updating, since the update path funnels through the same function) such a resource **without** a `grade_id` raised a `FunctionClauseError` → **500**. There was no way to create these resources via the `resource` API.

## What

- `grade_id` is now **optional** for all resource types *except* `problem` and `test`. The field is read with `Map.get` (handling both string and atom keys, consistent with the update path) and defaults to `nil`.
  - This is safe at the data layer: `grade_id` is already nullable — the `resource_curriculum` changeset only requires `resource_id` + `curriculum_id`.
- For `problem` and `test` resources, `grade_id` stays **required**, but via an explicit `validate_grade_required_for_type/2` that returns `{:error, "grade_id is required for <type> resources"}` (surfaced as a **422**) instead of the previous crash. Empty `curriculum_grades` for these types keeps its prior behavior (no curriculum rows created) — this PR doesn't newly tighten problem/test creation.

## Tests

New `test/dbservice/resources_test.exs` covers:
- non-problem/test resource created **without** `grade_id` → curriculum row with `grade_id = nil`
- non-problem/test resource **with** `grade_id` → grade persisted
- `problem` / `test` resource missing `grade_id` → `{:error, ...}`, no rows created
- `problem` resource with `grade_id` → succeeds

`mix test test/dbservice/resources_test.exs` → 5/5. `mix format` + `mix credo` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)