### PR TITLE
feat(session-occurrence): add start_time_lte/end_time_gte window filters

### DIFF
--- a/lib/dbservice_web/controllers/session_occurence_controller.ex
+++ b/lib/dbservice_web/controllers/session_occurence_controller.ex
@@ -5,6 +5,7 @@ defmodule DbserviceWeb.SessionOccurrenceController do
   alias Dbservice.Repo
   alias Dbservice.Sessions
   alias Dbservice.Sessions.SessionOccurrence
+  alias Dbservice.Utils.Util
 
   action_fallback(DbserviceWeb.FallbackController)
 
@@ -37,6 +38,22 @@ defmodule DbserviceWeb.SessionOccurrenceController do
         name: "is_start_time",
         enum: ["today", "active"]
       )
+
+      params(
+        :query,
+        :string,
+        "Only occurrences starting at or before this ISO-8601 timestamp",
+        required: false,
+        name: "start_time_lte"
+      )
+
+      params(
+        :query,
+        :string,
+        "Only occurrences ending at or after this ISO-8601 timestamp",
+        required: false,
+        name: "end_time_gte"
+      )
     end
 
     response(200, "OK", Schema.ref(:SessionOccurrences))
@@ -45,15 +62,29 @@ defmodule DbserviceWeb.SessionOccurrenceController do
   def index(conn, params) do
     session_ids = Map.get(params, "session_ids", [])
 
-    session_occurrences = fetch_filtered_session_occurrences(session_ids, params)
-    render(conn, :index, session_occurrence: session_occurrences)
+    case fetch_filtered_session_occurrences(session_ids, params) do
+      {:ok, session_occurrences} ->
+        render(conn, :index, session_occurrence: session_occurrences)
+
+      {:error, message} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{error: message})
+    end
   end
 
   def search(conn, params) do
     session_ids = Map.get(params, "session_ids", [])
 
-    session_occurrences = fetch_filtered_session_occurrences(session_ids, params)
-    render(conn, :index, session_occurrence: session_occurrences)
+    case fetch_filtered_session_occurrences(session_ids, params) do
+      {:ok, session_occurrences} ->
+        render(conn, :index, session_occurrence: session_occurrences)
+
+      {:error, message} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{error: message})
+    end
   end
 
   defp fetch_filtered_session_occurrences(session_ids, params) do
@@ -73,27 +104,59 @@ defmodule DbserviceWeb.SessionOccurrenceController do
         limit: ^params["limit"]
       )
 
-    filtered_query =
-      Enum.reduce(params, base_query, fn {key, value}, acc ->
-        case String.to_existing_atom(key) do
-          :offset ->
-            acc
+    params
+    |> Enum.reduce_while({:ok, base_query}, fn
+      {"start_time_lte", value}, {:ok, acc} ->
+        apply_window_filter(:start_time_lte, value, acc)
 
-          :limit ->
-            acc
+      {"end_time_gte", value}, {:ok, acc} ->
+        apply_window_filter(:end_time_gte, value, acc)
 
-          :is_start_time ->
-            apply_time_filter(acc, value, today_start, today_end, current_time)
+      {key, value}, {:ok, acc} ->
+        query =
+          case String.to_existing_atom(key) do
+            :offset ->
+              acc
 
-          :session_ids ->
-            from(u in acc, where: u.session_id in ^session_ids)
+            :limit ->
+              acc
 
-          atom ->
-            from(u in acc, where: field(u, ^atom) == ^value)
-        end
-      end)
+            :is_start_time ->
+              apply_time_filter(acc, value, today_start, today_end, current_time)
 
-    Repo.all(filtered_query)
+            :session_ids ->
+              from(u in acc, where: u.session_id in ^session_ids)
+
+            atom ->
+              from(u in acc, where: field(u, ^atom) == ^value)
+          end
+
+        {:cont, {:ok, query}}
+    end)
+    |> case do
+      {:ok, query} -> {:ok, Repo.all(query)}
+      {:error, message} -> {:error, message}
+    end
+  end
+
+  # start_time_lte and end_time_gte together select occurrences overlapping a
+  # caller-supplied window [end_time_gte, start_time_lte]. The window semantics
+  # (e.g. "now until end of today" for a homepage) belong to the caller; this
+  # endpoint only compares timestamps.
+  defp apply_window_filter(operator, value, acc) do
+    case Util.parse_datetime(value) do
+      {:ok, datetime} ->
+        query =
+          case operator do
+            :start_time_lte -> from(so in acc, where: so.start_time <= ^datetime)
+            :end_time_gte -> from(so in acc, where: so.end_time >= ^datetime)
+          end
+
+        {:cont, {:ok, query}}
+
+      :error ->
+        {:halt, {:error, "Invalid #{operator} timestamp"}}
+    end
   end
 
   swagger_path :create do

--- a/test/dbservice_web/controllers/session_occurence_controller_test.exs
+++ b/test/dbservice_web/controllers/session_occurence_controller_test.exs
@@ -37,6 +37,85 @@ defmodule DbserviceWeb.SessionOccurrenceControllerTest do
     end
   end
 
+  describe "time window filters (start_time_lte / end_time_gte)" do
+    # Window under test: 2030-01-01 10:00 → 2030-01-01 23:59:59.
+    # An occurrence overlaps it when start_time <= window end AND end_time >= window start.
+    defp window_fixtures(_) do
+      %{
+        # starts later inside the window (the "test starts at 2pm" case)
+        upcoming:
+          session_occurrence_fixture(%{
+            start_time: ~U[2030-01-01 14:00:00Z],
+            end_time: ~U[2030-01-01 18:00:00Z]
+          }),
+        # already over before the window opens
+        ended:
+          session_occurrence_fixture(%{
+            start_time: ~U[2030-01-01 06:00:00Z],
+            end_time: ~U[2030-01-01 09:00:00Z]
+          }),
+        # starts after the window closes
+        tomorrow:
+          session_occurrence_fixture(%{
+            start_time: ~U[2030-01-02 10:00:00Z],
+            end_time: ~U[2030-01-02 18:00:00Z]
+          }),
+        # started before the window and still open (multi-day continuous)
+        multiday:
+          session_occurrence_fixture(%{
+            start_time: ~U[2029-12-30 10:00:00Z],
+            end_time: ~U[2030-01-02 18:00:00Z]
+          })
+      }
+    end
+
+    setup [:window_fixtures]
+
+    test "search returns occurrences overlapping the window", %{conn: conn} = ctx do
+      session_ids =
+        Enum.map([ctx.upcoming, ctx.ended, ctx.tomorrow, ctx.multiday], & &1.session_id)
+
+      conn =
+        post(conn, ~p"/api/session-occurrence/search", %{
+          session_ids: session_ids,
+          end_time_gte: "2030-01-01T10:00:00Z",
+          start_time_lte: "2030-01-01T23:59:59Z"
+        })
+
+      ids = json_response(conn, 200) |> Enum.map(& &1["id"]) |> MapSet.new()
+
+      assert MapSet.member?(ids, ctx.upcoming.id)
+      assert MapSet.member?(ids, ctx.multiday.id)
+      refute MapSet.member?(ids, ctx.ended.id)
+      refute MapSet.member?(ids, ctx.tomorrow.id)
+    end
+
+    test "end_time_gte alone excludes only already-ended occurrences", %{conn: conn} = ctx do
+      conn = get(conn, ~p"/api/session-occurrence?end_time_gte=2030-01-01T10:00:00Z")
+      ids = json_response(conn, 200) |> Enum.map(& &1["id"]) |> MapSet.new()
+
+      assert MapSet.member?(ids, ctx.upcoming.id)
+      assert MapSet.member?(ids, ctx.tomorrow.id)
+      assert MapSet.member?(ids, ctx.multiday.id)
+      refute MapSet.member?(ids, ctx.ended.id)
+    end
+
+    test "start_time_lte alone excludes only later-starting occurrences", %{conn: conn} = ctx do
+      conn = get(conn, ~p"/api/session-occurrence?start_time_lte=2030-01-01T23:59:59Z")
+      ids = json_response(conn, 200) |> Enum.map(& &1["id"]) |> MapSet.new()
+
+      assert MapSet.member?(ids, ctx.upcoming.id)
+      assert MapSet.member?(ids, ctx.ended.id)
+      assert MapSet.member?(ids, ctx.multiday.id)
+      refute MapSet.member?(ids, ctx.tomorrow.id)
+    end
+
+    test "invalid timestamp returns 400", %{conn: conn} do
+      conn = get(conn, ~p"/api/session-occurrence?end_time_gte=not-a-date")
+      assert %{"error" => _} = json_response(conn, 400)
+    end
+  end
+
   describe "create session_occurrence" do
     test "renders session_occurrence when data is valid", %{conn: conn} do
       session = session_fixture()


### PR DESCRIPTION
## Problem
A **continuous** session (one occurrence spanning e.g. 9 Jul 2pm–6pm) never shows on the Gurukul home page before it opens — no "Starts at 2:00 PM" state. Gurukul queries `POST /session-occurrence/search` with `is_start_time=today`, whose continuous branch only returns occurrences that are *currently active* (`start_time <= now AND end_time >= now`), so a not-yet-started occurrence is never returned.

## Design
Per discussion (Pritam): db-service should not encode what Gurukul wants to show. It should just answer "which occurrences are active within a given time window" and let the client own visible/starts-soon logic.

## Change
Two new generic params on `GET /session-occurrence` and `POST /session-occurrence/search` (naming follows the existing `end_time_gte`/`end_time_lt` filters on `/session/search`):

- `start_time_lte` — occurrence starts at or before this ISO-8601 timestamp
- `end_time_gte` — occurrence ends at or after this ISO-8601 timestamp

Together they select occurrences overlapping the window `[end_time_gte, start_time_lte]`; each also works alone. Invalid timestamps return `400` (parsed with the existing `Util.parse_datetime`).

**Backward compatible:** `is_start_time=today|active` behavior is untouched; existing callers need no changes. Gurukul will switch to sending `end_time_gte=<now>` and `start_time_lte=<end of today>` in a follow-up PR (deploy this first).

## Tests
- Window overlap via `POST /search`: upcoming-today returned (the bug scenario), already-ended excluded, starts-tomorrow excluded, multi-day-still-open returned
- Each param alone
- Invalid timestamp → 400

`mix test`: the 4 new tests pass; the suite's 8 pre-existing failures are identical on clean `main` (unrelated: student import + error JSON wording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)