### PR TITLE
perf(session-occurrence): order active-window queries by end_time, not id

### DIFF
--- a/lib/dbservice_web/controllers/session_occurence_controller.ex
+++ b/lib/dbservice_web/controllers/session_occurence_controller.ex
@@ -203,9 +203,14 @@ defmodule DbserviceWeb.SessionOccurrenceController do
             )
 
       "active" ->
-        from(so in query,
-          where: so.start_time <= ^current_time and so.end_time >= ^current_time
-        )
+        # Active-window lookups filter by end_time (served by the end_time index). Override
+        # the base `ORDER BY id` - which makes PostgreSQL walk the primary key and scan
+        # ~630K rows to find the few active ones - with temporal ordering. `id` is a
+        # deterministic pagination tie-breaker for rows sharing an end_time.
+        query
+        |> exclude(:order_by)
+        |> where([so], so.start_time <= ^current_time and so.end_time >= ^current_time)
+        |> order_by([so], asc: so.end_time, asc: so.id)
 
       _ ->
         query

--- a/priv/repo/migrations/20260709120000_add_session_occurrence_end_time_id_index.exs
+++ b/priv/repo/migrations/20260709120000_add_session_occurrence_end_time_id_index.exs
@@ -1,0 +1,14 @@
+defmodule Dbservice.Repo.Migrations.AddSessionOccurrenceEndTimeIdIndex do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  # Backs the active-window ordering `ORDER BY end_time, id`: the existing single-column
+  # end_time index already serves the temporal filter, but a composite (end_time, id) lets
+  # PostgreSQL satisfy the filter and the id tie-breaker in one B-tree traversal (and
+  # supports future keyset/cursor pagination on that same key).
+  def change do
+    create_if_not_exists index(:session_occurrence, [:end_time, :id], concurrently: true)
+  end
+end

--- a/test/dbservice_web/controllers/session_occurence_controller_test.exs
+++ b/test/dbservice_web/controllers/session_occurence_controller_test.exs
@@ -39,13 +39,15 @@ defmodule DbserviceWeb.SessionOccurrenceControllerTest do
     test "is_start_time=active returns active occurrences ordered by end_time ascending", %{
       conn: conn
     } do
-      past = ~U[2020-01-01 00:00:00Z]
+      now = DateTime.utc_now()
+      past = DateTime.add(now, -365, :day)
 
       # All currently active (started in the past, end in the future), inserted in an order
-      # that differs from their end_time order.
-      mid = session_occurrence_fixture(%{start_time: past, end_time: ~U[2030-06-01 00:00:00Z]})
-      late = session_occurrence_fixture(%{start_time: past, end_time: ~U[2031-06-01 00:00:00Z]})
-      soon = session_occurrence_fixture(%{start_time: past, end_time: ~U[2029-06-01 00:00:00Z]})
+      # that differs from their end_time order. Anchored to `now` with fixed offsets so the
+      # relative ordering stays deterministic and the fixtures never expire with the calendar.
+      mid = session_occurrence_fixture(%{start_time: past, end_time: DateTime.add(now, 2, :day)})
+      late = session_occurrence_fixture(%{start_time: past, end_time: DateTime.add(now, 3, :day)})
+      soon = session_occurrence_fixture(%{start_time: past, end_time: DateTime.add(now, 1, :day)})
 
       # No limit/offset so all active rows come back; assert our three are end_time-ordered.
       conn = get(conn, ~p"/api/session-occurrence?is_start_time=active")

--- a/test/dbservice_web/controllers/session_occurence_controller_test.exs
+++ b/test/dbservice_web/controllers/session_occurence_controller_test.exs
@@ -35,6 +35,25 @@ defmodule DbserviceWeb.SessionOccurrenceControllerTest do
       assert found_record["start_time"] == DateTime.to_iso8601(session_occurrence.start_time)
       assert found_record["end_time"] == DateTime.to_iso8601(session_occurrence.end_time)
     end
+
+    test "is_start_time=active returns active occurrences ordered by end_time ascending", %{
+      conn: conn
+    } do
+      past = ~U[2020-01-01 00:00:00Z]
+
+      # All currently active (started in the past, end in the future), inserted in an order
+      # that differs from their end_time order.
+      mid = session_occurrence_fixture(%{start_time: past, end_time: ~U[2030-06-01 00:00:00Z]})
+      late = session_occurrence_fixture(%{start_time: past, end_time: ~U[2031-06-01 00:00:00Z]})
+      soon = session_occurrence_fixture(%{start_time: past, end_time: ~U[2029-06-01 00:00:00Z]})
+
+      # No limit/offset so all active rows come back; assert our three are end_time-ordered.
+      conn = get(conn, ~p"/api/session-occurrence?is_start_time=active")
+      ids = json_response(conn, 200) |> Enum.map(& &1["id"])
+
+      ours = Enum.filter(ids, &(&1 in [mid.id, late.id, soon.id]))
+      assert ours == [soon.id, mid.id, late.id]
+    end
   end
 
   describe "create session_occurrence" do


### PR DESCRIPTION
Closes #491

## Why

The active-window lookup `WHERE start_time <= now AND end_time >= now` inherited the controller's base `ORDER BY id`. With `ORDER BY id LIMIT n`, PostgreSQL walks the primary-key index and scans ~630K rows to find the handful of currently-active occurrences (~256ms, ~4.8 GB logical I/O per call). Ordering by `end_time` instead lets it use the `end_time` index and check ~66 rows (~0.45ms) — a ~565x speedup (the audit's highest single-query impact).

## What

- **Scoped to the `active` path only** (base `ORDER BY id` is unchanged for all other query paths, per the issue): `exclude(:order_by)` the inherited id ordering, then `ORDER BY end_time, id`. `id` is a deterministic pagination tie-breaker for occurrences that share an `end_time` (common — classes ending on the hour), preventing rows from shifting between pages.
- **Composite `(end_time, id)` index** (built `CONCURRENTLY`) so the temporal filter and the tie-breaker are served in a single B-tree traversal and future keyset/cursor pagination is supported. (The existing `end_time` index already delivers the speedup; this makes the ordering fully index-backed.)
- Controller test asserting `is_start_time=active` returns occurrences in `end_time`-ascending order regardless of insertion order.

## Behavior note
This changes the ordering of `active` results from insertion order (`id`) to "ending soonest first" (`end_time`). The `active` filter is a "what's happening now" view, so this is expected/desirable; other list paths are unaffected.

## Verification
`mix test test/dbservice_web/controllers/session_occurence_controller_test.exs` → 7/7; credo + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)