### PR TITLE
Add academic mentorship mapping schema

### DIFF
--- a/priv/repo/migrations/20260701002437_create_academic_mentorship_mentor_mentee_mappings.exs
+++ b/priv/repo/migrations/20260701002437_create_academic_mentorship_mentor_mentee_mappings.exs
@@ -1,0 +1,45 @@
+defmodule Dbservice.Repo.Migrations.CreateAcademicMentorshipMentorMenteeMappings do
+  use Ecto.Migration
+
+  def change do
+    create table(:academic_mentorship_mentor_mentee_mappings) do
+      add :school_id, references(:school, on_delete: :nothing), null: false
+      add :program_id, references(:program, on_delete: :nothing)
+      add :academic_year, :string, null: false
+      add :mentor_user_id, references(:user, on_delete: :nothing), null: false
+      add :student_id, references(:student, on_delete: :nothing), null: false
+      add :assigned_at, :utc_datetime, null: false
+      add :assigned_by_user_id, references(:user, on_delete: :nothing), null: false
+      add :ended_at, :utc_datetime
+      add :ended_by_user_id, references(:user, on_delete: :nothing)
+      add :end_reason, :text
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create unique_index(
+             :academic_mentorship_mentor_mentee_mappings,
+             [:school_id, :academic_year, :student_id],
+             where: "ended_at IS NULL",
+             name: :am_mentor_mentee_active_mentee_unique
+           )
+
+    create index(
+             :academic_mentorship_mentor_mentee_mappings,
+             [:school_id, :academic_year],
+             where: "ended_at IS NULL",
+             name: :am_mentor_mentee_school_year_active_idx
+           )
+
+    create index(
+             :academic_mentorship_mentor_mentee_mappings,
+             [:mentor_user_id, :academic_year],
+             where: "ended_at IS NULL",
+             name: :am_mentor_mentee_mentor_year_active_idx
+           )
+
+    create index(:academic_mentorship_mentor_mentee_mappings, [:mentor_user_id],
+             name: :am_mentor_mentee_teacher_history_idx
+           )
+  end
+end

--- a/test/dbservice/academic_mentorship_schema_test.exs
+++ b/test/dbservice/academic_mentorship_schema_test.exs
@@ -22,6 +22,75 @@ defmodule Dbservice.AcademicMentorshipSchemaTest do
   @identity_tables @tables -- ["acad_mentorship_runtime_settings"]
 
   describe "Academic Mentorship schema" do
+    test "creates the LMS Academic Mentor-Mentee Mapping table" do
+      table = "academic_mentorship_mentor_mentee_mappings"
+
+      assert table in table_names()
+
+      assert Map.keys(columns(table)) |> Enum.sort() == [
+               "academic_year",
+               "assigned_at",
+               "assigned_by_user_id",
+               "end_reason",
+               "ended_at",
+               "ended_by_user_id",
+               "id",
+               "inserted_at",
+               "mentor_user_id",
+               "program_id",
+               "school_id",
+               "student_id",
+               "updated_at"
+             ]
+
+      assert_required_columns(table, [
+        "id",
+        "school_id",
+        "academic_year",
+        "mentor_user_id",
+        "student_id",
+        "assigned_at",
+        "assigned_by_user_id",
+        "inserted_at",
+        "updated_at"
+      ])
+
+      assert columns(table)["id"].type == "bigint"
+      assert columns(table)["program_id"].nullable?
+      assert columns(table)["ended_at"].nullable?
+      assert columns(table)["ended_by_user_id"].nullable?
+      assert columns(table)["end_reason"].nullable?
+
+      assert foreign_keys(table) == [
+               {"assigned_by_user_id", "user", "id"},
+               {"ended_by_user_id", "user", "id"},
+               {"mentor_user_id", "user", "id"},
+               {"program_id", "program", "id"},
+               {"school_id", "school", "id"},
+               {"student_id", "student", "id"}
+             ]
+
+      assert index_def("am_mentor_mentee_active_mentee_unique") =~ "UNIQUE INDEX"
+
+      assert index_def("am_mentor_mentee_active_mentee_unique") =~
+               "(school_id, academic_year, student_id)"
+
+      assert index_def("am_mentor_mentee_active_mentee_unique") =~ "WHERE (ended_at IS NULL)"
+
+      assert index_def("am_mentor_mentee_school_year_active_idx") =~
+               "(school_id, academic_year)"
+
+      assert index_def("am_mentor_mentee_school_year_active_idx") =~ "WHERE (ended_at IS NULL)"
+
+      assert index_def("am_mentor_mentee_mentor_year_active_idx") =~
+               "(mentor_user_id, academic_year)"
+
+      assert index_def("am_mentor_mentee_mentor_year_active_idx") =~
+               "WHERE (ended_at IS NULL)"
+
+      assert ["mentor_user_id"] in indexes(table)
+    end
+
     test "creates the full phase-1 table set" do
       existing_tables = table_names()
 


### PR DESCRIPTION
## Summary

Adds the LMS-owned Academic Mentorship Mentor-Mentee Mapping schema required by avantifellows/af_lms#141.

## Changes

- Creates `academic_mentorship_mentor_mentee_mappings` with mentor, student, school, academic-year, program, assignment audit, and end audit columns.
- Adds the partial unique index that enforces one active mentor per student per school + academic year.
- Adds schema-level tests for columns, foreign keys, indexes, and rollback.

## Verification

- `mix test test/dbservice/academic_mentorship_schema_test.exs`
- `mix check`

Related LMS PR: avantifellows/af_lms#152
Closes avantifellows/af_lms#151
