### PR TITLE
Implement atomic LMS NVS student edit endpoint

### DIFF
--- a/lib/dbservice/lms_student_update.ex
+++ b/lib/dbservice/lms_student_update.ex
@@ -1,0 +1,447 @@
+defmodule Dbservice.LmsStudentUpdate do
+  @moduledoc """
+  Atomic LMS student correction flow.
+
+  Grade changes here are corrections to bad current data. They are not the annual
+  Grade 11 -> Grade 12 promotion flow, where the G12 graduating year stays stable.
+  """
+
+  import Ecto.Query
+
+  alias Dbservice.Batches.Batch
+  alias Dbservice.EnrollmentRecords.EnrollmentRecord
+  alias Dbservice.Grades
+  alias Dbservice.GroupUsers
+  alias Dbservice.Groups
+  alias Dbservice.Groups.GroupUser
+  alias Dbservice.LmsStudentWriteAudit
+  alias Dbservice.Repo
+  alias Dbservice.Schools
+  alias Dbservice.Users
+  alias Dbservice.Users.Student
+
+  @action "student_update"
+  @cbse_board "CENTRAL BOARD OF SECONDARY EDUCATION"
+  @user_fields ["first_name", "gender", "date_of_birth", "phone"]
+  @student_fields [
+    "category",
+    "physically_handicapped",
+    "board_stream",
+    "stream",
+    "father_name",
+    "annual_family_income",
+    "g10_board"
+  ]
+  @locked_fields [
+    "apaar_id",
+    "auth_group",
+    "batch_group_id",
+    "batch_id",
+    "g10_roll_no",
+    "grade_id",
+    "group_id",
+    "school_code",
+    "student_id",
+    "udise_code",
+    "user_id"
+  ]
+  @metadata_fields ["actor", "school", "program_id", "academic_year", "start_date"]
+  @editable_fields @user_fields ++ @student_fields ++ ["grade"]
+
+  def update(student_pk_id, params) do
+    Repo.transaction(fn ->
+      with :ok <- reject_locked_fields(params),
+           :ok <- reject_unsupported_fields(params),
+           {:ok, student} <- fetch_student(student_pk_id),
+           {:ok, school} <- fetch_school(params),
+           :ok <- validate_school_scope(student, school, params["program_id"]),
+           {:ok, user} <- fetch_user(student),
+           :ok <- validate_g10_board(student, params),
+           {:ok, plan} <- enrollment_plan(student, params),
+           {:ok, changed_values} <- changed_values(user, student, params, plan),
+           {:ok, user} <- update_user(user, params),
+           {:ok, student} <- update_student(student, params, plan),
+           {:ok, _enrollments} <- replace_enrollments(student.user_id, plan, params),
+           {:ok, audit} <- insert_audit(user, student, school, params, changed_values) do
+        %{
+          "status" => "updated",
+          "student_pk_id" => student.id,
+          "changed_fields" => changed_values |> Map.keys() |> Enum.sort(),
+          "audit_id" => audit.id
+        }
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+    |> case do
+      {:ok, result} -> {:ok, result}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp reject_locked_fields(params) do
+    case params |> Map.keys() |> Enum.filter(&(&1 in @locked_fields)) |> Enum.sort() do
+      [] -> :ok
+      fields -> {:error, error("locked_fields", "Locked fields cannot be updated", 422, fields)}
+    end
+  end
+
+  defp reject_unsupported_fields(params) do
+    allowed = @metadata_fields ++ @editable_fields
+
+    case params |> Map.keys() |> Enum.reject(&(&1 in allowed)) |> Enum.sort() do
+      [] ->
+        :ok
+
+      fields ->
+        {:error, error("unsupported_fields", "Unsupported fields cannot be updated", 422, fields)}
+    end
+  end
+
+  defp fetch_student(id) do
+    case Repo.get(Student, id) do
+      nil -> {:error, error("not_found", "Student not found", 404)}
+      student -> {:ok, student}
+    end
+  end
+
+  defp fetch_school(%{"school" => %{"code" => code, "udise_code" => udise_code}}) do
+    case Schools.get_school_by_code(code) do
+      %{udise_code: ^udise_code} = school -> {:ok, school}
+      _ -> {:error, error("school_not_found", "School not found", 404)}
+    end
+  end
+
+  defp fetch_school(_params), do: {:error, error("school_required", "School is required", 400)}
+
+  defp validate_school_scope(student, school, program_id) do
+    cond do
+      to_int(program_id) not in (school.program_ids || []) ->
+        {:error, error("program_not_allowed", "School is not eligible for this program", 403)}
+
+      not enrolled?(student.user_id, school.id, "school") ->
+        {:error, error("school_mismatch", "Student is not enrolled in this school", 403)}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp enrolled?(user_id, group_id, group_type) do
+    from(e in EnrollmentRecord,
+      where:
+        e.user_id == ^user_id and e.group_id == ^group_id and e.group_type == ^group_type and
+          e.is_current == true
+    )
+    |> Repo.exists?()
+  end
+
+  defp fetch_user(student) do
+    {:ok, Users.get_user!(student.user_id)}
+  rescue
+    Ecto.NoResultsError -> {:error, error("user_not_found", "Student user not found", 404)}
+  end
+
+  defp validate_g10_board(_student, params) when not is_map_key(params, "g10_board"), do: :ok
+
+  defp validate_g10_board(student, %{"g10_board" => @cbse_board}) do
+    if student.g10_roll_no in [nil, ""] or Regex.match?(~r/^\d{8}$/, student.g10_roll_no) do
+      :ok
+    else
+      {:error,
+       error(
+         "invalid_g10_roll_for_board",
+         "CBSE Grade 10 Roll no must be exactly 8 digits",
+         422,
+         ["g10_board"]
+       )}
+    end
+  end
+
+  defp validate_g10_board(student, _params) do
+    if student.g10_roll_no in [nil, ""] or Regex.match?(~r/^[A-Z0-9]+$/, student.g10_roll_no) do
+      :ok
+    else
+      {:error,
+       error(
+         "invalid_g10_roll_for_board",
+         "Grade 10 Roll no must contain only letters and digits",
+         422,
+         ["g10_board"]
+       )}
+    end
+  end
+
+  defp enrollment_plan(student, params) do
+    needs_enrollment_change? = Map.has_key?(params, "grade") or Map.has_key?(params, "stream")
+
+    if needs_enrollment_change? do
+      with {:ok, grade} <- fetch_grade(params["grade"] || current_grade_number(student)),
+           {:ok, batch} <-
+             fetch_batch(grade.number, params["stream"] || student.stream, params["program_id"]),
+           {:ok, student_id} <- generated_student_id(student, grade.number) do
+        {:ok,
+         %{
+           grade: grade,
+           batch: batch,
+           student_attrs: %{
+             "grade_id" => grade.id,
+             "g12_graduating_year" => g12_graduating_year(grade.number),
+             "student_id" => student_id
+           },
+           changed_values: derived_changed_values(student, grade, batch, student_id)
+         }}
+      end
+    else
+      {:ok, %{student_attrs: %{}, changed_values: %{}}}
+    end
+  end
+
+  defp fetch_grade(grade_number) do
+    case Grades.get_grade_by_number(to_int(grade_number)) do
+      nil -> {:error, error("grade_not_found", "Grade not found", 422, ["grade"])}
+      grade when grade.number in [11, 12] -> {:ok, grade}
+      _grade -> {:error, error("invalid_grade", "Grade must be 11 or 12", 422, ["grade"])}
+    end
+  end
+
+  defp current_grade_number(%{grade_id: nil}), do: nil
+
+  defp current_grade_number(student) do
+    case Grades.get_grade(student.grade_id) do
+      nil -> nil
+      grade -> grade.number
+    end
+  end
+
+  defp fetch_batch(grade, stream, program_id) do
+    batches =
+      from(b in Batch,
+        where:
+          b.program_id == ^to_int(program_id) and
+            fragment("?->>'grade' = ?", b.metadata, ^to_string(grade)) and
+            fragment("?->>'stream' = ?", b.metadata, ^stream)
+      )
+      |> Repo.all()
+
+    case batches do
+      [batch] ->
+        case Groups.get_group_by_child_id_and_type(batch.id, "batch") do
+          nil ->
+            {:error, error("batch_group_not_found", "Batch group not found", 422, ["stream"])}
+
+          _group ->
+            {:ok, batch}
+        end
+
+      [] ->
+        {:error, error("batch_not_found", "No matching batch found", 422, ["grade", "stream"])}
+
+      _ ->
+        {:error,
+         error("multiple_batches", "Multiple matching batches found", 422, ["grade", "stream"])}
+    end
+  end
+
+  defp generated_student_id(%{g10_roll_no: value}, _grade) when value in [nil, ""], do: {:ok, nil}
+
+  defp generated_student_id(student, grade) do
+    student_id = "#{g12_graduating_year(grade)}#{student.g10_roll_no}"
+
+    case Repo.get_by(Student, student_id: student_id) do
+      nil ->
+        {:ok, student_id}
+
+      %{id: id} when id == student.id ->
+        {:ok, student_id}
+
+      _student ->
+        {:error,
+         error("duplicate_student_id", "Generated Student ID already exists", 409, ["grade"])}
+    end
+  end
+
+  defp g12_graduating_year(11), do: 2028
+  defp g12_graduating_year(12), do: 2027
+
+  defp derived_changed_values(student, grade, batch, student_id) do
+    current_grade = current_grade_number(student)
+    current_batch = current_enrollment(student.user_id, "batch")
+
+    %{
+      "grade" => old_new(current_grade, grade.number),
+      "g12_graduating_year" =>
+        old_new(student.g12_graduating_year, g12_graduating_year(grade.number)),
+      "student_id" => old_new(student.student_id, student_id),
+      "batch_id" => old_new(current_batch && current_batch.group_id, batch.id)
+    }
+    |> Enum.reject(fn {_field, %{"old" => old, "new" => new}} -> old == new end)
+    |> Map.new()
+  end
+
+  defp current_enrollment(user_id, group_type) do
+    Repo.one(
+      from(e in EnrollmentRecord,
+        where: e.user_id == ^user_id and e.group_type == ^group_type and e.is_current == true
+      )
+    )
+  end
+
+  defp changed_values(user, student, params, plan) do
+    values =
+      params
+      |> Map.take(@user_fields)
+      |> Enum.map(fn {field, new} ->
+        {field, old_new(Map.get(user, String.to_existing_atom(field)), new)}
+      end)
+      |> Kernel.++(
+        params
+        |> Map.take(@student_fields)
+        |> Enum.map(fn {field, new} ->
+          {field, old_new(Map.get(student, String.to_existing_atom(field)), new)}
+        end)
+      )
+      |> Enum.reject(fn {_field, %{"old" => old, "new" => new}} -> old == new end)
+      |> Map.new()
+      |> Map.merge(plan.changed_values)
+
+    {:ok, values}
+  end
+
+  defp old_new(old, new), do: %{"old" => old, "new" => new}
+
+  defp update_user(user, params) do
+    case params |> Map.take(@user_fields) |> empty_to_ok(user, &Users.update_user/2) do
+      {:ok, user} ->
+        {:ok, user}
+
+      {:error, _changeset} ->
+        {:error, error("invalid_user_fields", "User fields are invalid", 422)}
+    end
+  end
+
+  defp update_student(student, params, plan) do
+    attrs =
+      params
+      |> Map.take(@student_fields)
+      |> Map.merge(plan.student_attrs)
+
+    case attrs |> empty_to_ok(student, &Users.update_student/2) do
+      {:ok, student} ->
+        {:ok, student}
+
+      {:error, _changeset} ->
+        {:error, error("invalid_student_fields", "Student fields are invalid", 422)}
+    end
+  end
+
+  defp empty_to_ok(attrs, schema, update) do
+    if attrs == %{}, do: {:ok, schema}, else: update.(schema, attrs)
+  end
+
+  defp replace_enrollments(_user_id, %{student_attrs: attrs}, _params) when attrs == %{},
+    do: {:ok, :unchanged}
+
+  defp replace_enrollments(user_id, %{grade: grade, batch: batch}, params) do
+    with {:ok, _grade} <- replace_enrollment(user_id, "grade", grade.id, params),
+         {:ok, _batch} <- replace_enrollment(user_id, "batch", batch.id, params) do
+      {:ok, :replaced}
+    end
+  end
+
+  defp replace_enrollment(user_id, group_type, group_id, params) do
+    case current_enrollment(user_id, group_type) do
+      %{group_id: ^group_id} ->
+        {:ok, :unchanged}
+
+      _old ->
+        from(e in EnrollmentRecord,
+          where: e.user_id == ^user_id and e.group_type == ^group_type and e.is_current == true,
+          update: [set: [is_current: false, end_date: ^params["start_date"]]]
+        )
+        |> Repo.update_all([])
+
+        with {:ok, enrollment} <-
+               %EnrollmentRecord{}
+               |> EnrollmentRecord.changeset(%{
+                 "user_id" => user_id,
+                 "group_id" => group_id,
+                 "group_type" => group_type,
+                 "academic_year" => params["academic_year"],
+                 "start_date" => params["start_date"],
+                 "is_current" => true
+               })
+               |> Repo.insert(),
+             {:ok, _group_user} <- replace_group_user(user_id, group_type, group_id) do
+          {:ok, enrollment}
+        else
+          {:error, _reason} ->
+            {:error,
+             error("enrollment_update_failed", "Enrollment update failed", 422, [group_type])}
+        end
+    end
+  end
+
+  defp replace_group_user(user_id, group_type, child_id) do
+    new_group = Groups.get_group_by_child_id_and_type(child_id, group_type)
+
+    old_group_user =
+      from(gu in GroupUser,
+        join: g in assoc(gu, :group),
+        where: gu.user_id == ^user_id and g.type == ^group_type,
+        limit: 1
+      )
+      |> Repo.one()
+
+    cond do
+      is_nil(new_group) ->
+        {:error, :missing_group}
+
+      old_group_user ->
+        GroupUsers.update_group_user(old_group_user, %{group_id: new_group.id})
+
+      true ->
+        GroupUsers.create_group_user(%{user_id: user_id, group_id: new_group.id})
+    end
+  end
+
+  defp insert_audit(user, student, school, params, changed_values) do
+    %LmsStudentWriteAudit{}
+    |> LmsStudentWriteAudit.changeset(%{
+      action: @action,
+      actor_user_id: get_in(params, ["actor", "user_id"]),
+      actor_email: get_in(params, ["actor", "email"]),
+      actor_login_type: get_in(params, ["actor", "login_type"]),
+      actor_role: get_in(params, ["actor", "role"]),
+      school_code: school.code,
+      school_udise_code: school.udise_code,
+      program_id: to_int(params["program_id"]),
+      row_counts: %{},
+      affected_identifiers: %{
+        "student_pk_id" => student.id,
+        "user_id" => user.id,
+        "student_id" => student.student_id,
+        "apaar_id" => student.apaar_id,
+        "g10_roll_no" => student.g10_roll_no
+      },
+      created_values: %{},
+      changed_values: changed_values
+    })
+    |> Repo.insert()
+  end
+
+  defp error(code, message, status, fields \\ []) do
+    %{"code" => code, "message" => message, "status" => status, "fields" => fields}
+  end
+
+  defp to_int(value) when is_integer(value), do: value
+
+  defp to_int(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, ""} -> int
+      _ -> nil
+    end
+  end
+
+  defp to_int(_value), do: nil
+end

--- a/lib/dbservice/lms_student_write_audit.ex
+++ b/lib/dbservice/lms_student_write_audit.ex
@@ -19,6 +19,7 @@ defmodule Dbservice.LmsStudentWriteAudit do
     field :row_counts, :map, default: %{}
     field :affected_identifiers, :map, default: %{}
     field :created_values, :map, default: %{}
+    field :changed_values, :map, default: %{}
 
     timestamps()
   end
@@ -39,8 +40,15 @@ defmodule Dbservice.LmsStudentWriteAudit do
       :row_number,
       :row_counts,
       :affected_identifiers,
-      :created_values
+      :created_values,
+      :changed_values
     ])
-    |> validate_required([:action, :row_counts, :affected_identifiers, :created_values])
+    |> validate_required([
+      :action,
+      :row_counts,
+      :affected_identifiers,
+      :created_values,
+      :changed_values
+    ])
   end
 end

--- a/lib/dbservice_web/controllers/student_controller.ex
+++ b/lib/dbservice_web/controllers/student_controller.ex
@@ -20,6 +20,7 @@ defmodule DbserviceWeb.StudentController do
   alias Dbservice.Services.ReEnrollmentService
   alias Dbservice.Utils.ChangesetFormatter
   alias Dbservice.LmsStudentIngestion
+  alias Dbservice.LmsStudentUpdate
 
   action_fallback(DbserviceWeb.FallbackController)
 
@@ -117,6 +118,18 @@ defmodule DbserviceWeb.StudentController do
         conn
         |> put_status(:bad_request)
         |> json(%{error: reason})
+    end
+  end
+
+  def lms_update_with_enrollments(conn, %{"student_id" => student_id} = params) do
+    case LmsStudentUpdate.update(student_id, conn.body_params || params) do
+      {:ok, result} ->
+        json(conn, result)
+
+      {:error, %{"status" => status} = error} ->
+        conn
+        |> put_status(status)
+        |> json(%{"error" => Map.delete(error, "status")})
     end
   end
 

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -157,6 +157,12 @@ defmodule DbserviceWeb.Router do
 
     post("/student/create-with-enrollments", StudentController, :create_with_enrollments)
 
+    patch(
+      "/lms/students/:student_id/update-with-enrollments",
+      StudentController,
+      :lms_update_with_enrollments
+    )
+
     get(
       "/resource/problem/:problem_id/:lang_code/:curriculum_id",
       ResourceController,

--- a/priv/repo/migrations/20260701130000_add_lms_student_audit_changed_values.exs
+++ b/priv/repo/migrations/20260701130000_add_lms_student_audit_changed_values.exs
@@ -1,0 +1,9 @@
+defmodule Dbservice.Repo.Migrations.AddLmsStudentAuditChangedValues do
+  use Ecto.Migration
+
+  def change do
+    alter table(:lms_student_write_audits) do
+      add :changed_values, :map, null: false, default: %{}
+    end
+  end
+end

--- a/test/dbservice_web/controllers/lms_student_update_controller_test.exs
+++ b/test/dbservice_web/controllers/lms_student_update_controller_test.exs
@@ -1,0 +1,419 @@
+defmodule DbserviceWeb.LmsStudentUpdateControllerTest do
+  use DbserviceWeb.ConnCase
+
+  import Ecto.Query
+
+  alias Dbservice.EnrollmentRecords.EnrollmentRecord
+  alias Dbservice.Grades.Grade
+  alias Dbservice.Groups.Group
+  alias Dbservice.Repo
+  alias Dbservice.Schools.School
+  alias Dbservice.Users
+  alias Dbservice.Users.Student
+
+  describe "PATCH /api/lms/students/:student_id/update-with-enrollments" do
+    test "updates safe profile fields and audits old and new values", %{conn: conn} do
+      school = insert_school!()
+      grade = insert_grade!(11)
+      batch = insert_nvs_batch!(11, "engineering")
+      {user, student} = insert_enrolled_student!(school, grade, batch)
+
+      conn =
+        patch(conn, "/api/lms/students/#{student.id}/update-with-enrollments", %{
+          "actor" => actor(),
+          "school" => %{"code" => school.code, "udise_code" => school.udise_code},
+          "program_id" => 64,
+          "academic_year" => "2026-2027",
+          "start_date" => "2026-07-01",
+          "first_name" => "Updated Name",
+          "gender" => "Others",
+          "category" => "OBC"
+        })
+
+      response = json_response(conn, 200)
+      assert response["status"] == "updated"
+      assert response["student_pk_id"] == student.id
+      assert response["changed_fields"] == ["category", "first_name", "gender"]
+
+      updated_user = Users.get_user!(user.id)
+      updated_student = Repo.get!(Student, student.id)
+      assert updated_user.first_name == "Updated Name"
+      assert updated_user.gender == "Others"
+      assert updated_student.category == "OBC"
+      assert updated_student.student_id == "202812345678"
+
+      assert [
+               [
+                 "student_update",
+                 "pm@example.org",
+                 school_code,
+                 64,
+                 affected_identifiers,
+                 changed_values
+               ]
+             ] =
+               Ecto.Adapters.SQL.query!(
+                 Repo,
+                 "SELECT action, actor_email, school_code, program_id, affected_identifiers, changed_values FROM lms_student_write_audits"
+               ).rows
+
+      assert school_code == school.code
+      assert affected_identifiers["student_pk_id"] == student.id
+      assert changed_values["first_name"] == %{"old" => user.first_name, "new" => "Updated Name"}
+      assert changed_values["category"] == %{"old" => "Gen", "new" => "OBC"}
+    end
+
+    test "rejects locked identity fields without changing editable fields", %{conn: conn} do
+      school = insert_school!()
+      grade = insert_grade!(11)
+      batch = insert_nvs_batch!(11, "engineering")
+      {user, student} = insert_enrolled_student!(school, grade, batch)
+
+      conn =
+        patch(conn, "/api/lms/students/#{student.id}/update-with-enrollments", %{
+          "actor" => actor(),
+          "school" => %{"code" => school.code, "udise_code" => school.udise_code},
+          "program_id" => 64,
+          "academic_year" => "2026-2027",
+          "start_date" => "2026-07-01",
+          "first_name" => "Should Not Apply",
+          "student_id" => "SHOULD-NOT-CHANGE"
+        })
+
+      response = json_response(conn, 422)
+      assert response["error"]["code"] == "locked_fields"
+      assert response["error"]["fields"] == ["student_id"]
+      assert Users.get_user!(user.id).first_name == user.first_name
+      assert Repo.get!(Student, student.id).student_id == "202812345678"
+      assert Repo.aggregate(Dbservice.LmsStudentWriteAudit, :count, :id) == 0
+    end
+
+    test "rejects fields outside the PRD editable contract", %{conn: conn} do
+      school = insert_school!()
+      grade = insert_grade!(11)
+      batch = insert_nvs_batch!(11, "engineering")
+      {_user, student} = insert_enrolled_student!(school, grade, batch)
+
+      conn =
+        patch(conn, "/api/lms/students/#{student.id}/update-with-enrollments", %{
+          "actor" => actor(),
+          "school" => %{"code" => school.code, "udise_code" => school.udise_code},
+          "program_id" => 64,
+          "academic_year" => "2026-2027",
+          "start_date" => "2026-07-01",
+          "mother_name" => "Not In Contract"
+        })
+
+      response = json_response(conn, 422)
+      assert response["error"]["code"] == "unsupported_fields"
+      assert response["error"]["fields"] == ["mother_name"]
+      assert Repo.aggregate(Dbservice.LmsStudentWriteAudit, :count, :id) == 0
+    end
+
+    test "rejects G10 board edits when the locked G10 roll is invalid for the new board", %{
+      conn: conn
+    } do
+      school = insert_school!()
+      grade = insert_grade!(11)
+      batch = insert_nvs_batch!(11, "engineering")
+
+      {_user, student} =
+        insert_enrolled_student!(school, grade, batch, %{
+          g10_board: "RAJASTHAN BOARD OF SECONDARY EDUCATION",
+          g10_roll_no: "ABC123"
+        })
+
+      conn =
+        patch(conn, "/api/lms/students/#{student.id}/update-with-enrollments", %{
+          "actor" => actor(),
+          "school" => %{"code" => school.code, "udise_code" => school.udise_code},
+          "program_id" => 64,
+          "academic_year" => "2026-2027",
+          "start_date" => "2026-07-01",
+          "g10_board" => "CENTRAL BOARD OF SECONDARY EDUCATION"
+        })
+
+      response = json_response(conn, 422)
+      assert response["error"]["code"] == "invalid_g10_roll_for_board"
+      assert Repo.get!(Student, student.id).g10_board == "RAJASTHAN BOARD OF SECONDARY EDUCATION"
+      assert Repo.aggregate(Dbservice.LmsStudentWriteAudit, :count, :id) == 0
+    end
+
+    test "grade edits atomically update derived identity, grade enrollment, and batch", %{
+      conn: conn
+    } do
+      school = insert_school!()
+      grade11 = insert_grade!(11)
+      grade12 = insert_grade!(12)
+      old_batch = insert_nvs_batch!(11, "engineering")
+      new_batch = insert_nvs_batch!(12, "engineering")
+      {_user, student} = insert_enrolled_student!(school, grade11, old_batch)
+
+      conn =
+        patch(conn, "/api/lms/students/#{student.id}/update-with-enrollments", %{
+          "actor" => actor(),
+          "school" => %{"code" => school.code, "udise_code" => school.udise_code},
+          "program_id" => 64,
+          "academic_year" => "2026-2027",
+          "start_date" => "2026-07-01",
+          "grade" => 12
+        })
+
+      response = json_response(conn, 200)
+
+      assert response["changed_fields"] == [
+               "batch_id",
+               "g12_graduating_year",
+               "grade",
+               "student_id"
+             ]
+
+      updated_student = Repo.get!(Student, student.id)
+      assert updated_student.grade_id == grade12.id
+      assert updated_student.g12_graduating_year == 2027
+      assert updated_student.student_id == "202712345678"
+
+      assert current_enrollment(student.user_id, "grade").group_id == grade12.id
+      assert current_enrollment(student.user_id, "batch").group_id == new_batch.id
+
+      refute Repo.get_by(EnrollmentRecord,
+               user_id: student.user_id,
+               group_type: "grade",
+               group_id: grade11.id
+             ).is_current
+
+      refute Repo.get_by(EnrollmentRecord,
+               user_id: student.user_id,
+               group_type: "batch",
+               group_id: old_batch.id
+             ).is_current
+
+      changed_values = only_audit_changed_values()
+      assert changed_values["grade"] == %{"old" => 11, "new" => 12}
+      assert changed_values["student_id"] == %{"old" => "202812345678", "new" => "202712345678"}
+      assert changed_values["batch_id"] == %{"old" => old_batch.id, "new" => new_batch.id}
+    end
+
+    test "stream edits atomically update stream and derived batch", %{conn: conn} do
+      school = insert_school!()
+      grade = insert_grade!(11)
+      old_batch = insert_nvs_batch!(11, "engineering")
+      new_batch = insert_nvs_batch!(11, "medical")
+      {_user, student} = insert_enrolled_student!(school, grade, old_batch)
+
+      conn =
+        patch(conn, "/api/lms/students/#{student.id}/update-with-enrollments", %{
+          "actor" => actor(),
+          "school" => %{"code" => school.code, "udise_code" => school.udise_code},
+          "program_id" => 64,
+          "academic_year" => "2026-2027",
+          "start_date" => "2026-07-01",
+          "stream" => "medical"
+        })
+
+      response = json_response(conn, 200)
+      assert response["changed_fields"] == ["batch_id", "stream"]
+      assert Repo.get!(Student, student.id).stream == "medical"
+      assert current_enrollment(student.user_id, "grade").group_id == grade.id
+      assert current_enrollment(student.user_id, "batch").group_id == new_batch.id
+
+      refute Repo.get_by(EnrollmentRecord,
+               user_id: student.user_id,
+               group_type: "batch",
+               group_id: old_batch.id
+             ).is_current
+    end
+
+    test "duplicate generated Student ID on grade edit leaves profile and enrollments unchanged",
+         %{
+           conn: conn
+         } do
+      school = insert_school!()
+      grade11 = insert_grade!(11)
+      insert_grade!(12)
+      old_batch = insert_nvs_batch!(11, "engineering")
+      insert_nvs_batch!(12, "engineering")
+      {user, student} = insert_enrolled_student!(school, grade11, old_batch)
+      Dbservice.UsersFixtures.student_fixture(%{student_id: "202712345678"})
+
+      conn =
+        patch(conn, "/api/lms/students/#{student.id}/update-with-enrollments", %{
+          "actor" => actor(),
+          "school" => %{"code" => school.code, "udise_code" => school.udise_code},
+          "program_id" => 64,
+          "academic_year" => "2026-2027",
+          "start_date" => "2026-07-01",
+          "first_name" => "Should Not Apply",
+          "grade" => 12
+        })
+
+      response = json_response(conn, 409)
+      assert response["error"]["code"] == "duplicate_student_id"
+      assert Users.get_user!(user.id).first_name == user.first_name
+      assert Repo.get!(Student, student.id).student_id == "202812345678"
+      assert current_enrollment(student.user_id, "grade").group_id == grade11.id
+      assert current_enrollment(student.user_id, "batch").group_id == old_batch.id
+      assert Repo.aggregate(Dbservice.LmsStudentWriteAudit, :count, :id) == 0
+    end
+
+    test "rejects stream edits when batch lookup is not exactly one match", %{conn: conn} do
+      school = insert_school!()
+      grade = insert_grade!(11)
+      old_batch = insert_nvs_batch!(11, "engineering")
+      {_user, student} = insert_enrolled_student!(school, grade, old_batch)
+
+      conn =
+        patch(conn, "/api/lms/students/#{student.id}/update-with-enrollments", %{
+          "actor" => actor(),
+          "school" => %{"code" => school.code, "udise_code" => school.udise_code},
+          "program_id" => 64,
+          "academic_year" => "2026-2027",
+          "start_date" => "2026-07-01",
+          "stream" => "clat"
+        })
+
+      response = json_response(conn, 422)
+      assert response["error"]["code"] == "batch_not_found"
+      assert Repo.get!(Student, student.id).stream == "engineering"
+      assert current_enrollment(student.user_id, "batch").group_id == old_batch.id
+
+      insert_nvs_batch!(11, "medical")
+      insert_nvs_batch!(11, "medical")
+
+      conn =
+        patch(recycle(conn), "/api/lms/students/#{student.id}/update-with-enrollments", %{
+          "actor" => actor(),
+          "school" => %{"code" => school.code, "udise_code" => school.udise_code},
+          "program_id" => 64,
+          "academic_year" => "2026-2027",
+          "start_date" => "2026-07-01",
+          "stream" => "medical"
+        })
+
+      response = json_response(conn, 422)
+      assert response["error"]["code"] == "multiple_batches"
+      assert Repo.get!(Student, student.id).stream == "engineering"
+      assert current_enrollment(student.user_id, "batch").group_id == old_batch.id
+    end
+  end
+
+  defp actor do
+    %{
+      "user_id" => 501,
+      "email" => "pm@example.org",
+      "login_type" => "google",
+      "role" => "program_manager"
+    }
+  end
+
+  defp insert_enrolled_student!(school, grade, batch, attrs \\ %{}) do
+    {user, student} =
+      %{
+        student_id: "202812345678",
+        apaar_id: "123456789012",
+        g10_board: "CENTRAL BOARD OF SECONDARY EDUCATION",
+        g10_roll_no: "12345678",
+        category: "Gen",
+        stream: "engineering",
+        grade_id: grade.id,
+        g12_graduating_year: 2028
+      }
+      |> Map.merge(attrs)
+      |> Dbservice.UsersFixtures.student_fixture()
+
+    insert_enrollment!(user.id, school.id, "school")
+    insert_enrollment!(user.id, grade.id, "grade")
+    insert_enrollment!(user.id, batch.id, "batch")
+    ensure_group_user!(user.id, "school", school.id)
+    ensure_group_user!(user.id, "grade", grade.id)
+    ensure_group_user!(user.id, "batch", batch.id)
+    {user, student}
+  end
+
+  defp insert_school! do
+    school =
+      Repo.insert!(%School{
+        code: "JNV001",
+        name: "JNV Test",
+        udise_code: "12345678901",
+        af_school_category: "JNV",
+        district_code: "D001",
+        district: "Hyderabad",
+        state_code: "TS",
+        state: "Telangana",
+        program_ids: [64]
+      })
+
+    Repo.insert!(%Group{type: "school", child_id: school.id})
+    school
+  end
+
+  defp insert_grade!(number) do
+    grade = Repo.get_by(Grade, number: number) || Repo.insert!(%Grade{number: number})
+    ensure_group!("grade", grade.id)
+    grade
+  end
+
+  defp insert_nvs_batch!(grade, stream) do
+    product = Dbservice.ProductsFixtures.product_fixture(%{code: "NVS"})
+
+    Repo.get(Dbservice.Programs.Program, 64) ||
+      Repo.insert!(%Dbservice.Programs.Program{
+        id: 64,
+        name: "JNV NVS",
+        product_id: product.id,
+        target_outreach: 100,
+        donor: "NVS",
+        state: "India",
+        model: "Lakshya",
+        is_current: true
+      })
+
+    {:ok, batch} =
+      Dbservice.Batches.create_batch_from_import(%{
+        "name" => "NVS #{grade} #{stream}",
+        "batch_id" => "EnableStudents_TP_#{if grade == 11, do: 2028, else: 2027}_#{stream}",
+        "program_id" => 64,
+        "metadata" => %{"grade" => grade, "stream" => stream}
+      })
+
+    ensure_group!("batch", batch.id)
+    batch
+  end
+
+  defp insert_enrollment!(user_id, group_id, group_type) do
+    Repo.insert!(%EnrollmentRecord{
+      user_id: user_id,
+      group_id: group_id,
+      group_type: group_type,
+      academic_year: "2026-2027",
+      start_date: ~D[2026-06-01],
+      is_current: true
+    })
+  end
+
+  defp ensure_group_user!(user_id, type, child_id) do
+    group = ensure_group!(type, child_id)
+    Repo.insert!(%Dbservice.Groups.GroupUser{user_id: user_id, group_id: group.id})
+  end
+
+  defp ensure_group!(type, child_id) do
+    Repo.get_by(Group, type: type, child_id: child_id) ||
+      Repo.insert!(%Group{type: type, child_id: child_id})
+  end
+
+  defp current_enrollment(user_id, group_type) do
+    Repo.one!(
+      from(e in EnrollmentRecord,
+        where: e.user_id == ^user_id and e.group_type == ^group_type and e.is_current == true
+      )
+    )
+  end
+
+  defp only_audit_changed_values do
+    [[changed_values]] =
+      Ecto.Adapters.SQL.query!(Repo, "SELECT changed_values FROM lms_student_write_audits").rows
+
+    changed_values
+  end
+end


### PR DESCRIPTION
Implements avantifellows/af_lms#159.

Linked parent: avantifellows/af_lms#155.

Stacked on db-service PR #577 because the required #156 ingestion foundation is still open. Retarget this PR to nvs_student_addition after #577 lands.

## Summary
- Add PATCH /api/lms/students/:student_id/update-with-enrollments.
- Reject locked identity/ownership/enrollment fields and unsupported fields.
- Update safe profile fields, G10 board, Grade corrections, and stream corrections atomically.
- Re-derive batch by exact NVS program + grade + stream match and audit old/new values.

## Checks
- mix test
- mix format --check-formatted
- mix check