### PR TITLE
[codex] Add staging target to database sync script

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -157,10 +157,11 @@ This configuration allows the application to authenticate with Google Cloud Plat
 For **internal developers (employees)**, you can sync your local database with the production or staging database by running:
 
 ```bash
-sh ./fetch-data.sh
+./utils/fetch-data.sh
 ```
 
 This script pulls data from the production/staging environment into your local setup.
+It can also sync production into staging when `TARGET_ENVIRONMENT=staging`.
 
 **Note:** Access to staging/production credentials is restricted to authorized personnel within the organization. Please contact the repository maintainers if you're an employee and require access.
 
@@ -195,5 +196,4 @@ For enhanced development experience with Elixir, consider installing [`ElixirLS:
 |      any        |     1.15.5      |        Yes        |  Broken formatter [#975](https://github.com/elixir-lsp/elixir-ls/issues/975) |
 |      27         |    1.17 - 1.18  |        Yes        |                            None                            |
 |      28         |      1.18.4     |        Yes        |                            None                            |
-
 

--- a/utils/.env.example
+++ b/utils/.env.example
@@ -4,6 +4,10 @@
 # Environment to fetch from (production or staging)
 FETCH_ENVIRONMENT=production
 
+# Environment to restore into (local or staging)
+# staging target is only allowed with FETCH_ENVIRONMENT=production
+TARGET_ENVIRONMENT=local
+
 # Production Database Credentials
 PROD_DB_HOST=xxx.rds.amazonaws.com
 PROD_DB_NAME=xxx

--- a/utils/README.md
+++ b/utils/README.md
@@ -27,16 +27,26 @@ This folder contains utilities for managing database operations.
 This script will:
 - ✅ Validate all required environment variables
 - ⚠️  Ask for confirmation before proceeding
-- 🧹 Clear your local database
+- 🧹 Clear your target database
 - 📥 Fetch data from the specified environment
-- 📤 Restore data to your local database
+- 📤 Restore data to your target database
 - 🧹 Clean up temporary files
+
+To sync production into staging:
+
+```bash
+FETCH_ENVIRONMENT=production
+TARGET_ENVIRONMENT=staging
+```
+
+Staging sync skips data for `session`, `session_occurrence`, `group_session`, and `user_session`.
 
 ### Configuration
 
 The script reads from `utils/.env` file. Key variables:
 
-- `FETCH_ENVIRONMENT`: Set to `production` or `staging`
+- `FETCH_ENVIRONMENT`: Source database, set to `production` or `staging`
+- `TARGET_ENVIRONMENT`: Target database, set to `local` or `staging`
 - `PROD_DB_*`: Production database credentials
 - `STAGING_DB_*`: Staging database credentials
 - `LOCAL_DB_*`: Local database settings

--- a/utils/fetch-data.sh
+++ b/utils/fetch-data.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+# shellcheck disable=SC2153
 
 # Enhanced Database Fetch Script with Environment Variables
-# This script fetches data from production/staging and restores to local database
+# This script fetches data from production/staging and restores to local/staging database
 
 set -e  # Exit on any error
 
@@ -30,6 +31,7 @@ fi
 
 # Load environment variables
 echo -e "${BLUE}📖 Loading configuration from .env...${NC}"
+# shellcheck source=/dev/null
 source "$ENV_FILE"
 
 # Function to check if a variable is set and not empty
@@ -48,47 +50,89 @@ check_required_var() {
 echo -e "${BLUE}🔍 Validating configuration...${NC}"
 
 check_required_var "FETCH_ENVIRONMENT" "$FETCH_ENVIRONMENT"
-check_required_var "LOCAL_DB_HOST" "$LOCAL_DB_HOST"
-check_required_var "LOCAL_DB_NAME" "$LOCAL_DB_NAME"
-check_required_var "LOCAL_DB_USER" "$LOCAL_DB_USER"
-check_required_var "LOCAL_DB_PASSWORD" "$LOCAL_DB_PASSWORD"
-
 # Set default values
 LOCAL_DB_PORT=${LOCAL_DB_PORT:-5432}
 DUMP_FILE=${DUMP_FILE:-dump.sql}
+TARGET_ENVIRONMENT=${TARGET_ENVIRONMENT:-local}
+STAGING_EXCLUDED_TABLE_DATA=(public.session public.session_occurrence public.group_session public.user_session)
 
-# Validate environment and set remote database credentials
+# Validate source environment and set database credentials
 if [ "$FETCH_ENVIRONMENT" == "production" ]; then
-    echo -e "${YELLOW}🏭 Using PRODUCTION environment${NC}"
+    echo -e "${YELLOW}🏭 Using PRODUCTION source environment${NC}"
     check_required_var "PROD_DB_HOST" "$PROD_DB_HOST"
     check_required_var "PROD_DB_NAME" "$PROD_DB_NAME"
     check_required_var "PROD_DB_USER" "$PROD_DB_USER"
     check_required_var "PROD_DB_PASSWORD" "$PROD_DB_PASSWORD"
     check_required_var "PROD_DB_PORT" "$PROD_DB_PORT"
     
-    REMOTE_DB_HOST=$PROD_DB_HOST
-    REMOTE_DB_NAME=$PROD_DB_NAME
-    REMOTE_DB_USER=$PROD_DB_USER
-    REMOTE_DB_PASSWORD=$PROD_DB_PASSWORD
-    REMOTE_DB_PORT=$PROD_DB_PORT
+    SOURCE_DB_HOST=$PROD_DB_HOST
+    SOURCE_DB_NAME=$PROD_DB_NAME
+    SOURCE_DB_USER=$PROD_DB_USER
+    SOURCE_DB_PASSWORD=$PROD_DB_PASSWORD
+    SOURCE_DB_PORT=$PROD_DB_PORT
     
 elif [ "$FETCH_ENVIRONMENT" == "staging" ]; then
-    echo -e "${YELLOW}🧪 Using STAGING environment${NC}"
+    echo -e "${YELLOW}🧪 Using STAGING source environment${NC}"
     check_required_var "STAGING_DB_HOST" "$STAGING_DB_HOST"
     check_required_var "STAGING_DB_NAME" "$STAGING_DB_NAME"
     check_required_var "STAGING_DB_USER" "$STAGING_DB_USER"
     check_required_var "STAGING_DB_PASSWORD" "$STAGING_DB_PASSWORD"
     check_required_var "STAGING_DB_PORT" "$STAGING_DB_PORT"
     
-    REMOTE_DB_HOST=$STAGING_DB_HOST
-    REMOTE_DB_NAME=$STAGING_DB_NAME
-    REMOTE_DB_USER=$STAGING_DB_USER
-    REMOTE_DB_PASSWORD=$STAGING_DB_PASSWORD
-    REMOTE_DB_PORT=$STAGING_DB_PORT
+    SOURCE_DB_HOST=$STAGING_DB_HOST
+    SOURCE_DB_NAME=$STAGING_DB_NAME
+    SOURCE_DB_USER=$STAGING_DB_USER
+    SOURCE_DB_PASSWORD=$STAGING_DB_PASSWORD
+    SOURCE_DB_PORT=$STAGING_DB_PORT
     
 else
     echo -e "${RED}❌ Error: Invalid FETCH_ENVIRONMENT '$FETCH_ENVIRONMENT'${NC}"
     echo -e "${YELLOW}💡 FETCH_ENVIRONMENT must be either 'production' or 'staging'${NC}"
+    exit 1
+fi
+
+# Validate target environment and set database credentials
+if [ "$TARGET_ENVIRONMENT" == "local" ]; then
+    echo -e "${YELLOW}💻 Using LOCAL target environment${NC}"
+    check_required_var "LOCAL_DB_HOST" "$LOCAL_DB_HOST"
+    check_required_var "LOCAL_DB_NAME" "$LOCAL_DB_NAME"
+    check_required_var "LOCAL_DB_USER" "$LOCAL_DB_USER"
+    check_required_var "LOCAL_DB_PASSWORD" "$LOCAL_DB_PASSWORD"
+
+    TARGET_DB_HOST=$LOCAL_DB_HOST
+    TARGET_DB_NAME=$LOCAL_DB_NAME
+    TARGET_DB_USER=$LOCAL_DB_USER
+    TARGET_DB_PASSWORD=$LOCAL_DB_PASSWORD
+    TARGET_DB_PORT=$LOCAL_DB_PORT
+
+elif [ "$TARGET_ENVIRONMENT" == "staging" ]; then
+    if [ "$FETCH_ENVIRONMENT" != "production" ]; then
+        echo -e "${RED}❌ Error: Staging target can only sync from production${NC}"
+        echo -e "${YELLOW}💡 Set FETCH_ENVIRONMENT=production and TARGET_ENVIRONMENT=staging${NC}"
+        exit 1
+    fi
+
+    echo -e "${YELLOW}🧪 Using STAGING target environment${NC}"
+    check_required_var "STAGING_DB_HOST" "$STAGING_DB_HOST"
+    check_required_var "STAGING_DB_NAME" "$STAGING_DB_NAME"
+    check_required_var "STAGING_DB_USER" "$STAGING_DB_USER"
+    check_required_var "STAGING_DB_PASSWORD" "$STAGING_DB_PASSWORD"
+    check_required_var "STAGING_DB_PORT" "$STAGING_DB_PORT"
+
+    TARGET_DB_HOST=$STAGING_DB_HOST
+    TARGET_DB_NAME=$STAGING_DB_NAME
+    TARGET_DB_USER=$STAGING_DB_USER
+    TARGET_DB_PASSWORD=$STAGING_DB_PASSWORD
+    TARGET_DB_PORT=$STAGING_DB_PORT
+    echo -e "${YELLOW}⏭️  Staging sync will skip data for session tables${NC}"
+
+elif [ "$TARGET_ENVIRONMENT" == "production" ]; then
+    echo -e "${RED}❌ Error: Production cannot be used as a sync target${NC}"
+    exit 1
+
+else
+    echo -e "${RED}❌ Error: Invalid TARGET_ENVIRONMENT '$TARGET_ENVIRONMENT'${NC}"
+    echo -e "${YELLOW}💡 TARGET_ENVIRONMENT must be either 'local' or 'staging'${NC}"
     exit 1
 fi
 
@@ -113,14 +157,22 @@ echo -e "${GREEN}✅ Configuration validated successfully${NC}"
 echo ""
 
 # Confirmation prompt
-echo -e "${YELLOW}⚠️  WARNING: This will completely replace your local database!${NC}"
-echo -e "${BLUE}📊 Source: $FETCH_ENVIRONMENT ($REMOTE_DB_HOST:$REMOTE_DB_PORT/$REMOTE_DB_NAME)${NC}"
-echo -e "${BLUE}🎯 Target: $LOCAL_DB_HOST:$LOCAL_DB_PORT/$LOCAL_DB_NAME${NC}"
+echo -e "${YELLOW}⚠️  WARNING: This will completely replace your $TARGET_ENVIRONMENT database!${NC}"
+echo -e "${BLUE}📊 Source: $FETCH_ENVIRONMENT ($SOURCE_DB_HOST:$SOURCE_DB_PORT/$SOURCE_DB_NAME)${NC}"
+echo -e "${BLUE}🎯 Target: $TARGET_ENVIRONMENT ($TARGET_DB_HOST:$TARGET_DB_PORT/$TARGET_DB_NAME)${NC}"
 echo ""
-read -p "Are you sure you want to continue? (y/N): " -r
-if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-    echo -e "${YELLOW}⏹️  Operation cancelled${NC}"
-    exit 0
+if [ "$TARGET_ENVIRONMENT" == "staging" ]; then
+    read -p "Type 'SYNC STAGING' to continue: " -r
+    if [ "$REPLY" != "SYNC STAGING" ]; then
+        echo -e "${YELLOW}⏹️  Operation cancelled${NC}"
+        exit 0
+    fi
+else
+    read -p "Are you sure you want to continue? (y/N): " -r
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo -e "${YELLOW}⏹️  Operation cancelled${NC}"
+        exit 0
+    fi
 fi
 
 echo ""
@@ -128,66 +180,69 @@ echo -e "${BLUE}🚀 Starting database fetch process...${NC}"
 
 # Step 1: Fetch data dump
 echo -e "${BLUE}📥 Fetching data from $FETCH_ENVIRONMENT database...${NC}"
-PGPASSWORD="$REMOTE_DB_PASSWORD" "$PG_DUMP_PATH" \
-    --host="$REMOTE_DB_HOST" \
-    --port="$REMOTE_DB_PORT" \
-    --username="$REMOTE_DB_USER" \
-    --dbname="$REMOTE_DB_NAME" \
+PG_DUMP_ARGS=(
+    --host="$SOURCE_DB_HOST" \
+    --port="$SOURCE_DB_PORT" \
+    --username="$SOURCE_DB_USER" \
+    --dbname="$SOURCE_DB_NAME" \
     --file="$SCRIPT_DIR/$DUMP_FILE" \
     --verbose
+)
 
-if [ $? -eq 0 ]; then
+if [ "$TARGET_ENVIRONMENT" == "staging" ]; then
+    for table in "${STAGING_EXCLUDED_TABLE_DATA[@]}"; do
+        PG_DUMP_ARGS+=(--exclude-table-data="$table")
+    done
+fi
+
+if PGPASSWORD="$SOURCE_DB_PASSWORD" "$PG_DUMP_PATH" "${PG_DUMP_ARGS[@]}"; then
     echo -e "${GREEN}✅ Data dump fetched successfully${NC}"
 else
     echo -e "${RED}❌ Error: Failed to fetch data dump${NC}"
-    echo -e "${YELLOW}💡 Local database remains unchanged${NC}"
+    echo -e "${YELLOW}💡 Target database remains unchanged${NC}"
     exit 1
 fi
 
 # Verify the dump file exists and has content
 if [ ! -s "$SCRIPT_DIR/$DUMP_FILE" ]; then
     echo -e "${RED}❌ Error: Dump file is empty or missing${NC}"
-    echo -e "${YELLOW}💡 Local database remains unchanged${NC}"
+    echo -e "${YELLOW}💡 Target database remains unchanged${NC}"
     rm -f "$SCRIPT_DIR/$DUMP_FILE"
     exit 1
 fi
 
 echo -e "${GREEN}✅ Dump file validated ($(du -h "$SCRIPT_DIR/$DUMP_FILE" | cut -f1))${NC}"
 
-# Step 2: NOW clear local database (only after successful fetch)
-echo -e "${BLUE}🧹 Clearing local database...${NC}"
-PGPASSWORD="$LOCAL_DB_PASSWORD" "$PSQL_PATH" \
-    --host="$LOCAL_DB_HOST" \
-    --port="$LOCAL_DB_PORT" \
-    --username="$LOCAL_DB_USER" \
-    --dbname="$LOCAL_DB_NAME" \
+# Step 2: NOW clear target database (only after successful fetch)
+echo -e "${BLUE}🧹 Clearing $TARGET_ENVIRONMENT database...${NC}"
+if PGPASSWORD="$TARGET_DB_PASSWORD" "$PSQL_PATH" \
+    --host="$TARGET_DB_HOST" \
+    --port="$TARGET_DB_PORT" \
+    --username="$TARGET_DB_USER" \
+    --dbname="$TARGET_DB_NAME" \
     --command="DROP SCHEMA public CASCADE; CREATE SCHEMA public;" \
-    --quiet
-
-if [ $? -eq 0 ]; then
-    echo -e "${GREEN}✅ Local database cleared${NC}"
+    --quiet; then
+    echo -e "${GREEN}✅ Target database cleared${NC}"
 else
-    echo -e "${RED}❌ Error: Failed to clear local database${NC}"
+    echo -e "${RED}❌ Error: Failed to clear target database${NC}"
     echo -e "${YELLOW}💡 Dump file saved at: $SCRIPT_DIR/$DUMP_FILE${NC}"
     echo -e "${YELLOW}💡 You can manually restore it later${NC}"
     exit 1
 fi
 
-# Step 3: Restore to local database
-echo -e "${BLUE}📤 Restoring data to local database...${NC}"
-PGPASSWORD="$LOCAL_DB_PASSWORD" "$PSQL_PATH" \
-    --host="$LOCAL_DB_HOST" \
-    --port="$LOCAL_DB_PORT" \
-    --username="$LOCAL_DB_USER" \
-    --dbname="$LOCAL_DB_NAME" \
+# Step 3: Restore to target database
+echo -e "${BLUE}📤 Restoring data to $TARGET_ENVIRONMENT database...${NC}"
+if PGPASSWORD="$TARGET_DB_PASSWORD" "$PSQL_PATH" \
+    --host="$TARGET_DB_HOST" \
+    --port="$TARGET_DB_PORT" \
+    --username="$TARGET_DB_USER" \
+    --dbname="$TARGET_DB_NAME" \
     --file="$SCRIPT_DIR/$DUMP_FILE" \
-    --quiet
-
-if [ $? -eq 0 ]; then
+    --quiet; then
     echo -e "${GREEN}✅ Data restored successfully${NC}"
 else
     echo -e "${RED}❌ Error: Failed to restore data${NC}"
-    echo -e "${YELLOW}💡 WARNING: Local database may be in an inconsistent state${NC}"
+    echo -e "${YELLOW}💡 WARNING: Target database may be in an inconsistent state${NC}"
     echo -e "${YELLOW}💡 Dump file saved at: $SCRIPT_DIR/$DUMP_FILE${NC}"
     exit 1
 fi
@@ -199,5 +254,5 @@ echo -e "${GREEN}✅ Cleanup complete${NC}"
 
 echo ""
 echo -e "${GREEN}🎉 Database fetch completed successfully!${NC}"
-echo -e "${BLUE}📊 Your local database now contains data from $FETCH_ENVIRONMENT${NC}"
+echo -e "${BLUE}📊 Your $TARGET_ENVIRONMENT database now contains data from $FETCH_ENVIRONMENT${NC}"
 echo ""


### PR DESCRIPTION
## Summary

- Adds `TARGET_ENVIRONMENT` support to `utils/fetch-data.sh`, defaulting to `local` for existing usage.
- Allows `FETCH_ENVIRONMENT=production` with `TARGET_ENVIRONMENT=staging` to restore production data into staging.
- Blocks production as a target and requires typing `SYNC STAGING` before staging is replaced.
- For staging syncs, skips data for `session`, `session_occurrence`, `group_session`, and `user_session` so session data is not copied from prod.
- Updates the env example and docs.

## Verification

- `bash -n utils/fetch-data.sh`
- `shellcheck utils/fetch-data.sh`
- `git diff --check`
- Mocked local sync path to confirm no excluded tables are passed to `pg_dump`
- Mocked prod-to-staging sync path to confirm the session table data exclusions are passed to `pg_dump`
- Took a full staging backup before running the real sync
- Ran the real prod-to-staging sync successfully
- Verified skipped staging tables have 0 rows: `session`, `session_occurrence`, `group_session`, `user_session`