### PR TITLE
fix(resources): return test problems in type_params order

### DIFF
--- a/lib/dbservice/resources.ex
+++ b/lib/dbservice/resources.ex
@@ -93,6 +93,9 @@ defmodule Dbservice.Resources do
         ]
       )
       |> Repo.all()
+      # SQL `IN` does not preserve list order, so re-sort the fetched problems to match the
+      # order the ids appear in the test's type_params (the order the test defines).
+      |> order_problems_by_ids(problem_ids)
 
     # topic_id lives on the resource_topic join table, not on the resource
     # itself, so fetch the mapping separately and attach it per problem.
@@ -109,6 +112,18 @@ defmodule Dbservice.Resources do
         requested_curriculum_id: curriculum_id
       }
     end)
+  end
+
+  # Re-sorts fetched problem resources to match the order the ids appear in the test's
+  # type_params. Ids that don't resolve to a problem resource are dropped; duplicate ids
+  # collapse to a single (first) occurrence.
+  defp order_problems_by_ids(problems, problem_ids) do
+    problems_by_id = Map.new(problems, &{&1.id, &1})
+
+    problem_ids
+    |> Enum.uniq()
+    |> Enum.map(&Map.get(problems_by_id, &1))
+    |> Enum.reject(&is_nil/1)
   end
 
   # Returns a map of resource_id => resource_topic record for the given

--- a/test/dbservice/resources_test.exs
+++ b/test/dbservice/resources_test.exs
@@ -92,4 +92,44 @@ defmodule Dbservice.ResourcesTest do
       assert rc.grade_id == grade.id
     end
   end
+
+  describe "get_problems_by_test_and_language/3 ordering" do
+    test "returns problems in the order defined in the test's type_params, not by id" do
+      # Unique code to avoid colliding with any pre-existing language in the test DB.
+      {:ok, _language} =
+        Dbservice.Languages.create_language(%{"name" => "Ordering Test", "code" => "zzt"})
+
+      # Created in ascending-id order; the test will define a different order.
+      p1 = resource_fixture("problem")
+      p2 = resource_fixture("problem")
+      p3 = resource_fixture("problem")
+      p4 = resource_fixture("problem")
+
+      # Deliberately scrambled relative to id order (mirrors issue #565).
+      ordered_ids = [p3.id, p1.id, p4.id, p2.id]
+
+      type_params = %{
+        "subjects" => [
+          %{
+            "subject_id" => 2,
+            "sections" => [
+              %{
+                "type" => "mcq_single_answer",
+                "compulsory" => %{
+                  "problems" => Enum.map(ordered_ids, fn id -> %{"id" => id} end)
+                }
+              }
+            ]
+          }
+        ]
+      }
+
+      {:ok, test_resource} =
+        Resources.create_resource(%{"type" => "test", "type_params" => type_params})
+
+      result = Resources.get_problems_by_test_and_language(test_resource.id, "zzt", 1)
+
+      assert Enum.map(result, & &1.resource.id) == ordered_ids
+    end
+  end
 end


### PR DESCRIPTION
Fixes #565

## Why

`GET /api/resource/test/:id/problems` returned problems in **ascending id order** instead of the order defined in the test's `resource.type_params`.

`extract_problem_ids_from_test/1` already produces the ids in `type_params` order, but `fetch_and_format_problems` then ran `where r.id in ^problem_ids` + `Repo.all` — and SQL `IN` does **not** preserve the list order, so the rows came back effectively in id order. From the issue: type_params order `2038, 2040, 2220, 2044` was returned as `2038, 2040, 2044, 2220`.

## What

Reorder the fetched problem resources to match the `type_params` id order before building the response (`order_problems_by_ids/2`):
- ids that don't resolve to a `problem` resource are dropped,
- duplicate ids collapse to their first occurrence.

No API/contract change — only the ordering of the returned list is corrected.

## Verification

- Added a test in `resources_test.exs`: builds a test whose `type_params` lists 4 problems in a deliberately scrambled order (vs their ascending ids) and asserts the response comes back in `type_params` order. Fails on `main`, passes with this fix.
- `mix test test/dbservice/resources_test.exs` → 6/6; `mix credo` clean; format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)