### PR TITLE
feat(api): accept lang_versions in problem create endpoints (POST /resource + batch)

### DIFF
--- a/lib/dbservice_web/controllers/resource_controller.ex
+++ b/lib/dbservice_web/controllers/resource_controller.ex
@@ -546,6 +546,11 @@ defmodule DbserviceWeb.ResourceController do
         conn
         |> put_status(:unprocessable_entity)
         |> json(%{error: reason})
+
+      {:error, {:language_error, reason}} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: reason})
     end
   end
 
@@ -647,6 +652,10 @@ defmodule DbserviceWeb.ResourceController do
     %{error: reason}
   end
 
+  defp format_batch_transaction_error({:language_error, reason}) do
+    %{error: reason}
+  end
+
   defp format_batch_transaction_error(other) do
     %{error: inspect(other)}
   end
@@ -679,26 +688,72 @@ defmodule DbserviceWeb.ResourceController do
     end
   end
 
+  # New multi-language path (issues #602/#603): one problem_lang row per
+  # lang_versions entry. Takes precedence over the flat lang_code/meta_data
+  # format when both are present.
+  defp insert_problem_language(resource, %{"lang_versions" => [_ | _] = lang_versions} = params) do
+    params = resolve_shared_paragraph_for_lang_versions(resource, params)
+
+    Enum.each(lang_versions, fn version ->
+      lang_code = version["lang_code"]
+
+      case lang_code && Repo.get_by(Language, code: lang_code) do
+        %Language{} = language ->
+          version_params = Map.put(params, "meta_data", version["meta_data"])
+          do_insert_problem_language(resource, version_params, language.id)
+
+        _ ->
+          Repo.rollback({:language_error, "Language with code '#{lang_code}' not found"})
+      end
+    end)
+  end
+
+  # Old single-language path — kept for backward compatibility until the new
+  # frontend (which sends lang_versions) is deployed.
   defp insert_problem_language(resource, %{"lang_code" => lang_code} = params)
        when not is_nil(lang_code) do
     if language = Repo.get_by(Language, code: lang_code) do
-      case Paragraphs.problem_language_insert_attrs(resource, params, language.id) do
-        {:ok, attrs} ->
-          case Dbservice.ProblemLanguages.create_problem_language(attrs) do
-            {:ok, _} -> :ok
-            {:error, cs} -> Repo.rollback({:changeset_error, cs})
-          end
-
-        {:error, %Ecto.Changeset{} = cs} ->
-          Repo.rollback({:changeset_error, cs})
-
-        {:error, {:missing_paragraph_body, msg}} ->
-          Repo.rollback({:comprehension_error, msg})
-      end
+      do_insert_problem_language(resource, params, language.id)
     end
   end
 
   defp insert_problem_language(_, _), do: :ok
+
+  defp do_insert_problem_language(resource, params, lang_id) do
+    case Paragraphs.problem_language_insert_attrs(resource, params, lang_id) do
+      {:ok, attrs} ->
+        case Dbservice.ProblemLanguages.create_problem_language(attrs) do
+          {:ok, _} -> :ok
+          {:error, cs} -> Repo.rollback({:changeset_error, cs})
+        end
+
+      {:error, %Ecto.Changeset{} = cs} ->
+        Repo.rollback({:changeset_error, cs})
+
+      {:error, {:missing_paragraph_body, msg}} ->
+        Repo.rollback({:comprehension_error, msg})
+    end
+  end
+
+  # For comprehension problems with multiple language versions, the paragraph
+  # body must become ONE shared paragraph row referenced by every problem_lang
+  # row — creating it inside the per-version insert would duplicate it per language.
+  defp resolve_shared_paragraph_for_lang_versions(resource, params) do
+    body = Paragraphs.paragraph_body_for_comprehension(params)
+
+    if is_binary(body) and Paragraphs.comprehension_problem?(resource, params) and
+         not is_integer(params["paragraph_id"]) do
+      case Paragraphs.create_paragraph(%{"body" => body}) do
+        {:ok, paragraph} ->
+          params |> Map.drop(["paragraph"]) |> Map.put("paragraph_id", paragraph.id)
+
+        {:error, cs} ->
+          Repo.rollback({:changeset_error, cs})
+      end
+    else
+      params
+    end
+  end
 
   defp insert_resource_chapter(resource, %{"chapter_id" => chapter_id})
        when not is_nil(chapter_id) do

--- a/lib/dbservice_web/json/resource_json.ex
+++ b/lib/dbservice_web/json/resource_json.ex
@@ -111,8 +111,22 @@ defmodule DbserviceWeb.ResourceJSON do
       end
 
     # Add meta_data if it exists
-    if Map.has_key?(resource, :meta_data) do
-      Map.put(base_map, :meta_data, resource.meta_data)
+    base_map =
+      if Map.has_key?(resource, :meta_data) do
+        Map.put(base_map, :meta_data, resource.meta_data)
+      else
+        base_map
+      end
+
+    # Problems always expose their language versions (create/show responses),
+    # so the frontend gets lang_versions back on a successful create. Other
+    # resource types don't have this concept.
+    if resource.type == "problem" do
+      Map.put(
+        base_map,
+        :lang_versions,
+        ProblemLanguages.list_lang_versions_by_resource_id(resource.id)
+      )
     else
       base_map
     end
@@ -263,11 +277,10 @@ defmodule DbserviceWeb.ResourceJSON do
     # the curriculum_grades list is redundant here.
     |> Map.delete(:curriculum_grades)
     # Top-level meta_data/lang_code keep the requested language for backward
-    # compatibility (see issue #610); lang_versions carries every available
-    # language for the new frontend.
+    # compatibility (see issue #610); lang_versions (added by render/1 for
+    # problems) carries every available language for the new frontend.
     |> Map.put(:meta_data, meta_data)
     |> Map.put(:lang_code, lang_code)
-    |> Map.put(:lang_versions, ProblemLanguages.list_lang_versions_by_resource_id(resource.id))
     |> Map.merge(%{
       curriculum_id: rc.curriculum_id,
       grade_id: rc.grade_id,

--- a/lib/dbservice_web/swagger_schemas/resource.ex
+++ b/lib/dbservice_web/swagger_schemas/resource.ex
@@ -40,6 +40,18 @@ defmodule DbserviceWeb.SwaggerSchema.Resource do
               :string,
               "Reading passage for comprehension problems (PATCH only). Upserts the shared paragraph linked to every `problem_lang` row of this resource via `paragraph_id`; ignored for non-comprehension subtypes."
             )
+
+            lang_versions(
+              Schema.array(:object),
+              "Problem content per language, each entry with a lang_code and meta_data — " <>
+                "inserts one problem_lang row per entry (problems only). Takes precedence over " <>
+                "the deprecated flat lang_code + meta_data pair, which is still accepted for " <>
+                "backward compatibility.",
+              example: [
+                %{lang_code: "en", meta_data: %{text: "What is 2+2?"}},
+                %{lang_code: "hi", meta_data: %{text: "2+2 क्या है?"}}
+              ]
+            )
           end
 
           example(%{
@@ -466,9 +478,13 @@ defmodule DbserviceWeb.SwaggerSchema.Resource do
             problems: [
               %{
                 subtype: "comprehension",
-                lang_code: "en",
                 name: [%{lang_code: "en", resource: "Q1"}],
-                meta_data: %{text: "q1", answer: ["2"], options: ["o1", "o2"]}
+                lang_versions: [
+                  %{
+                    lang_code: "en",
+                    meta_data: %{text: "q1", answer: ["2"], options: ["o1", "o2"]}
+                  }
+                ]
               },
               %{
                 subtype: "comprehension",

--- a/test/dbservice_web/controllers/resource_controller_test.exs
+++ b/test/dbservice_web/controllers/resource_controller_test.exs
@@ -1,0 +1,200 @@
+defmodule DbserviceWeb.ResourceControllerTest do
+  use DbserviceWeb.ConnCase
+
+  import Ecto.Query
+
+  alias Dbservice.Repo
+  alias Dbservice.Resources.ProblemLanguage
+  alias Dbservice.Resources.Resource
+
+  # Unique codes to avoid colliding with any pre-existing language in the test DB.
+  defp language_fixture(code, name) do
+    {:ok, language} = Dbservice.Languages.create_language(%{"name" => name, "code" => code})
+    language
+  end
+
+  defp problem_lang_rows(resource_id) do
+    from(pl in ProblemLanguage, where: pl.res_id == ^resource_id, order_by: [asc: pl.id])
+    |> Repo.all()
+  end
+
+  describe "POST /api/resource with lang_versions" do
+    test "creates one problem_lang row per lang_versions entry", %{conn: conn} do
+      en = language_fixture("rce", "Resource Create EN")
+      hi = language_fixture("rch", "Resource Create HI")
+
+      conn =
+        post(conn, ~p"/api/resource", %{
+          "type" => "problem",
+          "subtype" => "mcq_single_answer",
+          "type_params" => %{},
+          "lang_versions" => [
+            %{"lang_code" => "rce", "meta_data" => %{"text" => "What is 2+2?"}},
+            %{"lang_code" => "rch", "meta_data" => %{"text" => "2+2 क्या है?"}}
+          ]
+        })
+
+      assert %{"id" => id} = json_response(conn, 201)
+
+      assert [first, second] = problem_lang_rows(id)
+      assert first.lang_id == en.id
+      assert first.meta_data == %{"text" => "What is 2+2?"}
+      assert second.lang_id == hi.id
+      assert second.meta_data == %{"text" => "2+2 क्या है?"}
+    end
+
+    test "old flat lang_code + meta_data format keeps working", %{conn: conn} do
+      en = language_fixture("rco", "Resource Create Old")
+
+      conn =
+        post(conn, ~p"/api/resource", %{
+          "type" => "problem",
+          "subtype" => "mcq_single_answer",
+          "type_params" => %{},
+          "lang_code" => "rco",
+          "meta_data" => %{"text" => "Old format"}
+        })
+
+      assert %{"id" => id} = json_response(conn, 201)
+
+      assert [row] = problem_lang_rows(id)
+      assert row.lang_id == en.id
+      assert row.meta_data == %{"text" => "Old format"}
+    end
+
+    test "lang_versions takes precedence over flat lang_code + meta_data", %{conn: conn} do
+      language_fixture("rcp", "Resource Create Precedence")
+
+      conn =
+        post(conn, ~p"/api/resource", %{
+          "type" => "problem",
+          "subtype" => "mcq_single_answer",
+          "type_params" => %{},
+          "lang_code" => "rcp",
+          "meta_data" => %{"text" => "flat"},
+          "lang_versions" => [
+            %{"lang_code" => "rcp", "meta_data" => %{"text" => "from lang_versions"}}
+          ]
+        })
+
+      assert %{"id" => id} = json_response(conn, 201)
+
+      assert [row] = problem_lang_rows(id)
+      assert row.meta_data == %{"text" => "from lang_versions"}
+    end
+
+    test "rejects an unknown lang_code and rolls back the whole resource", %{conn: conn} do
+      language_fixture("rcu", "Resource Create Unknown")
+      before_count = Repo.aggregate(Resource, :count)
+
+      conn =
+        post(conn, ~p"/api/resource", %{
+          "type" => "problem",
+          "subtype" => "mcq_single_answer",
+          "type_params" => %{},
+          "lang_versions" => [
+            %{"lang_code" => "rcu", "meta_data" => %{"text" => "ok"}},
+            %{"lang_code" => "nope", "meta_data" => %{"text" => "bad"}}
+          ]
+        })
+
+      assert %{"error" => error} = json_response(conn, 422)
+      assert error =~ "nope"
+      assert Repo.aggregate(Resource, :count) == before_count
+    end
+
+    test "comprehension problem with lang_versions shares one paragraph across languages",
+         %{conn: conn} do
+      language_fixture("rcf", "Resource Comprehension EN")
+      language_fixture("rcg", "Resource Comprehension HI")
+
+      conn =
+        post(conn, ~p"/api/resource", %{
+          "type" => "problem",
+          "subtype" => "comprehension",
+          "type_params" => %{},
+          "paragraph" => "Read the following passage...",
+          "lang_versions" => [
+            %{"lang_code" => "rcf", "meta_data" => %{"text" => "Q en"}},
+            %{"lang_code" => "rcg", "meta_data" => %{"text" => "Q hi"}}
+          ]
+        })
+
+      assert %{"id" => id} = json_response(conn, 201)
+
+      assert [first, second] = problem_lang_rows(id)
+      assert is_integer(first.paragraph_id)
+      assert first.paragraph_id == second.paragraph_id
+    end
+  end
+
+  describe "POST /api/resources/problems/batch with lang_versions" do
+    test "creates comprehension problems from lang_versions sharing the batch paragraph",
+         %{conn: conn} do
+      language_fixture("rcb", "Resource Batch EN")
+
+      conn =
+        post(conn, ~p"/api/resources/problems/batch", %{
+          "paragraph" => "Shared passage for the comprehension set.",
+          "problems" => [
+            %{
+              "subtype" => "comprehension",
+              "type_params" => %{},
+              "lang_versions" => [
+                %{"lang_code" => "rcb", "meta_data" => %{"text" => "Q1"}}
+              ]
+            },
+            %{
+              "subtype" => "comprehension",
+              "type_params" => %{},
+              "lang_versions" => [
+                %{"lang_code" => "rcb", "meta_data" => %{"text" => "Q2"}}
+              ]
+            }
+          ]
+        })
+
+      assert %{"created" => [c1, c2], "failed" => []} = json_response(conn, 200)
+
+      [row1] = problem_lang_rows(c1["id"])
+      [row2] = problem_lang_rows(c2["id"])
+      assert row1.meta_data == %{"text" => "Q1"}
+      assert row2.meta_data == %{"text" => "Q2"}
+      # Both problems link to the single paragraph created for the batch
+      assert row1.paragraph_id == row2.paragraph_id
+      assert is_integer(row1.paragraph_id)
+    end
+
+    test "old flat format entries keep working and unknown languages fail per index",
+         %{conn: conn} do
+      language_fixture("rcz", "Resource Batch Old")
+
+      conn =
+        post(conn, ~p"/api/resources/problems/batch", %{
+          "paragraph" => "Shared passage.",
+          "problems" => [
+            %{
+              "subtype" => "comprehension",
+              "type_params" => %{},
+              "lang_code" => "rcz",
+              "meta_data" => %{"text" => "Old Q"}
+            },
+            %{
+              "subtype" => "comprehension",
+              "type_params" => %{},
+              "lang_versions" => [
+                %{"lang_code" => "nope", "meta_data" => %{"text" => "bad"}}
+              ]
+            }
+          ]
+        })
+
+      assert %{"created" => [c1], "failed" => [failure]} = json_response(conn, 200)
+
+      [row1] = problem_lang_rows(c1["id"])
+      assert row1.meta_data == %{"text" => "Old Q"}
+      assert failure["index"] == 1
+      assert failure["error"] =~ "nope"
+    end
+  end
+end

--- a/test/dbservice_web/controllers/resource_controller_test.exs
+++ b/test/dbservice_web/controllers/resource_controller_test.exs
@@ -34,7 +34,13 @@ defmodule DbserviceWeb.ResourceControllerTest do
           ]
         })
 
-      assert %{"id" => id} = json_response(conn, 201)
+      assert %{"id" => id, "lang_versions" => lang_versions} = json_response(conn, 201)
+
+      # The create response echoes back every language version that was stored.
+      assert lang_versions == [
+               %{"lang_code" => "rce", "meta_data" => %{"text" => "What is 2+2?"}},
+               %{"lang_code" => "rch", "meta_data" => %{"text" => "2+2 क्या है?"}}
+             ]
 
       assert [first, second] = problem_lang_rows(id)
       assert first.lang_id == en.id
@@ -155,6 +161,10 @@ defmodule DbserviceWeb.ResourceControllerTest do
         })
 
       assert %{"created" => [c1, c2], "failed" => []} = json_response(conn, 200)
+
+      # Each created problem echoes back its stored language versions.
+      assert c1["lang_versions"] == [%{"lang_code" => "rcb", "meta_data" => %{"text" => "Q1"}}]
+      assert c2["lang_versions"] == [%{"lang_code" => "rcb", "meta_data" => %{"text" => "Q2"}}]
 
       [row1] = problem_lang_rows(c1["id"])
       [row2] = problem_lang_rows(c2["id"])

--- a/test/dbservice_web/json/resource_json_test.exs
+++ b/test/dbservice_web/json/resource_json_test.exs
@@ -61,6 +61,35 @@ defmodule DbserviceWeb.ResourceJSONTest do
     end
   end
 
+  describe "show/1" do
+    test "includes lang_versions for a problem (create/show response)" do
+      en = language_fixture("zse", "JSON Show EN")
+      hi = language_fixture("zsh", "JSON Show HI")
+      problem = problem_fixture()
+
+      en_meta = %{"text" => "What is 2+2?"}
+      hi_meta = %{"text" => "2+2 क्या है?"}
+      problem_language_fixture(problem, en, en_meta)
+      problem_language_fixture(problem, hi, hi_meta)
+
+      rendered = ResourceJSON.show(%{resource: problem})
+
+      assert rendered.lang_versions == [
+               %{lang_code: "zse", meta_data: en_meta},
+               %{lang_code: "zsh", meta_data: hi_meta}
+             ]
+    end
+
+    test "omits lang_versions for a non-problem resource" do
+      {:ok, resource} =
+        Resources.create_resource(%{"type" => "video", "type_params" => %{}})
+
+      rendered = ResourceJSON.show(%{resource: resource})
+
+      refute Map.has_key?(rendered, :lang_versions)
+    end
+  end
+
   describe "problem_lang/1" do
     test "renders top-level meta_data for the requested language plus all lang_versions" do
       en = language_fixture("zke", "JSON Lang EN")


### PR DESCRIPTION
Closes #602
Closes #603

## What

Both problem-create endpoints now accept the new multi-language format:

- `POST /api/resource` (single problem — #602)
- `POST /api/resources/problems/batch` (comprehension batch, the endpoint behind the frontend's create-problems flow — #603)

When `lang_versions` is present and non-empty, one `problem_lang` row is inserted per entry (`lang_code` resolved to `lang_id`, `meta_data` stored per language). Both endpoints share the same insertion path (`insert_problem_language`), so the batch endpoint gets the behavior from the same code.

## Backward compatibility

- If `lang_versions` is absent/null, the existing flat `lang_code` + `meta_data` path runs unchanged — the currently deployed frontend keeps working.
- If both are present, `lang_versions` wins.
- The fallback can be removed in a follow-up once the new frontend is deployed.

## Details

- **Comprehension + multiple languages**: the `paragraph` body is created **once** and its id shared by every `problem_lang` row of the problem (previously the per-language insert would have created a duplicate paragraph per language). The batch endpoint's shared top-level `paragraph` continues to work — the injected `paragraph_id` is reused by all lang_versions rows.
- **Unknown `lang_code`** inside `lang_versions` rolls back the whole resource create and returns 422 with a clear error (per-index failure in the batch endpoint, other entries still succeed). The old flat path keeps its existing silently-skip behavior untouched.
- Swagger: `Resource` request schema documents `lang_versions`; batch request example shows both formats.

## Testing

- 7 new controller (ConnCase) tests covering: multi-language create, old-format fallback, precedence, unknown-language rollback, comprehension paragraph sharing across languages, batch create with lang_versions + shared paragraph, and batch mixed old/new with per-index failure.
- `mix test`, `mix format --check-formatted`, `mix credo` all green.

## Related

- GET-side counterpart (response `lang_versions`): #612 (issue #610)
- PATCH-side counterpart (#611) coming as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)