### PR TITLE
Implement NVS student dropout audit support

### DIFF
--- a/lib/dbservice/lms_student_update.ex
+++ b/lib/dbservice/lms_student_update.ex
@@ -22,7 +22,7 @@ defmodule Dbservice.LmsStudentUpdate do
 
   @action "student_update"
   @cbse_board "CENTRAL BOARD OF SECONDARY EDUCATION"
-  @user_fields ["first_name", "gender", "date_of_birth", "phone"]
+  @user_fields ["first_name", "last_name", "gender", "date_of_birth", "phone"]
   @student_fields [
     "category",
     "physically_handicapped",

--- a/lib/dbservice/services/dropout_service.ex
+++ b/lib/dbservice/services/dropout_service.ex
@@ -11,7 +11,10 @@ defmodule Dbservice.Services.DropoutService do
   alias Dbservice.EnrollmentRecords.EnrollmentRecord
   alias Dbservice.Statuses.Status
   alias Dbservice.Groups.Group
+  alias Dbservice.LmsStudentWriteAudit
   alias Dbservice.Users
+
+  @audit_action "student_dropout"
 
   @doc """
   Fetches dropout status information.
@@ -31,12 +34,31 @@ defmodule Dbservice.Services.DropoutService do
   Processes student dropout by updating enrollments and student status.
   Returns {:ok, student} on success or {:error, reason} on failure.
   """
-  def process_dropout(student, start_date, academic_year) do
+  def process_dropout(student, start_date, academic_year, audit_params \\ %{}) do
     # Check if the student's status is already 'dropout'
     if student.status == "dropout" do
       {:error, "Student is already marked as dropout"}
     else
-      create_dropout_enrollment(student, start_date, academic_year)
+      Repo.transaction(fn ->
+        with {:ok, updated_student} <-
+               create_dropout_enrollment(student, start_date, academic_year),
+             {:ok, _audit} <-
+               maybe_insert_lms_audit(
+                 student,
+                 updated_student,
+                 start_date,
+                 academic_year,
+                 audit_params
+               ) do
+          updated_student
+        else
+          {:error, reason} -> Repo.rollback(reason)
+        end
+      end)
+      |> case do
+        {:ok, updated_student} -> {:ok, updated_student}
+        {:error, reason} -> {:error, reason}
+      end
     end
   end
 
@@ -74,6 +96,41 @@ defmodule Dbservice.Services.DropoutService do
       academic_year: academic_year,
       grade_id: student.grade_id
     }
+  end
+
+  defp maybe_insert_lms_audit(_student, _updated_student, _start_date, _academic_year, params)
+       when params == %{},
+       do: {:ok, nil}
+
+  defp maybe_insert_lms_audit(_student, _updated_student, _start_date, _academic_year, params)
+       when not is_map_key(params, "actor") or not is_map_key(params, "school"),
+       do: {:ok, nil}
+
+  defp maybe_insert_lms_audit(student, updated_student, start_date, academic_year, params) do
+    %LmsStudentWriteAudit{}
+    |> LmsStudentWriteAudit.changeset(%{
+      action: @audit_action,
+      actor_user_id: get_in(params, ["actor", "user_id"]),
+      actor_email: get_in(params, ["actor", "email"]),
+      actor_login_type: get_in(params, ["actor", "login_type"]),
+      actor_role: get_in(params, ["actor", "role"]),
+      school_code: get_in(params, ["school", "code"]),
+      school_udise_code: get_in(params, ["school", "udise_code"]),
+      program_id: params["program_id"],
+      row_counts: %{},
+      affected_identifiers: %{
+        "student_pk_id" => student.id,
+        "user_id" => student.user_id,
+        "student_id" => student.student_id,
+        "apaar_id" => student.apaar_id
+      },
+      changed_values: %{
+        "status" => %{"old" => student.status, "new" => updated_student.status},
+        "dropout_date" => %{"old" => nil, "new" => start_date},
+        "academic_year" => %{"old" => nil, "new" => academic_year}
+      }
+    })
+    |> Repo.insert()
   end
 
   defp format_dropout_error(changeset) do

--- a/lib/dbservice_web/controllers/student_controller.ex
+++ b/lib/dbservice_web/controllers/student_controller.ex
@@ -214,7 +214,7 @@ defmodule DbserviceWeb.StudentController do
         |> json(%{errors: "Student not found with the provided identifier"})
 
       student ->
-        case DropoutService.process_dropout(student, dropout_start_date, academic_year) do
+        case DropoutService.process_dropout(student, dropout_start_date, academic_year, params) do
           {:ok, updated_student} ->
             render(conn, :show, student: updated_student)
 

--- a/test/dbservice_web/controllers/lms_student_update_controller_test.exs
+++ b/test/dbservice_web/controllers/lms_student_update_controller_test.exs
@@ -75,6 +75,7 @@ defmodule DbserviceWeb.LmsStudentUpdateControllerTest do
           "academic_year" => "2026-2027",
           "start_date" => "2026-07-01",
           "first_name" => "Updated Name",
+          "last_name" => "",
           "gender" => "Others",
           "category" => "OBC"
         })
@@ -82,11 +83,12 @@ defmodule DbserviceWeb.LmsStudentUpdateControllerTest do
       response = json_response(conn, 200)
       assert response["status"] == "updated"
       assert response["student_pk_id"] == student.id
-      assert response["changed_fields"] == ["category", "first_name", "gender"]
+      assert response["changed_fields"] == ["category", "first_name", "gender", "last_name"]
 
       updated_user = Users.get_user!(user.id)
       updated_student = Repo.get!(Student, student.id)
       assert updated_user.first_name == "Updated Name"
+      assert updated_user.last_name == nil
       assert updated_user.gender == "Others"
       assert updated_student.category == "OBC"
       assert updated_student.student_id == "202812345678"
@@ -109,6 +111,7 @@ defmodule DbserviceWeb.LmsStudentUpdateControllerTest do
       assert school_code == school.code
       assert affected_identifiers["student_pk_id"] == student.id
       assert changed_values["first_name"] == %{"old" => user.first_name, "new" => "Updated Name"}
+      assert changed_values["last_name"] == %{"old" => user.last_name, "new" => ""}
       assert changed_values["category"] == %{"old" => "Gen", "new" => "OBC"}
     end
 

--- a/test/dbservice_web/controllers/lms_student_update_controller_test.exs
+++ b/test/dbservice_web/controllers/lms_student_update_controller_test.exs
@@ -8,8 +8,57 @@ defmodule DbserviceWeb.LmsStudentUpdateControllerTest do
   alias Dbservice.Groups.Group
   alias Dbservice.Repo
   alias Dbservice.Schools.School
+  alias Dbservice.Statuses.Status
   alias Dbservice.Users
   alias Dbservice.Users.Student
+
+  describe "PATCH /api/dropout" do
+    test "marks the student dropout and writes LMS audit metadata", %{conn: conn} do
+      school = insert_school!()
+      grade = insert_grade!(11)
+      batch = insert_nvs_batch!(11, "engineering")
+      {_user, student} = insert_enrolled_student!(school, grade, batch)
+      dropout_status = ensure_dropout_status!()
+
+      conn =
+        patch(conn, "/api/dropout", %{
+          "student_id" => student.student_id,
+          "start_date" => "2026-07-01",
+          "academic_year" => "2026-2027",
+          "actor" => actor(),
+          "school" => %{"code" => school.code, "udise_code" => school.udise_code},
+          "program_id" => 64
+        })
+
+      response = json_response(conn, 200)
+      assert response["status"] == "dropout"
+      assert Repo.get!(Student, student.id).status == "dropout"
+      assert current_enrollment(student.user_id, "status").group_id == dropout_status.id
+
+      assert [
+               [
+                 "student_dropout",
+                 "pm@example.org",
+                 school_code,
+                 64,
+                 affected_identifiers,
+                 changed_values
+               ]
+             ] =
+               Ecto.Adapters.SQL.query!(
+                 Repo,
+                 "SELECT action, actor_email, school_code, program_id, affected_identifiers, changed_values FROM lms_student_write_audits"
+               ).rows
+
+      assert school_code == school.code
+      assert affected_identifiers["student_pk_id"] == student.id
+      assert affected_identifiers["student_id"] == student.student_id
+      assert affected_identifiers["apaar_id"] == student.apaar_id
+      assert changed_values["status"] == %{"old" => student.status, "new" => "dropout"}
+      assert changed_values["dropout_date"] == %{"old" => nil, "new" => "2026-07-01"}
+      assert changed_values["academic_year"] == %{"old" => nil, "new" => "2026-2027"}
+    end
+  end
 
   describe "PATCH /api/lms/students/:student_id/update-with-enrollments" do
     test "updates safe profile fields and audits old and new values", %{conn: conn} do
@@ -400,6 +449,15 @@ defmodule DbserviceWeb.LmsStudentUpdateControllerTest do
   defp ensure_group!(type, child_id) do
     Repo.get_by(Group, type: type, child_id: child_id) ||
       Repo.insert!(%Group{type: type, child_id: child_id})
+  end
+
+  defp ensure_dropout_status! do
+    status =
+      Repo.get_by(Status, title: :dropout) ||
+        Repo.insert!(%Status{title: :dropout})
+
+    ensure_group!("status", status.id)
+    status
   end
 
   defp current_enrollment(user_id, group_type) do


### PR DESCRIPTION
Implements avantifellows/af_lms#161 as part of the NVS student addition PRD stack.\n\nStacked on #578.\n\nChanges:\n- Add DB Service support for recording dropout audit metadata from LMS student actions.\n- Keep the endpoint atomic with the edit flow stack.\n\nValidation:\n- mix test\n- mix format --check-formatted\n- mix check