### PR TITLE
Backfill chapter_id on existing chapter tests

### DIFF
--- a/priv/repo/migrations/20260701162415_backfill_chapter_id_on_chapter_tests.exs
+++ b/priv/repo/migrations/20260701162415_backfill_chapter_id_on_chapter_tests.exs
@@ -1,0 +1,50 @@
+defmodule Dbservice.Repo.Migrations.BackfillChapterIdOnChapterTests do
+  use Ecto.Migration
+
+  # Seed type_params.chapter_id on existing chapter_test resources by deriving the chapter
+  # from the test's problems (test -> problems -> resource_chapter -> chapter). This mirrors
+  # how a chapter test's chapter has always been implicit (a question can only be authored
+  # inside a chapter/topic). Only tests whose problems resolve to exactly ONE chapter are
+  # backfilled; orphan/hand-made tests are left unset. Validated on staging: 107/111
+  # chapter tests resolve to a single chapter, 0 to multiple, 4 to none.
+  #
+  # chapter_id lives in the type_params jsonb (not a shared resource column) because it is
+  # only meaningful for chapter_test, one of several test subtypes.
+
+  def up do
+    execute("""
+    UPDATE resource t
+    SET type_params = jsonb_set(t.type_params, '{chapter_id}', to_jsonb(sub.chapter_id))
+    FROM (
+      SELECT tp.test_id, min(rc.chapter_id) AS chapter_id
+      FROM (
+        SELECT r.id AS test_id, (prob->>'id')::bigint AS problem_id
+        FROM resource r,
+             jsonb_array_elements(r.type_params->'subjects') subj,
+             jsonb_array_elements(subj->'sections') sec,
+             jsonb_array_elements(
+               COALESCE(sec->'compulsory'->'problems', '[]'::jsonb)
+               || COALESCE(sec->'optional'->'problems', '[]'::jsonb)
+             ) prob
+        WHERE r.type = 'test' AND r.subtype = 'chapter_test'
+      ) tp
+      JOIN resource_chapter rc ON rc.resource_id = tp.problem_id
+      GROUP BY tp.test_id
+      HAVING count(DISTINCT rc.chapter_id) = 1
+    ) sub
+    WHERE t.id = sub.test_id
+      AND t.type = 'test'
+      AND t.subtype = 'chapter_test'
+    """)
+  end
+
+  def down do
+    execute("""
+    UPDATE resource
+    SET type_params = type_params - 'chapter_id'
+    WHERE type = 'test'
+      AND subtype = 'chapter_test'
+      AND type_params ? 'chapter_id'
+    """)
+  end
+end


### PR DESCRIPTION
Part of the **lms-cms-tests** effort (pairs with nex-gen-cms PR #151). A data-only migration — no schema change.

## What

Seeds `type_params.chapter_id` on existing `chapter_test` resources by deriving the chapter from each test's problems: **test → problems → `resource_chapter` → chapter**. Only tests whose problems resolve to **exactly one** chapter are backfilled; orphan/hand-made tests are left unset.

A chapter test has always had an implicit chapter (a question can only be authored inside a chapter/topic), but it was never stored on the test — the chapter only lived in the test's name/code. This makes it explicit so the CMS and LMS can surface "tests for a chapter" without a per-request problem walk.

## Why `type_params`, not a column

`chapter_id` is only meaningful for `chapter_test` (one of several test subtypes), so it lives in the test's `type_params` jsonb rather than a shared `resource` column — matching how the model already treats subtype-specific fields.

## Validated (read-only, against staging)

- **107 / 111** chapter tests resolve to a single chapter; **0** to multiple; **4** orphans left unset.
- Derived chapter matches the chapter baked into each test's name, 100% on spot-check — e.g. `11C8 - Ionic Equilibrium` → chapter *Ionic Equilibrium*, `12P25 - Modern Physics` → *Modern Physics*.

## Reversible

`down/` strips the `chapter_id` key from `type_params` for chapter tests.

> Follow-up (not here): the CMS add/edit-test flow should let authors set `chapter_id` for **new** chapter tests — this migration only covers the existing ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)