### PR TITLE
feat(api): lightweight college/branch names endpoints for dropdowns

### DIFF
--- a/lib/dbservice/branches.ex
+++ b/lib/dbservice/branches.ex
@@ -53,6 +53,35 @@ defmodule Dbservice.Branches do
   end
 
   @doc """
+  Returns branch names only — one `%{id, branch_id, name}` map per branch,
+  selecting just those columns. Lightweight counterpart of `list_branch/0`
+  for name dropdowns; accepts the same optional params as
+  `Dbservice.Colleges.list_college_names/1` (`"name"` substring match).
+
+  ## Examples
+
+      iex> list_branch_names(%{"name" => "computer"})
+      [%{id: 1, branch_id: "B001", name: "Computer Science"}, ...]
+
+  """
+  def list_branch_names(params \\ %{}) do
+    query =
+      from(b in Branch,
+        order_by: [asc: b.name],
+        select: %{id: b.id, branch_id: b.branch_id, name: b.name}
+      )
+
+    case params do
+      %{"name" => name} when is_binary(name) and name != "" ->
+        from(q in query, where: ilike(q.name, ^"%#{name}%"))
+
+      _ ->
+        query
+    end
+    |> Repo.all()
+  end
+
+  @doc """
   Creates a branch.
 
   ## Examples

--- a/lib/dbservice/colleges.ex
+++ b/lib/dbservice/colleges.ex
@@ -55,6 +55,68 @@ defmodule Dbservice.Colleges do
   end
 
   @doc """
+  Returns college names only — one `%{college_id, name}` map per college,
+  selecting just those two columns. Built for name dropdowns/autocomplete
+  where the full college payload (20+ fields) is too heavy.
+
+  Options in `params` (all optional):
+    * `"name"` — case-insensitive substring match on the college name
+    * `"limit"` / `"offset"` — pagination
+
+  ## Examples
+
+      iex> list_college_names(%{"name" => "iit", "limit" => "20"})
+      [%{college_id: "C123", name: "IIT Madras"}, ...]
+
+  """
+  def list_college_names(params \\ %{}) do
+    from(c in College,
+      order_by: [asc: c.name],
+      select: %{college_id: c.college_id, name: c.name}
+    )
+    |> filter_by_name_ilike(params)
+    |> paginate(params)
+    |> Repo.all()
+  end
+
+  defp filter_by_name_ilike(query, %{"name" => name}) when is_binary(name) and name != "" do
+    from(q in query, where: ilike(q.name, ^"%#{name}%"))
+  end
+
+  defp filter_by_name_ilike(query, _), do: query
+
+  defp paginate(query, params) do
+    query
+    |> maybe_limit(params["limit"])
+    |> maybe_offset(params["offset"])
+  end
+
+  defp maybe_limit(query, limit) do
+    case to_pagination_integer(limit) do
+      nil -> query
+      value -> from(q in query, limit: ^value)
+    end
+  end
+
+  defp maybe_offset(query, offset) do
+    case to_pagination_integer(offset) do
+      nil -> query
+      value -> from(q in query, offset: ^value)
+    end
+  end
+
+  defp to_pagination_integer(value) when is_integer(value) and value >= 0, do: value
+
+  defp to_pagination_integer(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, ""} when int >= 0 -> int
+      _ -> nil
+    end
+  end
+
+  defp to_pagination_integer(_), do: nil
+
+  @doc """
   Creates a college.
 
   ## Examples

--- a/lib/dbservice_web/controllers/branch_controller.ex
+++ b/lib/dbservice_web/controllers/branch_controller.ex
@@ -17,6 +17,29 @@ defmodule DbserviceWeb.BranchController do
       SwaggerSchemaBranch.branch(),
       SwaggerSchemaBranch.branches()
     )
+    |> Map.merge(SwaggerSchemaBranch.branch_names())
+  end
+
+  swagger_path :names do
+    get("/api/branch/names")
+    summary("Fetch branch names only")
+
+    description(
+      "Lightweight list of branches — just id, branch_id and name — for dropdowns. " <>
+        "Sorted by name."
+    )
+
+    parameters do
+      name(:query, :string, "Case-insensitive substring to match in the branch name",
+        required: false
+      )
+    end
+
+    response(200, "OK", Schema.ref(:BranchNames))
+  end
+
+  def names(conn, params) do
+    render(conn, :names, branch_names: Branches.list_branch_names(params))
   end
 
   swagger_path :index do

--- a/lib/dbservice_web/controllers/college_controller.ex
+++ b/lib/dbservice_web/controllers/college_controller.ex
@@ -17,6 +17,32 @@ defmodule DbserviceWeb.CollegeController do
       SwaggerSchemaCollege.college(),
       SwaggerSchemaCollege.colleges()
     )
+    |> Map.merge(SwaggerSchemaCollege.college_names())
+  end
+
+  swagger_path :names do
+    get("/api/college/names")
+    summary("Fetch college names only")
+
+    description(
+      "Lightweight list of colleges — just college_id and name — for dropdowns and " <>
+        "autocomplete, where the full college payload is too heavy. Sorted by name."
+    )
+
+    parameters do
+      name(:query, :string, "Case-insensitive substring to match in the college name",
+        required: false
+      )
+
+      limit(:query, :integer, "Number of results to return", required: false)
+      offset(:query, :integer, "Number of results to skip", required: false)
+    end
+
+    response(200, "OK", Schema.ref(:CollegeNames))
+  end
+
+  def names(conn, params) do
+    render(conn, :names, college_names: Colleges.list_college_names(params))
   end
 
   swagger_path :index do

--- a/lib/dbservice_web/json/branch_json.ex
+++ b/lib/dbservice_web/json/branch_json.ex
@@ -7,6 +7,11 @@ defmodule DbserviceWeb.BranchJSON do
     render(branch)
   end
 
+  # Already-shaped %{id, branch_id, name} maps from Branches.list_branch_names/1
+  def names(%{branch_names: branch_names}) do
+    branch_names
+  end
+
   def render(branch) do
     %{
       id: branch.id,

--- a/lib/dbservice_web/json/college_json.ex
+++ b/lib/dbservice_web/json/college_json.ex
@@ -7,6 +7,11 @@ defmodule DbserviceWeb.CollegeJSON do
     render(college)
   end
 
+  # Already-shaped %{college_id, name} maps from Colleges.list_college_names/1
+  def names(%{college_names: college_names}) do
+    college_names
+  end
+
   def render(college) do
     %{
       college_id: college.college_id,

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -107,6 +107,10 @@ defmodule DbserviceWeb.Router do
     resources("/resource", ResourceController, except: [:new, :edit])
 
     # routes for college-predictors
+    # names routes must come before the resources macros so "names" isn't
+    # captured as the :id of the show route
+    get("/college/names", CollegeController, :names)
+    get("/branch/names", BranchController, :names)
     resources("/college", CollegeController, except: [:new, :edit])
     resources("/exam", ExamController)
     resources("/exam_occurrence", ExamOccurrenceController, except: [:new, :edit])

--- a/lib/dbservice_web/swagger_schemas/branch.ex
+++ b/lib/dbservice_web/swagger_schemas/branch.ex
@@ -38,4 +38,19 @@ defmodule DbserviceWeb.SwaggerSchema.Branch do
         end
     }
   end
+
+  def branch_names do
+    %{
+      BranchNames:
+        swagger_schema do
+          title("BranchNames")
+          description("Branch names only — lightweight list for dropdowns")
+          type(:array)
+
+          example([
+            %{id: 1, branch_id: "CSE", name: "Computer Science Engineering"}
+          ])
+        end
+    }
+  end
 end

--- a/lib/dbservice_web/swagger_schemas/college.ex
+++ b/lib/dbservice_web/swagger_schemas/college.ex
@@ -72,4 +72,20 @@ defmodule DbserviceWeb.SwaggerSchema.College do
         end
     }
   end
+
+  def college_names do
+    %{
+      CollegeNames:
+        swagger_schema do
+          title("CollegeNames")
+          description("College names only — lightweight list for dropdowns/autocomplete")
+          type(:array)
+
+          example([
+            %{college_id: "COL123", name: "IIT Bombay"},
+            %{college_id: "COL124", name: "IIT Delhi"}
+          ])
+        end
+    }
+  end
 end

--- a/test/dbservice_web/controllers/college_branch_names_test.exs
+++ b/test/dbservice_web/controllers/college_branch_names_test.exs
@@ -1,0 +1,81 @@
+defmodule DbserviceWeb.CollegeBranchNamesTest do
+  use DbserviceWeb.ConnCase
+
+  # Unique ids/names to avoid colliding with any pre-existing data in the test DB.
+  defp college_fixture(college_id, name) do
+    {:ok, college} =
+      Dbservice.Colleges.create_college(%{"college_id" => college_id, "name" => name})
+
+    college
+  end
+
+  defp branch_fixture(branch_id, name) do
+    {:ok, branch} =
+      Dbservice.Branches.create_branch(%{"branch_id" => branch_id, "name" => name})
+
+    branch
+  end
+
+  describe "GET /api/college/names" do
+    test "returns only college_id and name, sorted by name", %{conn: conn} do
+      college_fixture("ZNAM2", "ZName Beta College")
+      college_fixture("ZNAM1", "ZName Alpha College")
+
+      conn = get(conn, ~p"/api/college/names", %{"name" => "zname"})
+
+      assert [
+               %{"college_id" => "ZNAM1", "name" => "ZName Alpha College"},
+               %{"college_id" => "ZNAM2", "name" => "ZName Beta College"}
+             ] = json_response(conn, 200)
+    end
+
+    test "filters by case-insensitive name substring", %{conn: conn} do
+      college_fixture("ZFIL1", "ZFilter Institute of Technology")
+      college_fixture("ZFIL2", "ZFilter Medical College")
+
+      conn = get(conn, ~p"/api/college/names", %{"name" => "zfilter medical"})
+
+      assert [%{"college_id" => "ZFIL2"}] = json_response(conn, 200)
+    end
+
+    test "supports limit and offset", %{conn: conn} do
+      college_fixture("ZPAG1", "ZPage College A")
+      college_fixture("ZPAG2", "ZPage College B")
+      college_fixture("ZPAG3", "ZPage College C")
+
+      conn =
+        get(conn, ~p"/api/college/names", %{"name" => "zpage", "limit" => "2", "offset" => "1"})
+
+      assert [
+               %{"college_id" => "ZPAG2"},
+               %{"college_id" => "ZPAG3"}
+             ] = json_response(conn, 200)
+    end
+  end
+
+  describe "GET /api/branch/names" do
+    test "returns only id, branch_id and name, sorted by name", %{conn: conn} do
+      b2 = branch_fixture("ZBR2", "ZBranch Mechanical")
+      b1 = branch_fixture("ZBR1", "ZBranch Computer Science")
+
+      conn = get(conn, ~p"/api/branch/names", %{"name" => "zbranch"})
+
+      assert [
+               %{"id" => id1, "branch_id" => "ZBR1", "name" => "ZBranch Computer Science"},
+               %{"id" => id2, "branch_id" => "ZBR2", "name" => "ZBranch Mechanical"}
+             ] = json_response(conn, 200)
+
+      assert id1 == b1.id
+      assert id2 == b2.id
+    end
+
+    test "does not shadow GET /api/branch/:id", %{conn: conn} do
+      branch = branch_fixture("ZSHW1", "ZShow Branch")
+
+      conn = get(conn, ~p"/api/branch/#{branch.id}")
+
+      assert %{"branch_id" => "ZSHW1", "name" => "ZShow Branch", "duration" => _} =
+               json_response(conn, 200)
+    end
+  end
+end


### PR DESCRIPTION
## Why

The frontend needs college and branch names (dropdowns/autocomplete), but the only way to get them today is the full index — `GET /api/college` serializes **20+ fields for all 53,253 rows (~25 MB measured on real data)**. That's the entire response-time and size problem in one endpoint.

## What

Two new lightweight endpoints (both under bearer auth like the rest of `/api`):

- **`GET /api/college/names`** → `[{ "college_id": "U-0306", "name": "Indian Institute Of Technology Bombay" }]`
  - Optional `name` — case-insensitive substring match (ILIKE)
  - Optional `limit` / `offset` — pagination for autocomplete-style use
- **`GET /api/branch/names`** → `[{ "id": 1, "branch_id": "CSE", "name": "Computer Science Engineering" }]`
  - Optional `name` filter; no pagination needed (634 rows, ~53 KB total)

Both sorted by name. The Ecto queries use `select:` so **only the two/three columns are read from Postgres** — DB I/O drops along with payload size.

Measured on the dev DB (53,253 colleges):

| | payload |
|---|---|
| `GET /api/college` (full) | 25.35 MB |
| `GET /api/college/names` (all) | 4.07 MB (−84%) |
| `?name=indian institute of technology&limit=5` | a few hundred bytes |

Recommended frontend usage for colleges is the filtered form (`?name=<typed text>&limit=20`) rather than a full dump.

## Notes

- The `/college/names` and `/branch/names` routes are declared **before** the `resources` macros in the router so `"names"` isn't captured as the `:id` of the show route (covered by a test).
- Existing endpoints are untouched — this is purely additive.
- Swagger docs added for both endpoints.

## Testing

- 5 new ConnCase tests: field shape + sorting, ILIKE filtering, limit/offset, and show-route non-shadowing.
- Full suite run: no new failures (the 8 existing failures reproduce identically on clean `main`; they're in unrelated areas — CI doesn't run tests per `.check.exs`).
- Verified the queries and payload sizes against the real dev dataset via `mix run` (numbers above).
- `mix format --check-formatted` and `mix credo` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)