### PR TITLE
feat(centre): add centre_batch join table

### DIFF
--- a/priv/repo/migrations/20260710120000_create_centre_batch.exs
+++ b/priv/repo/migrations/20260710120000_create_centre_batch.exs
@@ -1,0 +1,24 @@
+defmodule Dbservice.Repo.Migrations.CreateCentreBatch do
+  use Ecto.Migration
+
+  def change do
+    create table(:centre_batch) do
+      add :centre_id, references(:centres, on_delete: :nothing), null: false
+      add :batch_id, references(:batch, on_delete: :nothing), null: false
+      add :deleted_at, :naive_datetime
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create index(:centre_batch, [:centre_id])
+    create index(:centre_batch, [:batch_id])
+
+    # A batch is linked to a centre at most once while the link is live.
+    # Soft-deleted history rows are exempt, so a link can be removed and
+    # re-created without tripping the constraint.
+    create unique_index(:centre_batch, [:centre_id, :batch_id],
+             where: "deleted_at IS NULL",
+             name: :centre_batch_active_link_unique
+           )
+  end
+end


### PR DESCRIPTION
## What

Adds a `centre_batch` join table linking batches to centres (many batches per centre).

Mirrors the existing centre-association tables (`centre_positions` for teachers, `centre_students` for students):
- FK `centre_id → centres`, FK `batch_id → batch`
- `deleted_at` soft-delete
- Partial unique index on active `(centre_id, batch_id)` links (soft-deleted rows exempt, so a link can be removed and re-created)

## Why

The LMS currently scopes quiz-sessions and teacher-feedback batches via `school → batch` (the `school_batch` table). This table enables scoping via **teacher → centre → batch** instead, treating batch as a first-class centre association like teachers and students already are.

Writes to `centre_batch` come from the LMS directly (like `centre_positions`/`centre_students`), so no controller/schema is added here — migration only.

## Deploy note

Backfill of existing centre↔batch links (from the DCF CSV) runs from the LMS side **after** this migration reaches prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)