### PR TITLE
feat(api): return lang_versions in all problem GET responses

### DIFF
--- a/lib/dbservice/problem_languages.ex
+++ b/lib/dbservice/problem_languages.ex
@@ -6,6 +6,7 @@ defmodule Dbservice.ProblemLanguages do
   import Ecto.Query, warn: false
   alias Dbservice.Repo
 
+  alias Dbservice.Languages.Language
   alias Dbservice.Resources.ProblemLanguage
 
   @doc """
@@ -40,6 +41,24 @@ defmodule Dbservice.ProblemLanguages do
   """
   def get_problem_language_by_problem_id_and_language_id(problem_id, language_id) do
     Repo.get_by(ProblemLanguage, res_id: problem_id, lang_id: language_id)
+  end
+
+  @doc """
+  Returns all language versions of a problem as a list of maps with
+  `lang_code` and `meta_data`, one entry per `problem_lang` row.
+  ## Examples
+      iex> list_lang_versions_by_resource_id(1)
+      [%{lang_code: "en", meta_data: %{...}}, %{lang_code: "hi", meta_data: %{...}}]
+  """
+  def list_lang_versions_by_resource_id(resource_id) do
+    from(pl in ProblemLanguage,
+      join: l in Language,
+      on: l.id == pl.lang_id,
+      where: pl.res_id == ^resource_id,
+      order_by: [asc: pl.id],
+      select: %{lang_code: l.code, meta_data: pl.meta_data}
+    )
+    |> Repo.all()
   end
 
   @doc """

--- a/lib/dbservice/problem_languages.ex
+++ b/lib/dbservice/problem_languages.ex
@@ -62,6 +62,30 @@ defmodule Dbservice.ProblemLanguages do
   end
 
   @doc """
+  Batched version of `list_lang_versions_by_resource_id/1`. Fetches the
+  language versions for many resources in a single query and returns a map of
+  `resource_id => [%{lang_code, meta_data}]`. Use this instead of calling
+  `list_lang_versions_by_resource_id/1` in a loop to avoid N+1 queries when
+  rendering a list of problems.
+  ## Examples
+      iex> list_lang_versions_by_resource_ids([1, 2])
+      %{1 => [%{lang_code: "en", meta_data: %{...}}], 2 => [...]}
+  """
+  def list_lang_versions_by_resource_ids([]), do: %{}
+
+  def list_lang_versions_by_resource_ids(resource_ids) do
+    from(pl in ProblemLanguage,
+      join: l in Language,
+      on: l.id == pl.lang_id,
+      where: pl.res_id in ^resource_ids,
+      order_by: [asc: pl.id],
+      select: %{res_id: pl.res_id, lang_code: l.code, meta_data: pl.meta_data}
+    )
+    |> Repo.all()
+    |> Enum.group_by(& &1.res_id, &Map.take(&1, [:lang_code, :meta_data]))
+  end
+
+  @doc """
   Creates a problem_language.
   ## Examples
       iex> create_problem_language(%{field: value})

--- a/lib/dbservice/resources.ex
+++ b/lib/dbservice/resources.ex
@@ -67,6 +67,47 @@ defmodule Dbservice.Resources do
     end
   end
 
+  @doc """
+  All-languages counterpart of `get_problems_by_test_and_language/3`. Returns
+  every problem in the test once (no language filter); each problem's languages
+  are attached as `lang_versions` by the JSON layer.
+  """
+  def get_problems_by_test(test_id, curriculum_id) do
+    test_resource = Repo.get(Resource, test_id)
+
+    cond do
+      is_nil(test_resource) -> {:error, :test_not_found}
+      test_resource.type != "test" -> {:error, :resource_not_test_type}
+      true -> fetch_and_format_problems_all_langs(test_resource, curriculum_id)
+    end
+  end
+
+  defp fetch_and_format_problems_all_langs(test_resource, curriculum_id) do
+    problem_ids = extract_problem_ids_from_test(test_resource.type_params)
+
+    problems =
+      from(r in Resource,
+        where: r.id in ^problem_ids and r.type == "problem",
+        preload: [:resource_curriculum, :chapter]
+      )
+      |> Repo.all()
+      # SQL `IN` does not preserve list order, so re-sort to match the order the
+      # ids appear in the test's type_params (the order the test defines).
+      |> order_problems_by_ids(problem_ids)
+
+    resource_topic_by_resource_id = resource_topics_by_resource_id(problem_ids)
+
+    Enum.map(problems, fn resource ->
+      %{
+        resource: resource,
+        resource_topic: Map.get(resource_topic_by_resource_id, resource.id, %{}),
+        resource_curriculums: resource.resource_curriculum,
+        problem_lang: %{},
+        requested_curriculum_id: curriculum_id
+      }
+    end)
+  end
+
   defp get_problems_for_test(test_id, lang_id, curriculum_id) do
     test_resource = Repo.get(Resource, test_id)
 
@@ -1259,6 +1300,84 @@ defmodule Dbservice.Resources do
     |> apply_problem_search_filters(params)
     |> select([pl], count(pl.id))
     |> Repo.one()
+  end
+
+  @doc """
+  All-languages counterpart of `search_problems/1`. A problem can match the
+  search in more than one language, so results are deduped to one entry per
+  problem (`problem_lang` is left empty; every language is attached as
+  `lang_versions` by the JSON layer). Sorting supports `code`/`subtype`;
+  `text` is language-specific and falls back to problem order.
+  """
+  def search_problems_all_langs(params \\ %{}) do
+    page =
+      ProblemLanguage
+      |> from(as: :pl)
+      |> apply_problem_search_filters(params)
+      |> all_langs_resources_query(params)
+      |> apply_problem_pagination(params)
+      |> Repo.all()
+
+    page
+    |> Enum.map(& &1.res_id)
+    |> build_all_langs_results()
+  end
+
+  @doc """
+  Counts distinct problems matching the search filters, ignoring language (the
+  count for `search_problems_all_langs/1`).
+  """
+  def count_problems_all_langs(params \\ %{}) do
+    ProblemLanguage
+    |> from(as: :pl)
+    |> apply_problem_search_filters(params)
+    |> select([pl], count(pl.res_id, :distinct))
+    |> Repo.one()
+  end
+
+  # Distinct problems (by res_id) for the current search filters, ordered for
+  # stable pagination. code/subtype are functionally dependent on res_id, so
+  # selecting them alongside keeps DISTINCT one-row-per-problem while allowing
+  # ORDER BY on those columns.
+  defp all_langs_resources_query(query, params) do
+    sort_order = get_sort_order(params["sort_order"])
+
+    base =
+      from(pl in query,
+        join: r in Resource,
+        as: :res,
+        on: r.id == pl.res_id,
+        distinct: true,
+        select: %{res_id: pl.res_id, code: r.code, subtype: r.subtype}
+      )
+
+    case params["sort_by"] do
+      "code" -> from([res: r] in base, order_by: [{^sort_order, r.code}])
+      "subtype" -> from([res: r] in base, order_by: [{^sort_order, r.subtype}])
+      _ -> from([pl: pl] in base, order_by: [{^sort_order, pl.res_id}])
+    end
+  end
+
+  defp build_all_langs_results([]), do: []
+
+  defp build_all_langs_results(ordered_ids) do
+    resources_by_id =
+      from(r in Resource, where: r.id in ^ordered_ids)
+      |> Repo.all()
+      |> Map.new(&{&1.id, &1})
+
+    curriculums_by_res_id =
+      from(rc in Dbservice.Resources.ResourceCurriculum, where: rc.resource_id in ^ordered_ids)
+      |> Repo.all()
+      |> Enum.group_by(& &1.resource_id)
+
+    Enum.map(ordered_ids, fn id ->
+      %{
+        resource: Map.get(resources_by_id, id),
+        problem_lang: %{},
+        resource_curriculums: Map.get(curriculums_by_res_id, id, [])
+      }
+    end)
   end
 
   # Private query building functions for problem search

--- a/lib/dbservice_web/controllers/resource_controller.ex
+++ b/lib/dbservice_web/controllers/resource_controller.ex
@@ -1061,15 +1061,46 @@ defmodule DbserviceWeb.ResourceController do
     end
   end
 
+  # All-languages variant of test_problems/2: no lang_code, so every problem in
+  # the test is returned once with all its languages in lang_versions.
+  # GET /api/resource/test/:id/problems?curriculum_id=1
+  def test_problems(conn, %{"id" => test_id, "curriculum_id" => curriculum_id}) do
+    test_id = String.to_integer(test_id)
+    curriculum_id = String.to_integer(curriculum_id)
+
+    case Resources.get_problems_by_test(test_id, curriculum_id) do
+      {:error, :test_not_found} ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{error: "Test resource not found"})
+
+      {:error, :resource_not_test_type} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{error: "The specified resource is not a test"})
+
+      problems ->
+        conn
+        |> put_status(:ok)
+        |> render("index.json", resource: problems)
+    end
+  end
+
   swagger_path :fetch_problems do
     get("/api/problems")
-    summary("Fetch problems by topic, curriculum and language")
-    description("Returns problems filtered by topic_id, curriculum_id and lang_code")
+    summary("Fetch problems by topic and curriculum (optionally a language)")
+
+    description(
+      "Returns problems filtered by topic_id and curriculum_id. When lang_code is " <>
+        "given, results are limited to that language (top-level meta_data is that " <>
+        "language). When lang_code is omitted, every problem is returned once with all " <>
+        "languages in lang_versions for client-side filtering."
+    )
 
     parameters do
       topic_id(:query, :integer, "Topic ID", required: true)
       curriculum_id(:query, :integer, "Curriculum ID", required: true)
-      lang_code(:query, :string, "Language code", required: true)
+      lang_code(:query, :string, "Language code (omit for all languages)", required: false)
 
       include_paragraph_siblings(
         :query,
@@ -1108,6 +1139,17 @@ defmodule DbserviceWeb.ResourceController do
 
       render(conn, "problems.json", problems: problems)
     end
+  end
+
+  def fetch_problems(conn, %{"topic_id" => topic_id, "curriculum_id" => curriculum_id} = params) do
+    problems =
+      topic_id
+      |> problems_query_all_langs(curriculum_id)
+      |> Repo.all()
+      |> Enum.uniq_by(& &1.resource.id)
+      |> maybe_add_paragraph_siblings_all_langs(params, curriculum_id)
+
+    render(conn, "problems.json", problems: problems)
   end
 
   defp problems_base_query(curriculum_id, lang_code) do
@@ -1188,6 +1230,81 @@ defmodule DbserviceWeb.ResourceController do
     )
   end
 
+  # All-languages counterpart of problems_base_query/2. No problem_lang/language
+  # join, so a problem appears at most once regardless of how many languages it
+  # has; the per-language data is attached as lang_versions by the JSON layer.
+  defp problems_base_query_all_langs(curriculum_id) do
+    from(r in Resource,
+      as: :resource,
+      join: rt in ResourceTopic,
+      as: :resource_topic,
+      on: rt.resource_id == r.id,
+      join: t in Topic,
+      on: t.id == rt.topic_id,
+      join: rc in ResourceCurriculum,
+      on: rc.resource_id == r.id,
+      where: rc.curriculum_id == ^curriculum_id,
+      where: r.type == "problem",
+      order_by: [asc: r.code],
+      select: %{
+        resource: r,
+        resource_topic: rt,
+        chapter_id: t.chapter_id,
+        resource_curriculums: [rc],
+        requested_curriculum_id: ^curriculum_id
+      }
+    )
+  end
+
+  defp problems_query_all_langs(topic_id, curriculum_id) do
+    from([resource_topic: rt] in problems_base_query_all_langs(curriculum_id),
+      where: rt.topic_id == ^topic_id
+    )
+  end
+
+  defp maybe_add_paragraph_siblings_all_langs(problems, params, curriculum_id) do
+    if params["include_paragraph_siblings"] == "true" do
+      res_ids = Enum.map(problems, & &1.resource.id)
+
+      paragraph_ids =
+        from(pl in ProblemLanguage,
+          where: pl.res_id in ^res_ids and not is_nil(pl.paragraph_id),
+          distinct: true,
+          select: pl.paragraph_id
+        )
+        |> Repo.all()
+
+      add_paragraph_siblings_all_langs(problems, paragraph_ids, curriculum_id)
+    else
+      problems
+    end
+  end
+
+  defp add_paragraph_siblings_all_langs(problems, [], _curriculum_id), do: problems
+
+  defp add_paragraph_siblings_all_langs(problems, paragraph_ids, curriculum_id) do
+    existing_res_ids = MapSet.new(Enum.map(problems, & &1.resource.id))
+
+    # Any problem sharing one of these paragraphs, in any language.
+    sibling_res_ids =
+      from(pl in ProblemLanguage,
+        where: pl.paragraph_id in ^paragraph_ids,
+        distinct: true,
+        select: pl.res_id
+      )
+      |> Repo.all()
+
+    siblings =
+      from([resource: r] in problems_base_query_all_langs(curriculum_id),
+        where: r.id in ^sibling_res_ids
+      )
+      |> Repo.all()
+      |> Enum.reject(fn p -> MapSet.member?(existing_res_ids, p.resource.id) end)
+      |> Enum.uniq_by(& &1.resource.id)
+
+    problems ++ siblings
+  end
+
   swagger_path :get_problem do
     get("/api/resource/problem/{problem_id}/{lang_code}/{curriculum_id}")
 
@@ -1252,6 +1369,72 @@ defmodule DbserviceWeb.ResourceController do
     end
   end
 
+  swagger_path :get_problem_all_languages do
+    get("/api/resource/problem/{problem_id}/{curriculum_id}")
+    summary("Fetch a problem in all languages")
+
+    description(
+      "All-languages variant of the problem endpoint. Returns the problem for the " <>
+        "given curriculum_id with every available language in `lang_versions`, so the " <>
+        "frontend can filter by language client-side. Top-level `meta_data`/`lang_code` " <>
+        "are null since no single language is requested."
+    )
+
+    parameters do
+      problem_id(:path, :integer, "The id of the problem resource", required: true)
+      curriculum_id(:path, :integer, "The curriculum ID", required: true)
+    end
+
+    response(200, "OK", Schema.ref(:ProblemResource))
+    response(404, "Not Found")
+  end
+
+  @doc """
+  Get a specific problem in all languages by resource ID and curriculum ID.
+
+  Unlike `get_problem/2`, this does not take a lang_code: the response carries
+  every language in `lang_versions` and leaves the top-level single-language
+  fields (`meta_data`, `lang_code`, `paragraph`) empty.
+  """
+  def get_problem_all_languages(conn, %{
+        "problem_id" => res_id,
+        "curriculum_id" => curriculum_id
+      }) do
+    query =
+      from(r in Resource,
+        where: r.id == ^res_id and r.type == "problem",
+        preload: [:resource_curriculum]
+      )
+
+    case Repo.one(query) do
+      nil ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{error: "Problem not found for given inputs"})
+
+      resource ->
+        resource_curriculum =
+          Enum.find(resource.resource_curriculum, fn rc ->
+            rc.curriculum_id == String.to_integer(curriculum_id)
+          end)
+
+        case resource_curriculum do
+          nil ->
+            conn
+            |> put_status(:not_found)
+            |> json(%{error: "No resource found for given curriculum_id"})
+
+          rc ->
+            render(conn, "problem_lang.json",
+              resource: resource,
+              meta_data: nil,
+              lang_code: nil,
+              resource_curriculum: rc
+            )
+        end
+    end
+  end
+
   swagger_path :search_problems do
     get("/api/problems/search")
 
@@ -1292,11 +1475,21 @@ defmodule DbserviceWeb.ResourceController do
       |> Map.put_new("limit", 10)
       |> Map.put_new("offset", 0)
 
-    total_count = Resources.count_problems(params)
-    problems = Resources.search_problems(params)
+    # With a lang_code, results are one row per problem in that language. Without
+    # it, the same problem can match on several languages, so use the deduped
+    # all-languages search (one entry per problem, all languages in lang_versions).
+    {total_count, problems} =
+      if lang_code_present?(params) do
+        {Resources.count_problems(params), Resources.search_problems(params)}
+      else
+        {Resources.count_problems_all_langs(params), Resources.search_problems_all_langs(params)}
+      end
 
     conn
     |> put_resp_header("x-total-count", Integer.to_string(total_count))
     |> render("problems.json", problems: problems)
   end
+
+  defp lang_code_present?(%{"lang_code" => code}) when is_binary(code) and code != "", do: true
+  defp lang_code_present?(_), do: false
 end

--- a/lib/dbservice_web/json/resource_json.ex
+++ b/lib/dbservice_web/json/resource_json.ex
@@ -4,6 +4,7 @@ defmodule DbserviceWeb.ResourceJSON do
   alias Dbservice.Resources.ResourceChapter
   alias Dbservice.Concepts
   alias Dbservice.Paragraphs
+  alias Dbservice.ProblemLanguages
   alias Dbservice.ResourceConcepts
   alias Dbservice.ResourceCurriculums
   alias Dbservice.Repo
@@ -193,12 +194,15 @@ defmodule DbserviceWeb.ResourceJSON do
         subject_id: Map.get(curriculum, :subject_id, nil)
       })
 
-    # Add problem language data
+    # Add problem language data. Top-level meta_data keeps the currently
+    # requested language for backward compatibility (see issue #610);
+    # lang_versions carries every available language for the new frontend.
     problem_map =
       Map.merge(resource_with_curriculum, %{
         meta_data: Map.get(problem_lang, :meta_data, nil),
         lang_id: Map.get(problem_lang, :lang_id, nil),
-        paragraph_id: Map.get(problem_lang, :paragraph_id, nil)
+        paragraph_id: Map.get(problem_lang, :paragraph_id, nil),
+        lang_versions: ProblemLanguages.list_lang_versions_by_resource_id(resource.id)
       })
 
     # Fetch concept information
@@ -239,8 +243,12 @@ defmodule DbserviceWeb.ResourceJSON do
     # top-level fields (merged below from the resolved resource_curriculum), so
     # the curriculum_grades list is redundant here.
     |> Map.delete(:curriculum_grades)
+    # Top-level meta_data/lang_code keep the requested language for backward
+    # compatibility (see issue #610); lang_versions carries every available
+    # language for the new frontend.
     |> Map.put(:meta_data, meta_data)
     |> Map.put(:lang_code, lang_code)
+    |> Map.put(:lang_versions, ProblemLanguages.list_lang_versions_by_resource_id(resource.id))
     |> Map.merge(%{
       curriculum_id: rc.curriculum_id,
       grade_id: rc.grade_id,

--- a/lib/dbservice_web/json/resource_json.ex
+++ b/lib/dbservice_web/json/resource_json.ex
@@ -11,10 +11,18 @@ defmodule DbserviceWeb.ResourceJSON do
   import Ecto.Query
 
   def index(%{resource: resources}) do
+    # Batch-fetch lang_versions for the problem-structure entries to avoid an
+    # N+1 query inside render_problem/2.
+    lang_versions_by_res_id =
+      resources
+      |> Enum.filter(&Map.has_key?(&1, :resource))
+      |> Enum.map(& &1.resource.id)
+      |> ProblemLanguages.list_lang_versions_by_resource_ids()
+
     Enum.map(resources, fn resource ->
       # If resource is a map with :resource key, it's the new structure
       if Map.has_key?(resource, :resource) do
-        render_problem(resource)
+        render_problem(resource, lang_versions_by_res_id)
       else
         render(resource)
       end
@@ -111,10 +119,17 @@ defmodule DbserviceWeb.ResourceJSON do
   end
 
   def problems(%{problems: problems}) do
-    Enum.map(problems, fn problem -> render_problem(problem) end)
+    # Batch-fetch lang_versions for every problem up front to avoid an N+1
+    # query (one lookup per problem inside render_problem/2).
+    lang_versions_by_res_id =
+      problems
+      |> Enum.map(& &1.resource.id)
+      |> ProblemLanguages.list_lang_versions_by_resource_ids()
+
+    Enum.map(problems, fn problem -> render_problem(problem, lang_versions_by_res_id) end)
   end
 
-  defp render_problem(problem) do
+  defp render_problem(problem, lang_versions_by_res_id) do
     # First get the base resource
     resource = problem.resource
     resource_topic = Map.get(problem, :resource_topic, %{})
@@ -194,6 +209,10 @@ defmodule DbserviceWeb.ResourceJSON do
         subject_id: Map.get(curriculum, :subject_id, nil)
       })
 
+    # lang_versions comes from the batched map (see problems/1 and index/1),
+    # keyed by resource id, to avoid an N+1 query per problem.
+    lang_versions = Map.get(lang_versions_by_res_id, resource.id, [])
+
     # Add problem language data. Top-level meta_data keeps the currently
     # requested language for backward compatibility (see issue #610);
     # lang_versions carries every available language for the new frontend.
@@ -202,7 +221,7 @@ defmodule DbserviceWeb.ResourceJSON do
         meta_data: Map.get(problem_lang, :meta_data, nil),
         lang_id: Map.get(problem_lang, :lang_id, nil),
         paragraph_id: Map.get(problem_lang, :paragraph_id, nil),
-        lang_versions: ProblemLanguages.list_lang_versions_by_resource_id(resource.id)
+        lang_versions: lang_versions
       })
 
     # Fetch concept information

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -165,6 +165,14 @@ defmodule DbserviceWeb.Router do
       :get_problem
     )
 
+    # All-languages variant (no lang_code): returns the problem with every
+    # language in lang_versions so the frontend can filter client-side.
+    get(
+      "/resource/problem/:problem_id/:curriculum_id",
+      ResourceController,
+      :get_problem_all_languages
+    )
+
     resources("/cms-status", CmsStatusController, except: [:new, :edit])
 
     def swagger_info do

--- a/lib/dbservice_web/swagger_schemas/resource.ex
+++ b/lib/dbservice_web/swagger_schemas/resource.ex
@@ -273,6 +273,16 @@ defmodule DbserviceWeb.SwaggerSchema.Resource do
             teacher_id(:integer, "Teacher id associated with the resource")
             meta_data(:map, "Additional meta data for the session")
 
+            lang_versions(
+              Schema.array(:object),
+              "All language versions of the problem, each with a lang_code and meta_data. " <>
+                "Top-level meta_data is kept for backward compatibility and mirrors the requested language.",
+              example: [
+                %{lang_code: "en", meta_data: %{text: "What is 2+2?"}},
+                %{lang_code: "hi", meta_data: %{text: "2+2 क्या है?"}}
+              ]
+            )
+
             paragraph(
               :string,
               "Reading passage when `subtype` is `comprehension`; stored in `paragraph.body` and linked via `problem_lang.paragraph_id`."
@@ -326,6 +336,10 @@ defmodule DbserviceWeb.SwaggerSchema.Resource do
             skill_ids: [1, 3, 7],
             teacher_id: 1,
             meta_data: %{difficulty: "medium"},
+            lang_versions: [
+              %{lang_code: "en", meta_data: %{text: "What is 2+2?"}},
+              %{lang_code: "hi", meta_data: %{text: "2+2 क्या है?"}}
+            ],
             curriculum_id: 1,
             grade_id: 12,
             subject_id: 2,

--- a/test/dbservice/problem_languages_test.exs
+++ b/test/dbservice/problem_languages_test.exs
@@ -1,0 +1,65 @@
+defmodule Dbservice.ProblemLanguagesTest do
+  use Dbservice.DataCase
+
+  alias Dbservice.ProblemLanguages
+  alias Dbservice.Resources
+
+  # Unique codes to avoid colliding with any pre-existing language in the test DB.
+  defp language_fixture(code, name) do
+    {:ok, language} = Dbservice.Languages.create_language(%{"name" => name, "code" => code})
+    language
+  end
+
+  defp problem_fixture do
+    {:ok, resource} = Resources.create_resource(%{"type" => "problem", "type_params" => %{}})
+    resource
+  end
+
+  describe "list_lang_versions_by_resource_id/1" do
+    test "returns one entry per language version with lang_code and meta_data" do
+      en = language_fixture("zle", "LangVersions EN")
+      hi = language_fixture("zlh", "LangVersions HI")
+      problem = problem_fixture()
+
+      {:ok, _} =
+        ProblemLanguages.create_problem_language(%{
+          res_id: problem.id,
+          lang_id: en.id,
+          meta_data: %{"text" => "What is 2+2?"}
+        })
+
+      {:ok, _} =
+        ProblemLanguages.create_problem_language(%{
+          res_id: problem.id,
+          lang_id: hi.id,
+          meta_data: %{"text" => "2+2 क्या है?"}
+        })
+
+      assert [
+               %{lang_code: "zle", meta_data: %{"text" => "What is 2+2?"}},
+               %{lang_code: "zlh", meta_data: %{"text" => "2+2 क्या है?"}}
+             ] = ProblemLanguages.list_lang_versions_by_resource_id(problem.id)
+    end
+
+    test "returns an empty list when the problem has no language versions" do
+      problem = problem_fixture()
+
+      assert ProblemLanguages.list_lang_versions_by_resource_id(problem.id) == []
+    end
+
+    test "does not include language versions of other problems" do
+      en = language_fixture("zlx", "LangVersions Other")
+      problem = problem_fixture()
+      other_problem = problem_fixture()
+
+      {:ok, _} =
+        ProblemLanguages.create_problem_language(%{
+          res_id: other_problem.id,
+          lang_id: en.id,
+          meta_data: %{"text" => "other"}
+        })
+
+      assert ProblemLanguages.list_lang_versions_by_resource_id(problem.id) == []
+    end
+  end
+end

--- a/test/dbservice/problem_languages_test.exs
+++ b/test/dbservice/problem_languages_test.exs
@@ -62,4 +62,56 @@ defmodule Dbservice.ProblemLanguagesTest do
       assert ProblemLanguages.list_lang_versions_by_resource_id(problem.id) == []
     end
   end
+
+  describe "list_lang_versions_by_resource_ids/1" do
+    test "returns an empty map for an empty list of ids" do
+      assert ProblemLanguages.list_lang_versions_by_resource_ids([]) == %{}
+    end
+
+    test "groups lang_versions by resource id in a single lookup" do
+      en = language_fixture("zbe", "Batch EN")
+      hi = language_fixture("zbh", "Batch HI")
+      problem_one = problem_fixture()
+      problem_two = problem_fixture()
+
+      {:ok, _} =
+        ProblemLanguages.create_problem_language(%{
+          res_id: problem_one.id,
+          lang_id: en.id,
+          meta_data: %{"text" => "one-en"}
+        })
+
+      {:ok, _} =
+        ProblemLanguages.create_problem_language(%{
+          res_id: problem_one.id,
+          lang_id: hi.id,
+          meta_data: %{"text" => "one-hi"}
+        })
+
+      {:ok, _} =
+        ProblemLanguages.create_problem_language(%{
+          res_id: problem_two.id,
+          lang_id: en.id,
+          meta_data: %{"text" => "two-en"}
+        })
+
+      result =
+        ProblemLanguages.list_lang_versions_by_resource_ids([problem_one.id, problem_two.id])
+
+      assert result[problem_one.id] == [
+               %{lang_code: "zbe", meta_data: %{"text" => "one-en"}},
+               %{lang_code: "zbh", meta_data: %{"text" => "one-hi"}}
+             ]
+
+      assert result[problem_two.id] == [
+               %{lang_code: "zbe", meta_data: %{"text" => "two-en"}}
+             ]
+    end
+
+    test "omits ids that have no language versions" do
+      problem = problem_fixture()
+
+      assert ProblemLanguages.list_lang_versions_by_resource_ids([problem.id]) == %{}
+    end
+  end
 end

--- a/test/dbservice_web/controllers/problem_all_languages_test.exs
+++ b/test/dbservice_web/controllers/problem_all_languages_test.exs
@@ -1,0 +1,227 @@
+defmodule DbserviceWeb.ProblemAllLanguagesTest do
+  @moduledoc """
+  Covers the lang_code-free (all-languages) variants of the problem GET
+  endpoints. Each returns every problem once with all languages in
+  `lang_versions`, so the frontend can filter client-side (see #612 review).
+  """
+  use DbserviceWeb.ConnCase
+
+  alias Dbservice.Curriculums
+  alias Dbservice.Languages
+  alias Dbservice.ProblemLanguages
+  alias Dbservice.ResourceCurriculums
+  alias Dbservice.ResourceTopics
+  alias Dbservice.Resources
+  alias Dbservice.Topics
+
+  defp language_fixture(code, name) do
+    {:ok, language} = Languages.create_language(%{"name" => name, "code" => code})
+    language
+  end
+
+  defp problem_fixture do
+    {:ok, resource} = Resources.create_resource(%{"type" => "problem", "type_params" => %{}})
+    resource
+  end
+
+  defp test_fixture(problem_ids) do
+    type_params = %{
+      "subjects" => [
+        %{
+          "sections" => [
+            %{"compulsory" => %{"problems" => Enum.map(problem_ids, &%{"id" => &1})}}
+          ]
+        }
+      ]
+    }
+
+    {:ok, resource} = Resources.create_resource(%{"type" => "test", "type_params" => type_params})
+    resource
+  end
+
+  defp problem_language_fixture(resource, language, meta_data) do
+    {:ok, problem_lang} =
+      ProblemLanguages.create_problem_language(%{
+        res_id: resource.id,
+        lang_id: language.id,
+        meta_data: meta_data
+      })
+
+    problem_lang
+  end
+
+  defp curriculum_fixture do
+    {:ok, curriculum} = Curriculums.create_curriculum(%{"name" => "Curriculum", "code" => "CURR"})
+    curriculum
+  end
+
+  defp topic_fixture do
+    {:ok, topic} = Topics.create_topic(%{"code" => "TOP-#{System.unique_integer([:positive])}"})
+    topic
+  end
+
+  defp resource_curriculum_fixture(resource, curriculum) do
+    {:ok, rc} =
+      ResourceCurriculums.create_resource_curriculum(%{
+        resource_id: resource.id,
+        curriculum_id: curriculum.id,
+        difficulty_level: "medium"
+      })
+
+    rc
+  end
+
+  defp resource_topic_fixture(resource, topic) do
+    {:ok, rt} =
+      ResourceTopics.create_resource_topic(%{resource_id: resource.id, topic_id: topic.id})
+
+    rt
+  end
+
+  describe "GET /api/resource/problem/:problem_id/:curriculum_id" do
+    test "returns the problem with all languages and no single-language fields", %{conn: conn} do
+      en = language_fixture("aae", "AA EN")
+      hi = language_fixture("aah", "AA HI")
+      curriculum = curriculum_fixture()
+      problem = problem_fixture()
+      resource_curriculum_fixture(problem, curriculum)
+
+      en_meta = %{"text" => "What is 2+2?"}
+      hi_meta = %{"text" => "2+2 क्या है?"}
+      problem_language_fixture(problem, en, en_meta)
+      problem_language_fixture(problem, hi, hi_meta)
+
+      conn = get(conn, ~p"/api/resource/problem/#{problem.id}/#{curriculum.id}")
+      body = json_response(conn, 200)
+
+      assert body["id"] == problem.id
+      # No single language requested, so the flat fields are empty...
+      assert body["meta_data"] == nil
+      assert body["lang_code"] == nil
+      # ...and every language is carried in lang_versions.
+      assert body["lang_versions"] == [
+               %{"lang_code" => "aae", "meta_data" => en_meta},
+               %{"lang_code" => "aah", "meta_data" => hi_meta}
+             ]
+    end
+
+    test "404 when the curriculum is not linked to the problem", %{conn: conn} do
+      problem = problem_fixture()
+      other_curriculum = curriculum_fixture()
+
+      conn = get(conn, ~p"/api/resource/problem/#{problem.id}/#{other_curriculum.id}")
+      assert json_response(conn, 404)
+    end
+  end
+
+  describe "GET /api/resource/test/:id/problems (no lang_code)" do
+    test "returns each test problem once with all languages", %{conn: conn} do
+      en = language_fixture("abe", "AB EN")
+      hi = language_fixture("abh", "AB HI")
+      curriculum = curriculum_fixture()
+      problem = problem_fixture()
+      resource_curriculum_fixture(problem, curriculum)
+
+      en_meta = %{"text" => "test EN"}
+      hi_meta = %{"text" => "test HI"}
+      problem_language_fixture(problem, en, en_meta)
+      problem_language_fixture(problem, hi, hi_meta)
+
+      test = test_fixture([problem.id])
+
+      conn = get(conn, ~p"/api/resource/test/#{test.id}/problems?curriculum_id=#{curriculum.id}")
+      body = json_response(conn, 200)
+
+      assert [entry] = body
+      assert entry["id"] == problem.id
+
+      assert entry["lang_versions"] == [
+               %{"lang_code" => "abe", "meta_data" => en_meta},
+               %{"lang_code" => "abh", "meta_data" => hi_meta}
+             ]
+    end
+  end
+
+  describe "GET /api/problems (no lang_code)" do
+    test "returns each problem once (deduped) with all languages", %{conn: conn} do
+      en = language_fixture("ace", "AC EN")
+      hi = language_fixture("ach", "AC HI")
+      curriculum = curriculum_fixture()
+      topic = topic_fixture()
+      problem = problem_fixture()
+      resource_curriculum_fixture(problem, curriculum)
+      resource_topic_fixture(problem, topic)
+
+      en_meta = %{"text" => "topic EN"}
+      hi_meta = %{"text" => "topic HI"}
+      problem_language_fixture(problem, en, en_meta)
+      problem_language_fixture(problem, hi, hi_meta)
+
+      conn = get(conn, ~p"/api/problems?topic_id=#{topic.id}&curriculum_id=#{curriculum.id}")
+      body = json_response(conn, 200)
+
+      # Two languages, but the problem appears exactly once.
+      assert [entry] = body
+      assert entry["id"] == problem.id
+
+      assert entry["lang_versions"] == [
+               %{"lang_code" => "ace", "meta_data" => en_meta},
+               %{"lang_code" => "ach", "meta_data" => hi_meta}
+             ]
+    end
+
+    test "still filters to a single language when lang_code is given", %{conn: conn} do
+      en = language_fixture("ade", "AD EN")
+      hi = language_fixture("adh", "AD HI")
+      curriculum = curriculum_fixture()
+      topic = topic_fixture()
+      problem = problem_fixture()
+      resource_curriculum_fixture(problem, curriculum)
+      resource_topic_fixture(problem, topic)
+
+      en_meta = %{"text" => "single EN"}
+      problem_language_fixture(problem, en, en_meta)
+      problem_language_fixture(problem, hi, %{"text" => "single HI"})
+
+      conn =
+        get(
+          conn,
+          ~p"/api/problems?topic_id=#{topic.id}&curriculum_id=#{curriculum.id}&lang_code=ade"
+        )
+
+      body = json_response(conn, 200)
+      assert [entry] = body
+      # Backward-compatible: flat meta_data is the requested language.
+      assert entry["meta_data"] == en_meta
+    end
+  end
+
+  describe "GET /api/problems/search (no lang_code)" do
+    test "dedupes a problem that matches in multiple languages", %{conn: conn} do
+      en = language_fixture("aee", "AE EN")
+      hi = language_fixture("aeh", "AE HI")
+      curriculum = curriculum_fixture()
+      problem = problem_fixture()
+      resource_curriculum_fixture(problem, curriculum)
+
+      # Same unique term in both languages -> two problem_lang rows match.
+      term = "zzsearchtoken"
+      en_meta = %{"text" => "english #{term}"}
+      hi_meta = %{"text" => "hindi #{term}"}
+      problem_language_fixture(problem, en, en_meta)
+      problem_language_fixture(problem, hi, hi_meta)
+
+      conn = get(conn, ~p"/api/problems/search?search=#{term}")
+      body = json_response(conn, 200)
+
+      assert [entry] = body
+      assert entry["id"] == problem.id
+      assert get_resp_header(conn, "x-total-count") == ["1"]
+
+      assert entry["lang_versions"] == [
+               %{"lang_code" => "aee", "meta_data" => en_meta},
+               %{"lang_code" => "aeh", "meta_data" => hi_meta}
+             ]
+    end
+  end
+end

--- a/test/dbservice_web/json/resource_json_test.exs
+++ b/test/dbservice_web/json/resource_json_test.exs
@@ -1,0 +1,97 @@
+defmodule DbserviceWeb.ResourceJSONTest do
+  use Dbservice.DataCase
+
+  alias Dbservice.ProblemLanguages
+  alias Dbservice.Resources
+  alias DbserviceWeb.ResourceJSON
+
+  defp language_fixture(code, name) do
+    {:ok, language} = Dbservice.Languages.create_language(%{"name" => name, "code" => code})
+    language
+  end
+
+  defp problem_fixture do
+    {:ok, resource} = Resources.create_resource(%{"type" => "problem", "type_params" => %{}})
+    resource
+  end
+
+  defp problem_language_fixture(resource, language, meta_data) do
+    {:ok, problem_lang} =
+      ProblemLanguages.create_problem_language(%{
+        res_id: resource.id,
+        lang_id: language.id,
+        meta_data: meta_data
+      })
+
+    problem_lang
+  end
+
+  describe "problems/1" do
+    test "renders top-level meta_data for the requested language plus all lang_versions" do
+      en = language_fixture("zje", "JSON EN")
+      hi = language_fixture("zjh", "JSON HI")
+      problem = problem_fixture()
+
+      en_meta = %{"text" => "What is 2+2?"}
+      hi_meta = %{"text" => "2+2 क्या है?"}
+      en_problem_lang = problem_language_fixture(problem, en, en_meta)
+      problem_language_fixture(problem, hi, hi_meta)
+
+      [rendered] =
+        ResourceJSON.problems(%{
+          problems: [
+            %{
+              resource: problem,
+              resource_topic: %{},
+              resource_curriculums: [],
+              requested_curriculum_id: nil,
+              problem_lang: en_problem_lang
+            }
+          ]
+        })
+
+      # Old shape stays intact for the currently deployed frontend
+      assert rendered.meta_data == en_meta
+
+      # New shape carries every available language
+      assert rendered.lang_versions == [
+               %{lang_code: "zje", meta_data: en_meta},
+               %{lang_code: "zjh", meta_data: hi_meta}
+             ]
+    end
+  end
+
+  describe "problem_lang/1" do
+    test "renders top-level meta_data for the requested language plus all lang_versions" do
+      en = language_fixture("zke", "JSON Lang EN")
+      hi = language_fixture("zkh", "JSON Lang HI")
+      problem = problem_fixture()
+
+      en_meta = %{"text" => "What is 2+2?"}
+      hi_meta = %{"text" => "2+2 क्या है?"}
+      problem_language_fixture(problem, en, en_meta)
+      problem_language_fixture(problem, hi, hi_meta)
+
+      rendered =
+        ResourceJSON.problem_lang(%{
+          resource: problem,
+          meta_data: en_meta,
+          lang_code: "zke",
+          resource_curriculum: %{
+            curriculum_id: 1,
+            grade_id: 1,
+            subject_id: 1,
+            difficulty_level: "medium"
+          }
+        })
+
+      assert rendered.meta_data == en_meta
+      assert rendered.lang_code == "zke"
+
+      assert rendered.lang_versions == [
+               %{lang_code: "zke", meta_data: en_meta},
+               %{lang_code: "zkh", meta_data: hi_meta}
+             ]
+    end
+  end
+end


### PR DESCRIPTION
Closes #610

## What

Standardizes the problem response format across all problem GET APIs to include a `lang_versions` array — one `{lang_code, meta_data}` entry per `problem_lang` row of the resource:

- `GET /api/resource/problem/{problem_id}/{lang_code}/{curriculum_id}`
- `GET /api/resource/test/{id}/problems`
- `GET /api/problems`
- `GET /api/problems/search`

## Backward compatibility

Both shapes are returned together during the transition (same pattern as the POST side in #602):

- Top-level `meta_data` (and `lang_code` where present) is unchanged and still reflects the requested language — the currently deployed frontend keeps working.
- `lang_versions` carries every available language for the new frontend.
- Once the new frontend is deployed, top-level `meta_data` can be removed in a follow-up cleanup.

Remaining response fields are untouched.

## How

- New `ProblemLanguages.list_lang_versions_by_resource_id/1` builds the array from `problem_lang` joined with `language`, ordered by insertion.
- `ResourceJSON.render_problem/1` (serves `/problems`, `/problems/search`, `/resource/test/:id/problems`) and `ResourceJSON.problem_lang/1` (serves `/resource/problem/...`, and the PATCH problem response) now include `lang_versions`.
- Swagger `ProblemResource` schema documents the new field.

## Testing

- New tests for the context function and both JSON render paths (`mix test` green; `mix format --check-formatted` and `mix credo` clean).
- Verified live against the dev server on all four endpoints with a problem having `en` + `hi` rows, e.g. `GET /api/resource/problem/503/en/1` returned the old flat `meta_data` (en) plus `lang_versions: [{en, ...}, {hi, ...}]`; single-language problems return a one-entry array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)