### PR TITLE
perf(db): add missing FK/lookup indexes on 12+ tables

### DIFF
--- a/priv/repo/migrations/20260701120300_add_missing_fk_indexes.exs
+++ b/priv/repo/migrations/20260701120300_add_missing_fk_indexes.exs
@@ -1,0 +1,37 @@
+defmodule Dbservice.Repo.Migrations.AddMissingFkIndexes do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  # 12+ tables have foreign-key/lookup columns that are joined/filtered on hot paths but have
+  # no index, forcing sequential scans. All built CONCURRENTLY so the tables stay writable
+  # during the build; create_if_not_exists keeps the migration re-runnable if interrupted.
+  def change do
+    # Hot-path tables (highest priority)
+    create_if_not_exists index(:resource_concept, [:resource_id], concurrently: true)
+    create_if_not_exists index(:resource_concept, [:concept_id], concurrently: true)
+    create_if_not_exists index(:problem_lang, [:res_id], concurrently: true)
+    create_if_not_exists index(:problem_lang, [:lang_id], concurrently: true)
+    create_if_not_exists index(:resource, [:teacher_id], concurrently: true)
+    create_if_not_exists index(:resource, [:code], concurrently: true)
+    create_if_not_exists index(:student_exam_record, [:student_id], concurrently: true)
+    create_if_not_exists index(:student_exam_record, [:exam_id], concurrently: true)
+
+    # Join tables
+    create_if_not_exists index(:chapter_curriculum, [:chapter_id], concurrently: true)
+    create_if_not_exists index(:chapter_curriculum, [:curriculum_id], concurrently: true)
+    create_if_not_exists index(:topic_curriculum, [:topic_id], concurrently: true)
+    create_if_not_exists index(:topic_curriculum, [:curriculum_id], concurrently: true)
+    create_if_not_exists index(:school_batch, [:school_id], concurrently: true)
+    create_if_not_exists index(:school_batch, [:batch_id], concurrently: true)
+
+    # Remaining
+    create_if_not_exists index(:learning_objective, [:concept_id], concurrently: true)
+    create_if_not_exists index(:school, [:user_id], concurrently: true)
+    create_if_not_exists index(:resource_curriculum, [:curriculum_id], concurrently: true)
+    create_if_not_exists index(:cutoffs, [:college_id], concurrently: true)
+    create_if_not_exists index(:cutoffs, [:branch_id], concurrently: true)
+    create_if_not_exists index(:cutoffs, [:demographic_profile_id], concurrently: true)
+  end
+end


### PR DESCRIPTION
Closes #483

## Why

12+ tables have FK/lookup columns that are regularly joined/filtered/preloaded but have **no index**, so those queries do sequential full-table scans. This compounds the serializer N+1 issues (#476, #479) — when a serializer fires 100+ per-item queries and each does a seq scan, the cost multiplies.

Highest-impact: `resource_concept` (every problem render via ResourceJSON), `problem_lang` (every problem endpoint), `resource.code`, `student_exam_record`.

## What

One migration adding indexes on the columns listed in the issue, across:
`resource_concept`, `problem_lang`, `resource` (`teacher_id`, `code`), `student_exam_record`, `chapter_curriculum`, `topic_curriculum`, `school_batch`, `learning_objective`, `school` (`user_id`), `resource_curriculum` (`curriculum_id`), and `cutoffs` (`college_id`, `branch_id`, `demographic_profile_id`).

All built **`CONCURRENTLY`** (`@disable_ddl_transaction` + `@disable_migration_lock`) with `create_if_not_exists` for idempotency. I verified every table/column exists in the schema before writing the migration. No app code change.

## Deploy note
Each `CREATE INDEX CONCURRENTLY` is non-blocking but adds I/O; run during lower traffic and `ANALYZE` the affected tables afterward. If any build is interrupted, check `pg_index.indisvalid` and drop/recreate the invalid one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)