### PR TITLE
Add centre_students view and active-centre uniqueness guard

### DIFF
--- a/priv/repo/migrations/20260706120000_create_centre_students_view.exs
+++ b/priv/repo/migrations/20260706120000_create_centre_students_view.exs
@@ -1,0 +1,78 @@
+defmodule Dbservice.Repo.Migrations.CreateCentreStudentsView do
+  use Ecto.Migration
+
+  @moduledoc """
+  Students are not stored per-centre anywhere: a centre's roster has always
+  been derived as "members of the centre's school whose (single) attributed
+  batch-program matches the centre's program". Until now that derivation was
+  reimplemented ad hoc by consumers (af_lms dashboard, school roster). This
+  view gives the derivation one canonical, always-live home so consumers can
+  simply `SELECT ... FROM centre_students WHERE centre_id = $1`.
+
+  It is a plain (non-materialized) view: reads cost the same as the query
+  consumers already run today, and it can never go stale.
+  """
+
+  def change do
+    # The view attributes students to a centre by (school_id, program_id), so
+    # two ACTIVE centres sharing that pair would silently claim the same
+    # students twice (as the duplicate "JNV South Canara" centre did before
+    # its cleanup on 2026-07-06). Enforce the invariant before creating the
+    # view that depends on it.
+    create unique_index(:centres, [:school_id, :program_id],
+             where: "is_active AND school_id IS NOT NULL AND program_id IS NOT NULL",
+             name: :centres_active_school_program_unique
+           )
+
+    # Design notes:
+    # - Lean membership keys only (no user/student display columns), so the
+    #   view does not block future ALTERs on those tables; consumers join for
+    #   whatever they need.
+    # - academic_year is exposed as a column (a view cannot take parameters);
+    #   callers filter to the current year.
+    # - The LATERAL picks each student's single attributed program FIRST
+    #   (preference: CoE -> Nodal -> NVS), and only then compares it to the
+    #   centre's program - so a student enrolled in both a CoE and a Nodal
+    #   batch lands in exactly one centre. This mirrors the tiebreaker af_lms
+    #   uses for its school roster. The preference matches by program NAME
+    #   (the stable business key) rather than hardcoded ids: ids currently
+    #   match across staging and production (verified 2026-07-06), but names
+    #   are self-documenting and survive any future id drift.
+    # - Centres with school_id IS NULL (online/foundation/bench) simply have
+    #   no rows: there is no roster path for them.
+    execute(
+      """
+      CREATE VIEW centre_students AS
+      SELECT
+        c.id            AS centre_id,
+        gu.user_id      AS user_id,
+        er.academic_year,
+        gr.number       AS grade,
+        p.program_id
+      FROM centres c
+      JOIN "group" g ON g.type = 'school' AND g.child_id = c.school_id
+      JOIN group_user gu ON gu.group_id = g.id
+      JOIN enrollment_record er ON er.user_id = gu.user_id
+        AND er.group_type = 'grade'
+        AND er.is_current = true
+      LEFT JOIN grade gr ON er.group_id = gr.id
+      LEFT JOIN LATERAL (
+        SELECT b.program_id
+        FROM group_user gub
+        JOIN "group" gb ON gub.group_id = gb.id AND gb.type = 'batch'
+        JOIN batch b ON gb.child_id = b.id
+        JOIN program pr ON pr.id = b.program_id
+        WHERE gub.user_id = gu.user_id
+        ORDER BY array_position(
+          ARRAY['JNV CoE', 'JNV Nodal', 'JNV NVS']::text[],
+          pr.name
+        )
+        LIMIT 1
+      ) p ON true
+      WHERE c.is_active
+        AND p.program_id = c.program_id
+      """,
+      "DROP VIEW centre_students"
+    )
+  end
+end

--- a/test/dbservice/centre_schema_test.exs
+++ b/test/dbservice/centre_schema_test.exs
@@ -88,7 +88,13 @@ defmodule Dbservice.CentreSchemaTest do
 
       assert ["code"] in unique_indexes("centre_option_sets")
       assert ["option_set_id", "code"] in unique_indexes("centre_options")
-      refute Enum.any?(unique_indexes("centres"), &(&1 != ["id"]))
+      # PK plus the active-centre guard: at most one ACTIVE centre per
+      # (school, program), the pair centre_students attributes students by.
+      assert ["school_id", "program_id"] in unique_indexes("centres")
+      refute Enum.any?(
+               unique_indexes("centres"),
+               &(&1 not in [["id"], ["school_id", "program_id"]])
+             )
 
       assert indexes("centre_options") |> Enum.any?(&(&1 == ["option_set_id"]))
       assert indexes("centres") |> Enum.any?(&(&1 == ["school_id"]))
@@ -105,6 +111,18 @@ defmodule Dbservice.CentreSchemaTest do
       assert foreign_keys("centres") == [
                {"program_id", "program", "id"},
                {"school_id", "school", "id"}
+             ]
+    end
+
+    test "exposes the centre_students view with lean membership keys" do
+      # The canonical "students in a centre" derivation. Lean keys only —
+      # consumers join user/student/program for display columns.
+      assert Map.keys(columns("centre_students")) |> Enum.sort() == [
+               "academic_year",
+               "centre_id",
+               "grade",
+               "program_id",
+               "user_id"
              ]
     end
   end

--- a/test/dbservice/centre_schema_test.exs
+++ b/test/dbservice/centre_schema_test.exs
@@ -91,6 +91,7 @@ defmodule Dbservice.CentreSchemaTest do
       # PK plus the active-centre guard: at most one ACTIVE centre per
       # (school, program), the pair centre_students attributes students by.
       assert ["school_id", "program_id"] in unique_indexes("centres")
+
       refute Enum.any?(
                unique_indexes("centres"),
                &(&1 not in [["id"], ["school_id", "program_id"]])


### PR DESCRIPTION
## What

One migration, two objects:

1. **`centre_students` view** — the canonical "students in a centre" derivation, as lean membership keys `(centre_id, user_id, academic_year, grade, program_id)`. Students are not stored per-centre anywhere; consumers (af_lms dashboard, school roster) have each re-derived this as *members of the centre's school whose single attributed batch-program matches the centre's program*. The view gives that derivation one always-live home: `SELECT ... FROM centre_students WHERE centre_id = $1 AND academic_year = $2`.
2. **Guard index** `centres_active_school_program_unique` — at most one ACTIVE centre per `(school_id, program_id)`. The view attributes students by that pair, so an active duplicate silently claims the same students twice (as the duplicate "JNV South Canara" centre did until its cleanup on 2026-07-06).

## Design notes

- **Plain view, not materialized** — costs the same as the query consumers already run; can never go stale.
- **Lean columns only** — no `user`/`student` display columns, so the view never blocks future `ALTER TABLE` on those tables; consumers join for what they need.
- **Attribute-then-match** — the LATERAL picks each student's *single* program first (CoE → Nodal → NVS preference), then compares to the centre's, so dual-batch students land in exactly one centre. Mirrors af_lms's roster tiebreaker.
- **Tiebreaker matches by program name** — ids currently match across staging and prod (verified 2026-07-06), but names are the stable business key and survive future id drift.
- `academic_year` is a column (views can't take params); callers filter to the current year.

## Verification

- `mix ecto.migrate` → `mix ecto.rollback` → `mix ecto.migrate` all clean on local dev; view has the intended 5-column shape.
- View body validated against **production** data: JNV Adilabad Nodal = 41 students / CoE = 82 (correct split of a two-centre school); sane counts across all 41 roster-bearing centres; by-name tiebreaker output ≡ by-id.
- Guard-index precondition (zero active duplicates) verified on **both prod and staging** — the South Canara duplicate (centre 20) has been archived in both.

## Follow-up (separate PR, af_lms)

`getCentreStudents(centreId)` in af_lms consuming this view — gated on this migration reaching the prod release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)