### PR TITLE
fix(ci): EC2 staging deploy silently skipped migrate + restart

### DIFF
--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -79,7 +79,7 @@ jobs:
             sudo env MIX_ENV=prod mix assets.deploy
             sudo fuser -k "${APP_PORT}/tcp" 2>/dev/null || true
             sleep 2
-            nohup sudo env MIX_ENV=prod elixir --erl \"-detached\" -S mix phx.server > /tmp/phx_server.log 2>&1 &
+            nohup sudo env MIX_ENV=prod mix phx.server > /tmp/phx_server.log 2>&1 &
             # Hit /api/health (public, no bearer token, and it verifies the DB) —
             # /api/session requires auth and would 401. Poll for up to ~2 min: a
             # cold prod boot (release load + DB pool) can take well over 5s. Fail
@@ -94,6 +94,7 @@ jobs:
               echo 'Server started successfully'
             else
               echo "Server health check failed (last HTTP ${CODE:-000}); see /tmp/phx_server.log on the host"
+              sudo tail -200 /tmp/phx_server.log || true
               exit 1
             fi
           } </dev/null

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -73,15 +73,22 @@ jobs:
             sudo fuser -k 4000/tcp 2>/dev/null || true
             sleep 2
             nohup sudo env MIX_ENV=prod elixir --erl \"-detached\" -S mix phx.server > /tmp/phx_server.log 2>&1 &
-            sleep 5
             # Hit /api/health (public, no bearer token, and it verifies the DB) —
-            # /api/session requires auth and would 401. Fail the job on non-200 so a
-            # broken boot doesn't show green.
-            CODE=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:4000/api/health || echo 000)
+            # /api/session requires auth and would 401. Poll for up to ~2 min: a
+            # cold prod boot (release load + DB pool) can take well over 5s. Fail
+            # the job on a persistent non-200 so a broken boot doesn't show green.
+            # NOTE: this checks port 4000 (matches the fuser/kill above); keep the
+            # STAGING_PORT secret at 4000 or this will never see the server.
+            CODE=000
+            for _ in $(seq 1 24); do
+              CODE=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:4000/api/health || true)
+              [ "$CODE" = "200" ] && break
+              sleep 5
+            done
             if [ "$CODE" = "200" ]; then
               echo 'Server started successfully'
             else
-              echo "Server health check failed (HTTP $CODE); see /tmp/phx_server.log on the host"
+              echo "Server health check failed (last HTTP ${CODE:-000}); see /tmp/phx_server.log on the host"
               exit 1
             fi
           } </dev/null

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -38,7 +38,17 @@ jobs:
           echo "Deploying branch: $DEPLOY_BRANCH"
           echo "$PRIVATE_KEY" > private_key && chmod 600 private_key
           ssh -o StrictHostKeyChecking=no -i private_key "${USER_NAME}@${HOSTNAME}" "DEPLOY_BRANCH=$(printf '%q' "$DEPLOY_BRANCH") bash -se" <<'EOF'
+          # bash -se reads this whole script from its stdin. Wrapping the body in a
+          # brace group whose stdin is /dev/null makes bash parse the entire group
+          # up front and detaches inner commands from this stdin, so a command that
+          # reads stdin (a mix/hex/rebar prompt or a sudo password prompt) can't
+          # silently swallow the rest of the script. Previously the deploy stopped
+          # right after `mix deps.get` — migrate, asset build, and the server
+          # restart never ran, yet the job still exited 0.
+          {
+            set -o pipefail
             cd /var/www/html/db-service/config
+            [ -f .env ] || { echo "config/.env not found on host — cannot inject secrets"; exit 1; }
             sudo sed -i 's|DATABASE_URL=.*|DATABASE_URL=${{ secrets.STAGING_DATABASE_URL }}|' .env
             sudo sed -i 's|SECRET_KEY_BASE=.*|SECRET_KEY_BASE=${{ secrets.STAGING_SECRET_KEY_BASE }}|' .env
             sudo sed -i 's|PHX_HOST=.*|PHX_HOST=${{ secrets.STAGING_PHX_HOST }}|' .env
@@ -64,9 +74,15 @@ jobs:
             sleep 2
             nohup sudo env MIX_ENV=prod elixir --erl \"-detached\" -S mix phx.server > /tmp/phx_server.log 2>&1 &
             sleep 5
-            if curl -s -o /dev/null -w '%{http_code}' http://localhost:4000/api/session?limit=1 | grep -q '200'; then
+            # Hit /api/health (public, no bearer token, and it verifies the DB) —
+            # /api/session requires auth and would 401. Fail the job on non-200 so a
+            # broken boot doesn't show green.
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:4000/api/health || echo 000)
+            if [ "$CODE" = "200" ]; then
               echo 'Server started successfully'
             else
-              echo 'Warning: Server may not have started'
+              echo "Server health check failed (HTTP $CODE); see /tmp/phx_server.log on the host"
+              exit 1
             fi
+          } </dev/null
           EOF

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -56,6 +56,13 @@ jobs:
             sudo sed -i 's|POOL_SIZE=.*|POOL_SIZE=${{ secrets.STAGING_POOL_SIZE }}|' .env
             sudo sed -i 's|PORT=.*|PORT=${{ secrets.STAGING_PORT }}|' .env
             sudo sed -i 's|BEARER_TOKEN=.*|BEARER_TOKEN=${{ secrets.STAGING_BEARER_TOKEN }}|' .env
+            # Read the port the app actually binds (PORT in .env) so the kill and
+            # health check target the right port rather than a hardcoded 4000. The
+            # app serves fine via nginx on the domain; only this local check was
+            # looking at the wrong port.
+            APP_PORT=$(sed -n 's/^PORT=//p' .env | head -1 | tr -dc '0-9')
+            APP_PORT=${APP_PORT:-4000}
+            echo "App port (from .env): ${APP_PORT}"
             cd /var/www/html/db-service
             sudo git checkout .
             if [ -f /var/www/html/db-service/priv/static/swagger.json ]; then
@@ -70,18 +77,16 @@ jobs:
             sudo env MIX_ENV=prod mix ecto.migrate
             sudo env MIX_ENV=prod mix phx.swagger.generate
             sudo env MIX_ENV=prod mix assets.deploy
-            sudo fuser -k 4000/tcp 2>/dev/null || true
+            sudo fuser -k "${APP_PORT}/tcp" 2>/dev/null || true
             sleep 2
             nohup sudo env MIX_ENV=prod elixir --erl \"-detached\" -S mix phx.server > /tmp/phx_server.log 2>&1 &
             # Hit /api/health (public, no bearer token, and it verifies the DB) —
             # /api/session requires auth and would 401. Poll for up to ~2 min: a
             # cold prod boot (release load + DB pool) can take well over 5s. Fail
             # the job on a persistent non-200 so a broken boot doesn't show green.
-            # NOTE: this checks port 4000 (matches the fuser/kill above); keep the
-            # STAGING_PORT secret at 4000 or this will never see the server.
             CODE=000
             for _ in $(seq 1 24); do
-              CODE=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:4000/api/health || true)
+              CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:${APP_PORT}/api/health" || true)
               [ "$CODE" = "200" ] && break
               sleep 5
             done


### PR DESCRIPTION
## Symptom
On the EC2 staging deploy (`staging_deploy.yml`), the `.env` looked un-applied and `mix ecto.migrate` (plus swagger/assets and the **server restart**) never ran — yet the job showed **green**.

## Root cause
The remote script is piped into `bash -se` over the ssh **stdin** (`ssh ... "bash -se" <<'HEREDOC'`). `bash -s` reads its *script* from stdin. A command after `mix deps.get` (a Hex/rebar prompt, or a `sudo` password prompt) read from that same stdin and **swallowed the remaining script lines**. bash then hit EOF and exited **0**, so `deps.compile`, `ecto.migrate`, the asset build, and the server restart were all skipped — and the job still passed.

Confirmed from the run log: output stops right after the `deps.get` dependency list — no "Compiling", no "Migrations", and not even the final `echo` — then straight to job cleanup, exit 0. The `.env` *was* patched (`config/.env` on the host was rewritten at deploy time), but the app was never restarted to pick it up and migrations never ran.

Note: `config/.env` is **untracked**, so `git checkout .` does *not* revert it — the checkout ordering is not the problem.

## Fixes
- **Wrap the remote body in a brace group with stdin from `/dev/null`** — bash parses the whole group before executing it, and its stdin is `/dev/null`, so no inner command can consume the script. Core fix.
- **Health-check `/api/health`** (public, and it verifies the DB) instead of `/api/session?limit=1` (which requires a bearer token and would 401), and **exit non-zero on non-200** so a broken boot fails the job instead of reporting success.
- **Guard that `config/.env` exists** before the `sed` injection, with a clear error otherwise.

## Validation
`actionlint` reports no issues on the changed step. The two warnings it flags are pre-existing on the untouched "Determine branch to deploy" step (`SC2086` on `$GITHUB_OUTPUT` and the `github.head_ref` injection note) — out of scope here; happy to clean those separately.

⚠️ This can only be exercised end-to-end by an actual deploy — recommend a `workflow_dispatch` run of this branch to confirm migrate + restart now run and the health check gates correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
