### PR TITLE
perf(db): add composite index on group_user(user_id, group_id)

### DIFF
--- a/priv/repo/migrations/20260701120200_add_group_user_composite_index.exs
+++ b/priv/repo/migrations/20260701120200_add_group_user_composite_index.exs
@@ -1,0 +1,18 @@
+defmodule Dbservice.Repo.Migrations.AddGroupUserCompositeIndex do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  # The membership probe `WHERE group_id = ? AND user_id = ?` is the #1 cumulative time
+  # consumer. With only separate single-column indexes, the planner picks one and filters on
+  # the other - scanning many rows for large groups (some have 100k+ members). A composite
+  # with user_id leading (users have ~9-12 memberships, far more selective than group_id)
+  # answers the probe in one traversal and also serves user_id-only lookups.
+  #
+  # Non-unique on purpose: a UNIQUE index would need existing duplicate (user_id, group_id)
+  # pairs de-duped first, which is tracked separately.
+  def change do
+    create_if_not_exists index(:group_user, [:user_id, :group_id], concurrently: true)
+  end
+end


### PR DESCRIPTION
Closes #489

## Why

The membership probe `WHERE group_id = ? AND user_id = ?` is the **#1 cumulative time consumer** (~23h over 4.58M calls, 18ms mean, 508ms worst case). The table has only separate single-column indexes, so the planner scans rows on one column and filters the other — which explodes for large groups (some have 100k–258k members).

## What

Adds a composite index `(user_id, group_id)` — `user_id` leading because it's far more selective (users have ~9–12 memberships vs groups up to 258k). It answers the probe in a single B-tree traversal and is dual-purpose (also serves `user_id`-only lookups like `get_group_user_by_user_id`).

Built **`CONCURRENTLY`**, `create_if_not_exists`. The existing single-column indexes are left in place (the `group_id` one still serves "list all members of a group").

**Non-unique on purpose:** the issue suggests *considering* a UNIQUE index, but that requires de-duping existing `(user_id, group_id)` pairs first (same class of work as #546/#482), so it's out of scope for this low-risk index add.

The issue's Phase 2/3 app-level batching + caching (reducing the 4.58M call volume) are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)