### PR TITLE
perf(db): add composite index on session_occurrence(session_id, start_time, end_time)

### DIFF
--- a/priv/repo/migrations/20260701120100_add_session_occurrence_composite_index.exs
+++ b/priv/repo/migrations/20260701120100_add_session_occurrence_composite_index.exs
@@ -1,0 +1,16 @@
+defmodule Dbservice.Repo.Migrations.AddSessionOccurrenceCompositeIndex do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  # The active-window query `WHERE session_id = ? AND start_time <= ? AND end_time >= ?`
+  # currently relies on a BitmapAnd of separate single-column indexes (the #1/#3 cumulative
+  # time consumers). A composite (session_id, start_time, end_time) lets the planner satisfy
+  # the whole predicate in one B-tree traversal: equality on session_id, then a range scan.
+  def change do
+    create_if_not_exists index(:session_occurrence, [:session_id, :start_time, :end_time],
+                           concurrently: true
+                         )
+  end
+end


### PR DESCRIPTION
Closes #492

## Why

The active-window query `WHERE session_id = ? AND start_time <= ? AND end_time >= ? ORDER BY id` is one of the top cumulative-time consumers (≈11h total over ~2M calls). The table has separate single-column indexes on `session_id`, `start_time`, `end_time`, so the planner does a **BitmapAnd** intersection — functional but sensitive to data distribution (slow when a session has many occurrences or the range is wide).

## What

Adds a composite index `(session_id, start_time, end_time)`:
- `session_id` (equality) narrows to one session,
- `start_time` enables the range scan,
- `end_time` lets the planner apply `end_time >= ?` from the index.

Built **`CONCURRENTLY`** (`@disable_ddl_transaction` + `@disable_migration_lock`), `create_if_not_exists` for idempotency. No app code change.

## Follow-ups noted in the issue (not in this PR)
- After ~1 week of `pg_stat_user_indexes` monitoring, the redundant standalone `session_occurence_session_id_index` (note the typo, ~11 MB) can be dropped.
- Splitting the continuous vs non-continuous schedule queries into distinct Ecto queries is a separate app-level improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)