### PR TITLE
Range filters on GET session 

### DIFF
--- a/lib/dbservice/utils/util.ex
+++ b/lib/dbservice/utils/util.ex
@@ -198,6 +198,20 @@ defmodule Dbservice.Utils.Util do
 
   def naive_to_datetime(%DateTime{} = datetime), do: datetime
 
+  @doc """
+  Parses an ISO-8601 datetime string into a second-precision `DateTime`.
+  Returns `{:ok, datetime}` on success and `:error` for non-binary or
+  unparseable values.
+  """
+  def parse_datetime(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, datetime, _offset} -> {:ok, DateTime.truncate(datetime, :second)}
+      _ -> :error
+    end
+  end
+
+  def parse_datetime(_value), do: :error
+
   def process_credentials(credentials) do
     private_key = credentials["private_key"]
 

--- a/lib/dbservice_web/controllers/session_controller.ex
+++ b/lib/dbservice_web/controllers/session_controller.ex
@@ -5,6 +5,7 @@ defmodule DbserviceWeb.SessionController do
   alias Dbservice.Repo
   alias Dbservice.Sessions
   alias Dbservice.Sessions.Session
+  alias Dbservice.Utils.Util
 
   action_fallback DbserviceWeb.FallbackController
 
@@ -110,7 +111,7 @@ defmodule DbserviceWeb.SessionController do
   end
 
   defp apply_end_time_filter(operator, value, acc) do
-    case parse_datetime(value) do
+    case Util.parse_datetime(value) do
       {:ok, datetime} ->
         query =
           case operator do
@@ -124,15 +125,6 @@ defmodule DbserviceWeb.SessionController do
         {:halt, {:error, "Invalid end_time range timestamp"}}
     end
   end
-
-  defp parse_datetime(value) when is_binary(value) do
-    case DateTime.from_iso8601(value) do
-      {:ok, datetime, _offset} -> {:ok, DateTime.truncate(datetime, :second)}
-      _ -> :error
-    end
-  end
-
-  defp parse_datetime(_value), do: :error
 
   defp extract_sort_order(params) do
     case params["sort_order"] do

--- a/lib/dbservice_web/controllers/session_controller.ex
+++ b/lib/dbservice_web/controllers/session_controller.ex
@@ -39,39 +39,65 @@ defmodule DbserviceWeb.SessionController do
       params(:query, :string, "The name the session", required: false, name: "name")
 
       params(:query, :string, "The platform id the session", required: false, name: "platform_id")
+
+      params(:query, :string, "Inclusive lower bound for session end time",
+        required: false,
+        name: "end_time_gte"
+      )
+
+      params(:query, :string, "Exclusive upper bound for session end time",
+        required: false,
+        name: "end_time_lt"
+      )
     end
 
     response(200, "OK", Schema.ref(:Sessions))
   end
 
   def index(conn, params) do
+    case build_session_index_query(params) do
+      {:ok, query} ->
+        session = Repo.all(query)
+        render(conn, :index, session: session)
+
+      {:error, message} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{error: message})
+    end
+  end
+
+  defp build_session_index_query(params) do
     query = base_session_query(params)
 
-    query =
-      Enum.reduce(params, query, fn {key, value}, acc ->
+    Enum.reduce_while(params, {:ok, query}, fn
+      {"end_time_gte", value}, {:ok, acc} ->
+        apply_end_time_filter(:gte, value, acc)
+
+      {"end_time_lt", value}, {:ok, acc} ->
+        apply_end_time_filter(:lt, value, acc)
+
+      {key, value}, {:ok, acc} ->
         case String.to_existing_atom(key) do
           :offset ->
-            acc
+            {:cont, {:ok, acc}}
 
           :limit ->
-            acc
+            {:cont, {:ok, acc}}
 
           :sort_order ->
-            acc
+            {:cont, {:ok, acc}}
 
           :session_id_is_null ->
-            apply_session_id_null_filter(value, acc)
+            {:cont, {:ok, apply_session_id_null_filter(value, acc)}}
 
           :is_quiz ->
-            apply_is_quiz_filter(value, acc)
+            {:cont, {:ok, apply_is_quiz_filter(value, acc)}}
 
           atom ->
-            apply_filter_based_on_schema(atom, key, value, acc)
+            {:cont, {:ok, apply_filter_based_on_schema(atom, key, value, acc)}}
         end
-      end)
-
-    session = Repo.all(query)
-    render(conn, :index, session: session)
+    end)
   end
 
   defp apply_filter_based_on_schema(atom, key, value, acc) do
@@ -82,6 +108,31 @@ defmodule DbserviceWeb.SessionController do
         where: fragment("?->>? = ?", u.meta_data, ^key, ^value)
     end
   end
+
+  defp apply_end_time_filter(operator, value, acc) do
+    case parse_datetime(value) do
+      {:ok, datetime} ->
+        query =
+          case operator do
+            :gte -> from(u in acc, where: u.end_time >= ^datetime)
+            :lt -> from(u in acc, where: u.end_time < ^datetime)
+          end
+
+        {:cont, {:ok, query}}
+
+      :error ->
+        {:halt, {:error, "Invalid end_time range timestamp"}}
+    end
+  end
+
+  defp parse_datetime(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, datetime, _offset} -> {:ok, DateTime.truncate(datetime, :second)}
+      _ -> :error
+    end
+  end
+
+  defp parse_datetime(_value), do: :error
 
   defp extract_sort_order(params) do
     case params["sort_order"] do

--- a/test/dbservice_web/controllers/session_controller_test.exs
+++ b/test/dbservice_web/controllers/session_controller_test.exs
@@ -118,6 +118,74 @@ defmodule DbserviceWeb.SessionControllerTest do
       assert Map.has_key?(head, "inserted_at")
       assert Map.has_key?(head, "updated_at")
     end
+
+    test "filters sessions by platform equality", %{conn: conn} do
+      quiz_session = session_fixture(%{platform: "quiz", platform_id: "quiz-index-filter"})
+      _meet_session = session_fixture(%{platform: "meet", platform_id: "meet-index-filter"})
+
+      conn = get(conn, ~p"/api/session", %{platform: "quiz"})
+
+      response = json_response(conn, 200)
+      returned_ids = Enum.map(response, & &1["id"])
+
+      assert quiz_session.id in returned_ids
+      assert Enum.all?(response, fn session -> session["platform"] == "quiz" end)
+    end
+
+    test "filters quiz sessions by end_time range", %{conn: conn} do
+      before_window =
+        session_fixture(%{
+          platform: "quiz",
+          platform_id: "quiz-before-window",
+          end_time: ~U[2026-06-17 14:29:59Z]
+        })
+
+      in_window =
+        session_fixture(%{
+          platform: "quiz",
+          platform_id: "quiz-in-window",
+          end_time: ~U[2026-06-17 14:30:00Z]
+        })
+
+      upper_bound =
+        session_fixture(%{
+          platform: "quiz",
+          platform_id: "quiz-upper-bound",
+          end_time: ~U[2026-06-17 15:30:00Z]
+        })
+
+      _non_quiz_in_window =
+        session_fixture(%{
+          platform: "meet",
+          platform_id: "meet-in-window",
+          end_time: ~U[2026-06-17 15:00:00Z]
+        })
+
+      conn =
+        get(conn, ~p"/api/session", %{
+          platform: "quiz",
+          end_time_gte: "2026-06-17T14:30:00Z",
+          end_time_lt: "2026-06-17T15:30:00Z"
+        })
+
+      response = json_response(conn, 200)
+      returned_ids = Enum.map(response, & &1["id"])
+
+      assert in_window.id in returned_ids
+      refute before_window.id in returned_ids
+      refute upper_bound.id in returned_ids
+      assert Enum.all?(response, fn session -> session["platform"] == "quiz" end)
+    end
+
+    test "returns bad request for invalid end_time range timestamp", %{conn: conn} do
+      conn =
+        get(conn, ~p"/api/session", %{
+          platform: "quiz",
+          end_time_gte: "not-a-timestamp"
+        })
+
+      assert json_response(conn, 400)["error"] == "Invalid end_time range timestamp"
+    end
   end
 
   describe "create session" do


### PR DESCRIPTION
Add `end_time` range filters to `GET /api/session`

  Support optional `end_time_gte` (inclusive) and `end_time_lt` (exclusive) query params on the session index endpoint, callers can fetch sessions within an end-time window. Used by the quiz ETL incremental-sync flow to discover recently-finalized quiz sessions.

  - Add both params to the index Swagger spec.
  - Refactor index query building into build_session_index_query/1 using reduce_while so a bad timestamp can short-circuit with an error.
  - Parse range values with DateTime.from_iso8601; invalid timestamps return HTTP 400 {"error": "Invalid end_time range timestamp"}.
  - Filters are additive: existing equality, pagination, and metadata filters are unchanged, so callers that don't pass the new params behave as before.
  - Add controller tests: platform equality still works, platform + end_time range (inclusive lower / exclusive upper bounds, non-quiz excluded), and invalid timestamp returns 400.