### PR TITLE
Cms bugs issue 20 - Preserve saved test problem order

### DIFF
--- a/lib/dbservice/resources.ex
+++ b/lib/dbservice/resources.ex
@@ -93,6 +93,7 @@ defmodule Dbservice.Resources do
         ]
       )
       |> Repo.all()
+      |> order_resources_by_ids(problem_ids)
 
     # topic_id lives on the resource_topic join table, not on the resource
     # itself, so fetch the mapping separately and attach it per problem.
@@ -108,6 +109,17 @@ defmodule Dbservice.Resources do
         problem_lang: problem_lang || %{},
         requested_curriculum_id: curriculum_id
       }
+    end)
+  end
+
+  defp order_resources_by_ids(resources, resource_ids) do
+    resources_by_id = Map.new(resources, &{&1.id, &1})
+
+    Enum.flat_map(resource_ids, fn resource_id ->
+      case Map.fetch(resources_by_id, resource_id) do
+        {:ok, resource} -> [resource]
+        :error -> []
+      end
     end)
   end
 

--- a/test/dbservice/resources_test.exs
+++ b/test/dbservice/resources_test.exs
@@ -1,0 +1,65 @@
+defmodule Dbservice.ResourcesTest do
+  use Dbservice.DataCase, async: true
+
+  alias Dbservice.Languages.Language
+  alias Dbservice.Repo
+  alias Dbservice.Resources
+  alias Dbservice.Resources.ProblemLanguage
+  alias Dbservice.Resources.Resource
+
+  describe "get_problems_by_test_and_language/3" do
+    test "returns problems in the order saved on the test" do
+      language =
+        Repo.insert!(%Language{
+          name: "English",
+          code: "test_en_#{System.unique_integer([:positive])}"
+        })
+
+      first = insert_problem!(language.id)
+      second = insert_problem!(language.id)
+      third = insert_problem!(language.id)
+
+      test_resource =
+        Repo.insert!(%Resource{
+          type: "test",
+          type_params: %{
+            "subjects" => [
+              %{
+                "sections" => [
+                  %{
+                    "compulsory" => %{
+                      "problems" => [
+                        %{"id" => second.id},
+                        %{"id" => first.id},
+                        %{"id" => third.id}
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        })
+
+      problems = Resources.get_problems_by_test_and_language(test_resource.id, language.code, 1)
+
+      assert Enum.map(problems, & &1.resource.id) == [second.id, first.id, third.id]
+    end
+  end
+
+  defp insert_problem!(language_id) do
+    resource =
+      Repo.insert!(%Resource{
+        type: "problem",
+        type_params: %{}
+      })
+
+    Repo.insert!(%ProblemLanguage{
+      res_id: resource.id,
+      lang_id: language_id,
+      meta_data: %{}
+    })
+
+    resource
+  end
+end


### PR DESCRIPTION
## Summary
- Reorder test-problem API results to match the problem order saved in test type_params
- Add coverage for saved problem order in `get_problems_by_test_and_language/3`

## Verification
- `mix test test/dbservice/resources_test.exs`
- Local browser repro against CMS test `2205`: after save, the detail page shows the shuffled order

## Note
- Full `mix test` currently has unrelated existing failures in error JSON, student controller, group update processor, and enrollment service tests.

## Related PRs
- CMS: https://github.com/avantifellows/nex-gen-cms/pull/145