### PR TITLE
feat(data-import): add block_code and block_name to school_addition import

### DIFF
--- a/lib/dbservice/constants/mappings.ex
+++ b/lib/dbservice/constants/mappings.ex
@@ -447,6 +447,18 @@ defmodule Dbservice.Constants.Mappings do
       optional: [],
       type: :string
     },
+    "block_code" => %{
+      db_field: "block_code",
+      required: [],
+      optional: ["school_addition"],
+      type: :string
+    },
+    "block_name" => %{
+      db_field: "block_name",
+      required: [],
+      optional: ["school_addition"],
+      type: :string
+    },
     "board" => %{
       db_field: "school_board",
       required: [],

--- a/lib/dbservice/utils/import_worker.ex
+++ b/lib/dbservice/utils/import_worker.ex
@@ -1388,6 +1388,8 @@ defmodule Dbservice.DataImport.ImportWorker do
     |> maybe_put_school("state", record["school_state"] |> trim_str())
     |> maybe_put_school("district_code", record["district_code"] |> trim_str())
     |> maybe_put_school("district", record["school_district"] |> trim_str())
+    |> maybe_put_school("block_code", record["block_code"] |> trim_str())
+    |> maybe_put_school("block_name", record["block_name"] |> trim_str())
     |> maybe_put_school("board", record["school_board"] |> trim_str())
   end
 


### PR DESCRIPTION
## Why

The `School` schema already has `block_code` and `block_name` columns (and the changeset casts them), but the **school_addition** import had no way to populate them — the columns weren't in the CSV template and the import worker never mapped them into the school attrs.

## What

- **`Mappings`** — add `block_code` and `block_name` as **optional** `school_addition` fields. Since the template download and header validation are both driven by the mappings, the columns now appear in the downloaded template and pass validation automatically.
- **`ImportWorker.build_school_attrs/2`** — carry `record["block_code"]` / `record["block_name"]` into the school attrs (trimmed, skipped when blank — same `maybe_put_school` handling as every other optional field).

## Verified

Template header row now generates as:

```
State_code,academic_year,af_school_category,block_code,block_name,board,board_medium,district,district_code,group,program_model,region,school_code,school_gender_type,school_name,state,udise_code,update_date
```

Compiles clean with `--warnings-as-errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)