### PR TITLE
fix(template): allow school_addition CSV template download

### DIFF
--- a/lib/dbservice_web/controllers/template_controller.ex
+++ b/lib/dbservice_web/controllers/template_controller.ex
@@ -19,6 +19,7 @@ defmodule DbserviceWeb.TemplateController do
          "product_addition",
          "program_addition",
          "batch_addition",
+         "school_addition",
          "alumni_addition",
          "batch_movement",
          "dropout",


### PR DESCRIPTION
## Problem

Clicking "Download School Addition Template" on the imports page throws a "file is not available on site" error.

## Cause

`TemplateController.download_csv_template/2` validates the import type against a hardcoded allowlist, and `school_addition` was never added to it — so `/templates/school_addition/download` returned a 404, even though the school import itself and its header mappings in `Dbservice.Constants.Mappings` fully support it.

## Fix

Add `school_addition` to the allowed types list.

Verified the template now generates correctly:

```
State_code,academic_year,af_school_category,board,board_medium,district,district_code,group,program_model,region,school_code,school_gender_type,school_name,state,udise_code,update_date
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)