### PR TITLE
perf(db): add user_id and session_id indexes on user_session

### DIFF
--- a/priv/repo/migrations/20260701120000_add_user_session_indexes.exs
+++ b/priv/repo/migrations/20260701120000_add_user_session_indexes.exs
@@ -1,0 +1,17 @@
+defmodule Dbservice.Repo.Migrations.AddUserSessionIndexes do
+  use Ecto.Migration
+
+  # CREATE INDEX CONCURRENTLY cannot run inside a transaction, and the migration
+  # advisory lock can conflict with the concurrent build, so both are disabled.
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  # `user_session` is the largest table (~3.9M rows) and was left without indexes on
+  # `user_id`/`session_id` after `user_id` was dropped and re-added via references/2
+  # (which creates the FK but not an index). Both columns are queried on hot paths
+  # (deletes, exists? checks, association preloads), causing full table scans.
+  def change do
+    create_if_not_exists index(:user_session, [:user_id], concurrently: true)
+    create_if_not_exists index(:user_session, [:session_id], concurrently: true)
+  end
+end


### PR DESCRIPTION
Closes #493

## Why

`user_session` (~3.9M rows, 407 MB — the largest table) has no index on `user_id` or `session_id`, so every lookup is a parallel sequential scan (~244ms in prod). The `user_id` index was implicitly dropped when the column was removed (`20230320064301`) and re-added via `references/2` (`20240525065205`), which creates the FK constraint but **not** an index.

Hot paths hitting these unindexed columns: `Sessions.delete_user_sessions_by_user_id` (`delete_all`), `user_session_controller` cleanup `exists?`, the dynamic list endpoint, and `User` ↔ `SessionOccurrence` association preloads.

## What

New migration adding single-column indexes on `user_id` and `session_id`, built **`CONCURRENTLY`** (`@disable_ddl_transaction true` + `@disable_migration_lock true`) so the table isn't write-locked during the build. `create_if_not_exists` keeps it idempotent if interrupted.

App code unchanged.

## Deploy note
Concurrent build does two full scans of a 407 MB table — run during low traffic (~2–5 min/index on `db.t4g.large`), then `ANALYZE user_session;`. If a build is interrupted, `CONCURRENTLY` can leave an invalid index — check `pg_index.indisvalid` and drop/recreate if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)