### PR TITLE
Prod deployment: centre_batch join table

### DIFF
--- a/priv/repo/migrations/20260710120000_create_centre_batch.exs
+++ b/priv/repo/migrations/20260710120000_create_centre_batch.exs
@@ -1,0 +1,24 @@
+defmodule Dbservice.Repo.Migrations.CreateCentreBatch do
+  use Ecto.Migration
+
+  def change do
+    create table(:centre_batch) do
+      add :centre_id, references(:centres, on_delete: :nothing), null: false
+      add :batch_id, references(:batch, on_delete: :nothing), null: false
+      add :deleted_at, :naive_datetime
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create index(:centre_batch, [:centre_id])
+    create index(:centre_batch, [:batch_id])
+
+    # A batch is linked to a centre at most once while the link is live.
+    # Soft-deleted history rows are exempt, so a link can be removed and
+    # re-created without tripping the constraint.
+    create unique_index(:centre_batch, [:centre_id, :batch_id],
+             where: "deleted_at IS NULL",
+             name: :centre_batch_active_link_unique
+           )
+  end
+end


### PR DESCRIPTION
Promotes `main` → `release` to deploy to prod.

## Payload
Exactly one change — the `centre_batch` join table migration (#596, already merged to main):
- `priv/repo/migrations/20260710120000_create_centre_batch.exs`

No other commits ride along (the rest of the main↔release delta is merge bubbles from prior promotions).

## Effect on merge
Push to `release` triggers `production_deploy.yml` → `mix ecto.migrate` on prod → creates `centre_batch` (FK centre_id→centres, batch_id→batch, deleted_at soft-delete, partial unique index on active (centre_id, batch_id)).

After this lands, the LMS-side centre↔batch backfill runs against prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)