### PR TITLE
feat(api): sync problem_lang rows from lang_versions in PATCH /resource

### DIFF
--- a/lib/dbservice/resources.ex
+++ b/lib/dbservice/resources.ex
@@ -937,6 +937,10 @@ defmodule Dbservice.Resources do
 
   defp update_problem_language(resource, params) do
     cond do
+      has_lang_versions?(params) ->
+        params = pre_sync_shared_paragraph(resource, params)
+        sync_problem_lang_versions(resource, params)
+
       has_lang_code?(params) ->
         params = pre_sync_shared_paragraph(resource, params)
         update_problem_language_for_lang(resource, params)
@@ -949,6 +953,91 @@ defmodule Dbservice.Resources do
         :ok
     end
   end
+
+  # New multi-language path (issue #611): syncs problem_lang rows to exactly
+  # the languages present in lang_versions — upserts one row per entry and
+  # deletes rows whose language is absent from the request. Takes precedence
+  # over the flat lang_code/meta_data format, which remains as a backward
+  # compatibility fallback until the new frontend is deployed.
+  defp sync_problem_lang_versions(resource, %{"lang_versions" => versions} = params) do
+    existing = Repo.all(from(pl in ProblemLanguage, where: pl.res_id == ^resource.id))
+    existing_by_lang_id = Map.new(existing, &{&1.lang_id, &1})
+
+    # New rows of a comprehension problem must join the problem's shared paragraph.
+    shared_paragraph_id = params["paragraph_id"] || Enum.find_value(existing, & &1.paragraph_id)
+
+    base_params = Map.drop(params, ["lang_versions", "lang_code", "meta_data"])
+
+    kept_lang_ids =
+      versions
+      |> Enum.map(
+        &upsert_problem_lang_version(
+          resource,
+          base_params,
+          shared_paragraph_id,
+          existing_by_lang_id,
+          &1
+        )
+      )
+      |> Enum.reject(&is_nil/1)
+      |> MapSet.new()
+
+    existing
+    |> Enum.reject(&MapSet.member?(kept_lang_ids, &1.lang_id))
+    |> Enum.each(&Dbservice.ProblemLanguages.delete_problem_language/1)
+  end
+
+  # Upserts the problem_lang row for one lang_versions entry and returns its
+  # lang_id, or nil when the lang_code doesn't resolve to a language (skipped,
+  # matching the flat lang_code path which no-ops on unknown languages).
+  defp upsert_problem_lang_version(
+         resource,
+         base_params,
+         shared_paragraph_id,
+         existing_by_lang_id,
+         version
+       ) do
+    lang_code = version["lang_code"]
+    lang = is_binary(lang_code) && Dbservice.Languages.get_language_by_code(lang_code)
+
+    case lang do
+      %Language{id: lang_id} ->
+        version_params = Map.put(base_params, "meta_data", version["meta_data"])
+
+        case Map.get(existing_by_lang_id, lang_id) do
+          nil ->
+            insert_problem_lang_version(resource, version_params, shared_paragraph_id, lang_id)
+
+          pl ->
+            do_update_problem_language(resource, version_params, pl)
+        end
+
+        lang_id
+
+      _ ->
+        nil
+    end
+  end
+
+  defp insert_problem_lang_version(resource, version_params, shared_paragraph_id, lang_id) do
+    version_params =
+      if shared_paragraph_id,
+        do: Map.put_new(version_params, "paragraph_id", shared_paragraph_id),
+        else: version_params
+
+    case Paragraphs.problem_language_insert_attrs(resource, version_params, lang_id) do
+      {:ok, attrs} ->
+        Dbservice.ProblemLanguages.create_problem_language(attrs)
+
+      # Comprehension language with no resolvable paragraph: skip the insert,
+      # consistent with how the other association updates swallow errors.
+      {:error, _} ->
+        :ok
+    end
+  end
+
+  defp has_lang_versions?(%{"lang_versions" => [_ | _]}), do: true
+  defp has_lang_versions?(_), do: false
 
   # When `params["paragraph"]` carries a body for a comprehension problem, upsert the
   # shared paragraph once. Existing distinct paragraphs are updated via a single helper;

--- a/test/dbservice/resources_lang_versions_test.exs
+++ b/test/dbservice/resources_lang_versions_test.exs
@@ -1,0 +1,156 @@
+defmodule Dbservice.ResourcesLangVersionsTest do
+  use Dbservice.DataCase
+
+  import Ecto.Query
+
+  alias Dbservice.Paragraphs
+  alias Dbservice.ProblemLanguages
+  alias Dbservice.Repo
+  alias Dbservice.Resources
+  alias Dbservice.Resources.ProblemLanguage
+
+  # Unique codes to avoid colliding with any pre-existing language in the test DB.
+  defp language_fixture(code, name) do
+    {:ok, language} = Dbservice.Languages.create_language(%{"name" => name, "code" => code})
+    language
+  end
+
+  defp problem_fixture(attrs \\ %{}) do
+    {:ok, resource} =
+      Resources.create_resource(Map.merge(%{"type" => "problem", "type_params" => %{}}, attrs))
+
+    resource
+  end
+
+  defp problem_language_fixture(resource, language, meta_data, extra \\ %{}) do
+    {:ok, problem_lang} =
+      ProblemLanguages.create_problem_language(
+        Map.merge(
+          %{res_id: resource.id, lang_id: language.id, meta_data: meta_data},
+          extra
+        )
+      )
+
+    problem_lang
+  end
+
+  defp problem_lang_rows(resource_id) do
+    from(pl in ProblemLanguage, where: pl.res_id == ^resource_id, order_by: [asc: pl.id])
+    |> Repo.all()
+  end
+
+  describe "update_resource_and_associations/2 with lang_versions" do
+    test "updates existing languages and inserts new ones" do
+      en = language_fixture("upe", "Update EN")
+      hi = language_fixture("uph", "Update HI")
+      problem = problem_fixture()
+      problem_language_fixture(problem, en, %{"text" => "old en"})
+
+      {:ok, _} =
+        Resources.update_resource_and_associations(problem, %{
+          "lang_versions" => [
+            %{"lang_code" => "upe", "meta_data" => %{"text" => "new en"}},
+            %{"lang_code" => "uph", "meta_data" => %{"text" => "new hi"}}
+          ]
+        })
+
+      rows = problem_lang_rows(problem.id)
+      assert Enum.map(rows, & &1.lang_id) == [en.id, hi.id]
+      assert Enum.map(rows, & &1.meta_data) == [%{"text" => "new en"}, %{"text" => "new hi"}]
+    end
+
+    test "deletes languages absent from lang_versions" do
+      en = language_fixture("dle", "Delete EN")
+      hi = language_fixture("dlh", "Delete HI")
+      problem = problem_fixture()
+      problem_language_fixture(problem, en, %{"text" => "en"})
+      problem_language_fixture(problem, hi, %{"text" => "hi"})
+
+      {:ok, _} =
+        Resources.update_resource_and_associations(problem, %{
+          "lang_versions" => [
+            %{"lang_code" => "dle", "meta_data" => %{"text" => "en updated"}}
+          ]
+        })
+
+      assert [row] = problem_lang_rows(problem.id)
+      assert row.lang_id == en.id
+      assert row.meta_data == %{"text" => "en updated"}
+    end
+
+    test "skips unknown lang_codes without touching valid entries" do
+      en = language_fixture("ske", "Skip EN")
+      problem = problem_fixture()
+      problem_language_fixture(problem, en, %{"text" => "en"})
+
+      {:ok, _} =
+        Resources.update_resource_and_associations(problem, %{
+          "lang_versions" => [
+            %{"lang_code" => "ske", "meta_data" => %{"text" => "en updated"}},
+            %{"lang_code" => "nope", "meta_data" => %{"text" => "bad"}}
+          ]
+        })
+
+      assert [row] = problem_lang_rows(problem.id)
+      assert row.lang_id == en.id
+      assert row.meta_data == %{"text" => "en updated"}
+    end
+
+    test "old flat lang_code + meta_data format keeps working" do
+      en = language_fixture("ofe", "Old Flat EN")
+      hi = language_fixture("ofh", "Old Flat HI")
+      problem = problem_fixture()
+      problem_language_fixture(problem, en, %{"text" => "en"})
+      problem_language_fixture(problem, hi, %{"text" => "hi"})
+
+      {:ok, _} =
+        Resources.update_resource_and_associations(problem, %{
+          "lang_code" => "ofe",
+          "meta_data" => %{"text" => "en updated"}
+        })
+
+      # Only the addressed language changes; nothing is deleted on the old path
+      rows = problem_lang_rows(problem.id)
+      assert Enum.map(rows, & &1.meta_data) == [%{"text" => "en updated"}, %{"text" => "hi"}]
+    end
+
+    test "a new language of a comprehension problem joins the shared paragraph" do
+      en = language_fixture("cpe", "Comprehension EN")
+      hi = language_fixture("cph", "Comprehension HI")
+      problem = problem_fixture(%{"subtype" => "comprehension"})
+      {:ok, paragraph} = Paragraphs.create_paragraph(%{"body" => "Shared passage"})
+      problem_language_fixture(problem, en, %{"text" => "en"}, %{paragraph_id: paragraph.id})
+
+      {:ok, _} =
+        Resources.update_resource_and_associations(problem, %{
+          "lang_versions" => [
+            %{"lang_code" => "cpe", "meta_data" => %{"text" => "en"}},
+            %{"lang_code" => "cph", "meta_data" => %{"text" => "hi"}}
+          ]
+        })
+
+      rows = problem_lang_rows(problem.id)
+      assert Enum.map(rows, & &1.lang_id) == [en.id, hi.id]
+      assert Enum.map(rows, & &1.paragraph_id) == [paragraph.id, paragraph.id]
+    end
+
+    test "paragraph body in the request updates the shared paragraph once" do
+      en = language_fixture("pbe", "Paragraph EN")
+      problem = problem_fixture(%{"subtype" => "comprehension"})
+      {:ok, paragraph} = Paragraphs.create_paragraph(%{"body" => "Old passage"})
+      problem_language_fixture(problem, en, %{"text" => "en"}, %{paragraph_id: paragraph.id})
+
+      {:ok, _} =
+        Resources.update_resource_and_associations(problem, %{
+          "paragraph" => "New passage",
+          "lang_versions" => [
+            %{"lang_code" => "pbe", "meta_data" => %{"text" => "en updated"}}
+          ]
+        })
+
+      assert Paragraphs.fetch_paragraph!(paragraph.id).body == "New passage"
+      assert [row] = problem_lang_rows(problem.id)
+      assert row.meta_data == %{"text" => "en updated"}
+    end
+  end
+end

--- a/test/dbservice_web/controllers/resource_patch_lang_versions_test.exs
+++ b/test/dbservice_web/controllers/resource_patch_lang_versions_test.exs
@@ -1,0 +1,97 @@
+defmodule DbserviceWeb.ResourcePatchLangVersionsTest do
+  @moduledoc """
+  PATCH /api/resource/:id must return `lang_versions` in the response so the
+  frontend gets the synced set of languages back (see #614 review). The
+  representation is shared with the problem GET endpoints (#612).
+  """
+  use DbserviceWeb.ConnCase
+
+  alias Dbservice.Curriculums
+  alias Dbservice.Languages
+  alias Dbservice.ResourceCurriculums
+  alias Dbservice.Resources
+
+  defp language_fixture(code, name) do
+    {:ok, language} = Languages.create_language(%{"name" => name, "code" => code})
+    language
+  end
+
+  defp problem_fixture do
+    {:ok, resource} = Resources.create_resource(%{"type" => "problem", "type_params" => %{}})
+    resource
+  end
+
+  defp curriculum_fixture do
+    {:ok, curriculum} = Curriculums.create_curriculum(%{"name" => "Curriculum", "code" => "CURR"})
+    curriculum
+  end
+
+  defp resource_curriculum_fixture(resource, curriculum) do
+    {:ok, rc} =
+      ResourceCurriculums.create_resource_curriculum(%{
+        resource_id: resource.id,
+        curriculum_id: curriculum.id,
+        difficulty_level: "medium"
+      })
+
+    rc
+  end
+
+  describe "PATCH /api/resource/:id with lang_versions" do
+    test "response includes every synced language in lang_versions", %{conn: conn} do
+      language_fixture("pae", "PA EN")
+      language_fixture("pah", "PA HI")
+      curriculum = curriculum_fixture()
+      problem = problem_fixture()
+      resource_curriculum_fixture(problem, curriculum)
+
+      en_meta = %{"text" => "patch en"}
+      hi_meta = %{"text" => "patch hi"}
+
+      conn =
+        patch(conn, ~p"/api/resource/#{problem.id}", %{
+          "lang_versions" => [
+            %{"lang_code" => "pae", "meta_data" => en_meta},
+            %{"lang_code" => "pah", "meta_data" => hi_meta}
+          ]
+        })
+
+      body = json_response(conn, 200)
+
+      assert body["lang_versions"] == [
+               %{"lang_code" => "pae", "meta_data" => en_meta},
+               %{"lang_code" => "pah", "meta_data" => hi_meta}
+             ]
+    end
+
+    test "lang_versions reflects a language removed by the sync", %{conn: conn} do
+      language_fixture("pbe", "PB EN")
+      language_fixture("pbh", "PB HI")
+      curriculum = curriculum_fixture()
+      problem = problem_fixture()
+      resource_curriculum_fixture(problem, curriculum)
+
+      # Seed both languages...
+      patch(conn, ~p"/api/resource/#{problem.id}", %{
+        "lang_versions" => [
+          %{"lang_code" => "pbe", "meta_data" => %{"text" => "en"}},
+          %{"lang_code" => "pbh", "meta_data" => %{"text" => "hi"}}
+        ]
+      })
+
+      # ...then PATCH with only English; Hindi should be dropped from the response.
+      conn =
+        patch(conn, ~p"/api/resource/#{problem.id}", %{
+          "lang_versions" => [%{"lang_code" => "pbe", "meta_data" => %{"text" => "en only"}}]
+        })
+
+      body = json_response(conn, 200)
+
+      assert body["lang_versions"] == [
+               %{"lang_code" => "pbe", "meta_data" => %{"text" => "en only"}}
+             ]
+
+      assert length(body["lang_versions"]) == 1
+    end
+  end
+end


### PR DESCRIPTION
Closes #611

## What

`PATCH /api/resource/{id}` now accepts the `lang_versions` array and syncs the problem's `problem_lang` rows to **exactly** the languages in the request:

1. **Upsert** — each `{lang_code, meta_data}` entry inserts a new row or updates the existing one for that language
2. **Delete** — languages present in the DB but absent from `lang_versions` are deleted (the frontend only sends languages the user has enabled via the language tabs, so missing = unchecked)

`PATCH /api/resources/problems/batch` shares the same update path (`update_resource_and_associations`), so batch updates get the behavior too.

## Backward compatibility

Same pattern as #602/#613 — when `lang_versions` is absent/null, the existing flat `lang_code` + `meta_data` path runs unchanged (which only updates the addressed language and never deletes). `lang_versions` takes precedence when present. The fallback can be removed once the new frontend is deployed.

## Details

- **Comprehension problems**: a language added via `lang_versions` joins the problem's existing shared paragraph (its `paragraph_id` is inherited), and a `paragraph` body in the same request still updates the shared paragraph exactly once via the existing pre-sync.
- **Unknown `lang_code`** entries are skipped without affecting valid entries, matching the flat path's no-op behavior on unknown languages (PATCH association updates run outside a transaction, so there is no rollback to lean on).
- Swagger request docs for `lang_versions` land in #613; no schema changes here to avoid conflicts.

## Testing

- 6 new DataCase tests: upsert (update + insert), delete-on-absence, unknown-language skip, old-flat-format unchanged (no deletions), comprehension paragraph inheritance, and shared-paragraph body update.
- Verified live against the dev server: `PATCH /api/resource/503` with `[en, hi]` inserted the Hindi row; a follow-up PATCH with `[en]` deleted it. DB restored to its original state afterwards.
- `mix test`, `mix format --check-formatted`, `mix credo` all green.

## Related

- POST side (#602, #603): #613
- GET side (#610): #612

🤖 Generated with [Claude Code](https://claude.com/claude-code)