### PR TITLE
feat(data-import): create schools as users on school import

### DIFF
--- a/lib/dbservice/schools.ex
+++ b/lib/dbservice/schools.ex
@@ -9,6 +9,7 @@ defmodule Dbservice.Schools do
 
   alias Dbservice.Groups.Group
   alias Dbservice.Schools.School
+  alias Dbservice.Users
   alias Dbservice.Users.User
   alias Dbservice.Schools
 
@@ -189,4 +190,29 @@ defmodule Dbservice.Schools do
       {:ok, school}
     end
   end
+
+  @doc """
+  Creates or updates a school (matched by `code`) together with its associated user.
+
+  New schools are created with a user (`create_school_with_user/1`). For an existing school,
+  its linked user is updated; a legacy school that predates school-as-user (no `user_id`) has
+  a user created and attached. Mirrors the `/school-with-user` endpoint so the data-import
+  tool produces schools that are also users.
+
+  Returns `{:ok, %School{}}` or `{:error, %Ecto.Changeset{}}`.
+  """
+  def create_or_update_school_with_user(attrs) do
+    case get_school_by_code(attrs["code"]) do
+      nil ->
+        create_school_with_user(attrs)
+
+      %School{} = existing ->
+        with {:ok, %User{} = user} <- ensure_school_user(existing, attrs) do
+          update_school_with_user(existing, user, attrs)
+        end
+    end
+  end
+
+  defp ensure_school_user(%School{user_id: nil}, attrs), do: Users.create_user(attrs)
+  defp ensure_school_user(%School{user_id: user_id}, _attrs), do: {:ok, Users.get_user!(user_id)}
 end

--- a/lib/dbservice/utils/import_worker.ex
+++ b/lib/dbservice/utils/import_worker.ex
@@ -1390,11 +1390,10 @@ defmodule Dbservice.DataImport.ImportWorker do
     |> maybe_put_school("board", record["school_board"] |> trim_str())
   end
 
-  defp create_or_update_school(code, attrs) do
-    case Schools.get_school_by_code(code) do
-      nil -> Schools.create_school(attrs)
-      existing -> Schools.update_school(existing, attrs)
-    end
+  # School imports create the school *as a user* too (School.user_id), matching the
+  # /school-with-user endpoint. `code` is already carried in attrs.
+  defp create_or_update_school(_code, attrs) do
+    Schools.create_or_update_school_with_user(attrs)
   end
 
   defp format_school_result({:ok, school}), do: {:ok, school}

--- a/test/dbservice/schools_test.exs
+++ b/test/dbservice/schools_test.exs
@@ -342,4 +342,54 @@ defmodule Dbservice.SchoolsTest do
     #     assert %Ecto.Changeset{} = Schools.change_enrollment_record(enrollment_record)
     #   end
   end
+
+  describe "create_or_update_school_with_user/1" do
+    alias Dbservice.Schools.School
+    alias Dbservice.Users
+    alias Dbservice.Users.User
+
+    @with_user_attrs %{
+      "code" => "SCH_WU_001",
+      "name" => "WU School",
+      "af_school_category" => "Cat",
+      "district_code" => "DC1",
+      "district" => "District 1",
+      "state_code" => "SC1",
+      "state" => "State 1"
+    }
+
+    test "creates a new school together with a user" do
+      assert {:ok, %School{} = school} =
+               Schools.create_or_update_school_with_user(@with_user_attrs)
+
+      assert school.code == "SCH_WU_001"
+      assert is_integer(school.user_id)
+      assert %User{} = Users.get_user!(school.user_id)
+    end
+
+    test "updates an existing school and backfills a user when none is linked" do
+      {:ok, legacy} = Schools.create_school(@with_user_attrs)
+      assert is_nil(legacy.user_id)
+
+      assert {:ok, %School{} = updated} =
+               Schools.create_or_update_school_with_user(
+                 Map.put(@with_user_attrs, "name", "Renamed")
+               )
+
+      assert updated.id == legacy.id
+      assert updated.name == "Renamed"
+      assert is_integer(updated.user_id)
+    end
+
+    test "reuses the linked user when updating a school that already has one" do
+      {:ok, created} = Schools.create_school_with_user(@with_user_attrs)
+
+      assert {:ok, %School{} = updated} =
+               Schools.create_or_update_school_with_user(
+                 Map.put(@with_user_attrs, "name", "Again")
+               )
+
+      assert updated.user_id == created.user_id
+    end
+  end
 end


### PR DESCRIPTION
## Why

The `school_addition` import used plain `Schools.create_school`/`update_school`, so schools created via import had **no associated user** (`School.user_id` was `nil`). We already have a `POST /school-with-user` endpoint (`SchoolController.create_school_with_user`) that creates a school together with a user — the import should do the same so imported schools are also users.

## What

- **`Schools.create_or_update_school_with_user/1`** — matches the school by `code` and:
  - new school → `create_school_with_user/1` (creates the user + school),
  - existing school with a linked user → updates that user (`update_school_with_user/3`),
  - existing school with **no** user (legacy rows that predate school-as-user) → creates a user and attaches it.

  This consolidates the create/update-with-user logic (mirrors what the `/school-with-user` controller does inline).
- The import worker's `create_or_update_school` now delegates to it — no other change to the school import (columns, validation, etc. unchanged).

## Notes
- School users are created via the existing `create_school_with_user` path, so they carry the same fields that endpoint sets (shared columns like region/state/district from the import row); no role is set, matching the existing endpoint. If a dedicated `"school"` role is wanted, that's a follow-up on `create_school_with_user` itself so both paths stay consistent.
- The controller still has its own inline copy of this logic; a follow-up could switch it to the new context function to de-duplicate (left out here to keep the PR focused).

## Verification
- `mix test test/dbservice/schools_test.exs test/dbservice/utils/import_worker_test.exs` → 23/23; credo + format clean.
- New tests cover: new school creates a user; legacy school update backfills a user; existing linked user is reused on update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)