### PR TITLE
Add Holistic Mentorship schema and Profile machine APIs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,12 @@ Complex operations that span multiple domains:
 - `group_update_service` - Group synchronization
 - `student_update_service` - Bulk student operations
 
+Holistic Mentorship eligibility cleanup is transaction-coupled to canonical Student
+and enrollment mutations. Route Student status/Grade changes through
+`Dbservice.Users.update_student/2` and current School/Program changes through
+`Dbservice.EnrollmentRecords`; do not update those records directly from controllers
+or import processors.
+
 ### Web Layer (`lib/dbservice_web/`)
 
 - **Controllers** (`/controllers`): 53 controllers handling REST API endpoints

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,11 +69,10 @@ Complex operations that span multiple domains:
 - `group_update_service` - Group synchronization
 - `student_update_service` - Bulk student operations
 
-Holistic Mentorship eligibility cleanup is transaction-coupled to canonical Student
-and enrollment mutations. Route Student status/Grade changes through
-`Dbservice.Users.update_student/2` and current School/Program changes through
-`Dbservice.EnrollmentRecords`; do not update those records directly from controllers
-or import processors.
+Holistic Mentorship status/Grade/dropout cleanup remains transaction-coupled to
+canonical Student mutations through `Dbservice.Users.update_student/2`. Generic
+School/Program `Dbservice.EnrollmentRecords` CRUD must not query or mutate Holistic
+tables; AF LMS reconciles those eligibility changes before protected Holistic work.
 
 ### Revised NVS student writes
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -117,6 +117,8 @@ _Avoid_: best-effort identity matching
 - Phase definition mutations retain content-free actor/time audit without storing
   prior Guidance or Question versions.
 - Raw questionnaire answers and rendered per-Student prompts are not persisted.
+- Profile Program eligibility comes from the Student's one current School and
+  that School's canonical Program IDs; it does not require a Program enrollment.
 - Profile publication is atomic per Student and revalidates identity and scope.
 - Student eligibility mutations end affected active Mappings atomically.
 - Production-to-staging sync excludes all Holistic table data after launch.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -50,12 +50,15 @@ _Avoid_: persisted active flag, manual Make Active action
 An audit event recording a Phase's Open/Locked change, human actor, and
 occurrence time. The timeline lets LMS derive which Phase was Active when a
 Mentor-Mentee Mapping began.
+The authenticated email is the required actor snapshot; `actor_user_id` is an
+optional link because LMS access does not require a canonical `user` row.
 _Avoid_: persisted Active Phase, progress snapshot
 
 **Phase Mutation Audit**:
 A content-free actor/time record for Phase creation, definition edits, reorder,
 or deletion. It stores no Guidance or Question snapshot and survives deletion
 of a never-opened Phase.
+The authenticated email is required and `actor_user_id` is optional.
 _Avoid_: definition history, content snapshot
 
 **Mentor-Mentee Mapping**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,128 @@
+# db-service Domain Context
+
+This file defines the canonical language used by db-service. It includes the
+Holistic Mentorship persistence and machine-contract terms approved for v1.
+
+## Language
+
+### Core identities
+
+**User**:
+The canonical LMS login identity referenced by staff and Student records.
+_Avoid_: account record, email identity
+
+**Student**:
+The canonical learner record identified internally by `student.id` and linked
+to exactly one User through `student.user_id`.
+_Avoid_: using business `student.student_id` as a database join key
+
+**Program**:
+The canonical organizational scope that groups eligible Schools and Students.
+Holistic Mentorship v1 launches only for Program ID `1`.
+_Avoid_: hard-coded School allowlist
+
+**Academic Year**:
+The year boundary that scopes a Holistic Phase Plan and Mentor-Mentee Mapping.
+_Avoid_: mentorship cycle
+
+### Holistic Mentorship
+
+**Holistic Mentorship**:
+A mentorship domain independent of Academic Mentorship, with its own Phases,
+Mappings, Notes, Historical Notes, Profiles, and regeneration records.
+_Avoid_: extending or reusing Academic Mentorship records
+
+**Phase Plan**:
+The ordered Grade 11 and Grade 12 Holistic Phase definition for one Program and
+Academic Year.
+_Avoid_: phase template, static eight-phase list
+
+**Phase**:
+A stable item in a Phase Plan with a Grade, title, order, Locked/Open state,
+Markdown Guidance, and one to four ordered Post-Session Questions.
+_Avoid_: storing the displayed Phase number as identity
+
+**Active Phase**:
+The latest ordered Open Phase for a Grade in a Phase Plan, derived at read time.
+_Avoid_: persisted active flag, manual Make Active action
+
+**Mentor-Mentee Mapping**:
+A time-bounded assignment of one Student to one Mentor User at a School for a
+Program and Academic Year. Ended rows remain as history.
+_Avoid_: Academic Mentorship mapping, overwriting assignment history
+
+**Post-Session Notes**:
+The current official ordered answer set for one Mentee and stable Phase, with
+optimistic revision and content-free mutation audit metadata.
+_Avoid_: meeting record, answer revision archive
+
+**Historical Holistic Notes**:
+A provenance-bearing legacy answer set imported for a safely matched Student,
+without inventing a canonical Phase, Mapping, or completion.
+_Avoid_: migrated Post-Session Notes
+
+**Student Profile**:
+A journey-level set of ordered Question Set summaries generated from an
+approved Profile Form and stored by immutable prompt/model configuration.
+_Avoid_: raw questionnaire response, per-grade Profile
+
+**Prompt Configuration**:
+An immutable Prompt Version, exact template and hash, and exact model ID. One
+registered configuration is explicitly Active; newest is never active by default.
+_Avoid_: mutable prompt row, automatically latest prompt
+
+**Regeneration Request**:
+An idempotent request recorded for a human Admin to replace one Profile output
+through the existing ETL flow while retaining the previous success on failure.
+_Avoid_: synchronous generation request
+
+**Profile Preflight**:
+A bounded machine check that resolves a source User ID to one canonical Student
+and verifies approved Form, entry Grade, Program, School, and current eligibility.
+_Avoid_: best-effort identity matching
+
+## Relationships
+
+- A Program has one Phase Plan per Academic Year; a Phase Plan has ordered Phases.
+- A Student has at most one active Mentor-Mentee Mapping per Academic Year.
+- Post-Session Notes belong to one Student, one stable Phase, and their author.
+- A Student Profile belongs to the canonical Student journey and one immutable
+  Prompt Configuration; older configurations remain retained.
+- A Regeneration Request points to its human actor, Student, requested
+  configuration, and ETL run/status.
+- Holistic records may reference canonical User, Student, School, Program, and
+  Academic Year identities but never Academic Mentorship-owned records.
+- `db-service` owns schema, constraints, Profile machine APIs, and Student-side
+  Mapping cleanup. `af_lms` owns product reads/writes; `etl-next` owns generation.
+
+## Invariants
+
+- Main Postgres is the sole durable Holistic Mentorship store.
+- Displayed Phase number, Active Phase, Student Context, progress summaries, and
+  Grade 12 placeholders are derived rather than stored.
+- Raw questionnaire answers and rendered per-Student prompts are not persisted.
+- Profile publication is atomic per Student and revalidates identity and scope.
+- Student eligibility mutations end affected active Mappings atomically.
+- Production-to-staging sync excludes all Holistic table data after launch.
+
+## Example Dialogue
+
+> **ETL engineer:** "Can I publish this Profile using the business Student ID?"
+> **db-service engineer:** "No. Profile Preflight must resolve and return canonical
+> `student.id`, and publication must revalidate it."
+
+> **LMS engineer:** "Which Phase row is Active?"
+> **db-service engineer:** "Derive the latest ordered Open Phase for that Grade;
+> there is no stored active flag."
+
+> **Operator:** "A new generation failed. Should the prior Profile be removed?"
+> **db-service engineer:** "No. Keep the last successful Profile until an atomic
+> replacement succeeds."
+
+## Flagged Ambiguities
+
+- Exact table decomposition and API route names follow existing Ecto and Phoenix
+  conventions and are settled during the PRD and slice steps; the ownership and
+  invariants above are fixed.
+- The live staging deployment path may change, so release work must verify the
+  currently active path rather than encode one historical workflow name.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,6 +52,12 @@ occurrence time. The timeline lets LMS derive which Phase was Active when a
 Mentor-Mentee Mapping began.
 _Avoid_: persisted Active Phase, progress snapshot
 
+**Phase Mutation Audit**:
+A content-free actor/time record for Phase creation, definition edits, reorder,
+or deletion. It stores no Guidance or Question snapshot and survives deletion
+of a never-opened Phase.
+_Avoid_: definition history, content snapshot
+
 **Mentor-Mentee Mapping**:
 A time-bounded assignment of one Student to one Mentor User at a School for a
 Program and Academic Year. Ended rows remain as history.
@@ -108,6 +114,8 @@ _Avoid_: best-effort identity matching
   Grade 12 placeholders are derived rather than stored.
 - Open/Locked transition history is retained with actor/time so past Active Phase
   state can be reconstructed without storing an Active or progress snapshot.
+- Phase definition mutations retain content-free actor/time audit without storing
+  prior Guidance or Question versions.
 - Raw questionnaire answers and rendered per-Student prompts are not persisted.
 - Profile publication is atomic per Student and revalidates identity and scope.
 - Student eligibility mutations end affected active Mappings atomically.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -46,6 +46,12 @@ _Avoid_: storing the displayed Phase number as identity
 The latest ordered Open Phase for a Grade in a Phase Plan, derived at read time.
 _Avoid_: persisted active flag, manual Make Active action
 
+**Phase State Transition**:
+An audit event recording a Phase's Open/Locked change, human actor, and
+occurrence time. The timeline lets LMS derive which Phase was Active when a
+Mentor-Mentee Mapping began.
+_Avoid_: persisted Active Phase, progress snapshot
+
 **Mentor-Mentee Mapping**:
 A time-bounded assignment of one Student to one Mentor User at a School for a
 Program and Academic Year. Ended rows remain as history.
@@ -100,6 +106,8 @@ _Avoid_: best-effort identity matching
 - Main Postgres is the sole durable Holistic Mentorship store.
 - Displayed Phase number, Active Phase, Student Context, progress summaries, and
   Grade 12 placeholders are derived rather than stored.
+- Open/Locked transition history is retained with actor/time so past Active Phase
+  state can be reconstructed without storing an Active or progress snapshot.
 - Raw questionnaire answers and rendered per-Student prompts are not persisted.
 - Profile publication is atomic per Student and revalidates identity and scope.
 - Student eligibility mutations end affected active Mappings atomically.

--- a/config/config.exs
+++ b/config/config.exs
@@ -42,6 +42,7 @@ config :logger, :request_log,
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
+config :phoenix, :filter_parameters, ["password", "template_text"]
 
 config :dbservice, :phoenix_swagger,
   swagger_files: %{

--- a/docs/holistic_mentorship_rollout.md
+++ b/docs/holistic_mentorship_rollout.md
@@ -1,0 +1,164 @@
+# Holistic Mentorship Rollout
+
+## Active deployment path
+
+As of 2026-07-16, staging deploys through ECS Fargate with
+`.github/workflows/staging_deploy_ecs.yml`; the former staging EC2 workflow is
+disabled. Production still deploys the `release` branch to EC2 through
+`.github/workflows/production_deploy.yml`. The production ECS workflow is
+manual validation only until its documented cutover.
+
+Use the active workflow for each environment. Do not use the standalone legacy
+staging migration workflow for this rollout.
+
+## Release order
+
+1. Configure different `BEARER_TOKEN` values in staging and production. Verify
+   that each environment rejects the other environment's token with `401`.
+2. Deploy db-service to staging. Its active ECS workflow runs the additive
+   migrations before replacing the service.
+3. Complete every staging smoke check below.
+4. Merge and deploy db-service from `release` to production. Confirm migrations,
+   liveness, readiness, and authentication before enabling callers.
+5. Deploy and enable `etl-next` Profile generation.
+6. Deploy `af_lms` Holistic Mentorship workflows.
+
+Never run a down migration after Holistic Mentorship tables contain data.
+
+## Staging smoke checks
+
+Use only deterministic staging fixtures. Do not use production credentials,
+source records, questionnaire answers, prompt content, or summaries.
+
+```bash
+export BASE_URL=https://staging-db.avantifellows.org
+export BEARER_TOKEN='<staging token from the approved secret store>'
+
+test "$(curl -sS -o /dev/null -w '%{http_code}' "$BASE_URL/api/health")" = 200
+test "$(curl -sS -o /dev/null -w '%{http_code}' "$BASE_URL/api/health/ready")" = 200
+test "$(curl -sS -o /dev/null -w '%{http_code}' \
+  -H 'Authorization: Bearer invalid-smoke-token' \
+  "$BASE_URL/api/holistic-mentorship/profile-preflight")" = 401
+```
+
+Register and explicitly activate a disposable configuration. `abc` and its
+published SHA-256 value are test-only constants.
+
+```bash
+export SMOKE_ID="staging-smoke-$(date +%s)"
+
+CONFIG_ID=$(curl -fsS -X POST \
+  -H "Authorization: Bearer $BEARER_TOKEN" -H 'content-type: application/json' \
+  "$BASE_URL/api/holistic-mentorship/prompt-configurations" \
+  -d "{\"prompt_version\":\"$SMOKE_ID\",\"template_text\":\"abc\",\"template_hash\":\"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\",\"model_id\":\"smoke/test-model\"}" \
+  | jq -er '.id')
+
+curl -fsS -X POST -H "Authorization: Bearer $BEARER_TOKEN" \
+  -H 'content-type: application/json' \
+  "$BASE_URL/api/holistic-mentorship/prompt-configurations/$CONFIG_ID/activate" \
+  -d '{}' | jq -e '.state == "active"'
+```
+
+Preflight one seeded, eligible, synthetic Grade 11 Student. The approved Grade
+11 source is Form `6a44a83d1184e717b920c499` and AF Session
+`EnableStudents_6a44a83d1184e717b920c499`. The Grade 12 equivalents are Form
+`6a4deca8e030ebe34669fb0f` and AF Session
+`EnableStudents_6a4deca8e030ebe34669fb0f`.
+
+```bash
+export SOURCE_USER_ID='<synthetic staging user.id>'
+
+PREFLIGHT=$(jq -nc --arg user "$SOURCE_USER_ID" --argjson config "$CONFIG_ID" \
+  '{records:[{record_ref:"staging-smoke",source_user_id:$user,source_record_type:"production",form_id:"6a44a83d1184e717b920c499",af_session_id:"EnableStudents_6a44a83d1184e717b920c499",entry_grade:11,answer_fingerprint:"staging-smoke-answers-v1",prompt_configuration_id:$config}]}' \
+  | curl -fsS -X POST -H "Authorization: Bearer $BEARER_TOKEN" \
+      -H 'content-type: application/json' \
+      "$BASE_URL/api/holistic-mentorship/profile-preflight" -d @-)
+
+STUDENT_ID=$(jq -er '.results[0].student_id' <<<"$PREFLIGHT")
+REVISION=$(jq -r '.results[0].profile_revision // "null"' <<<"$PREFLIGHT")
+```
+
+Queue and start a unique run, then publish exactly five summaries. Confirm the
+response and query the staging database for one parent at revision 1 with five
+children; that verifies the atomic publication boundary.
+
+```bash
+export ETL_RUN_ID="$SMOKE_ID"
+
+status_body() {
+  jq -nc --arg run "$ETL_RUN_ID" --arg state "$1" \
+    --argjson student "$STUDENT_ID" --argjson config "$CONFIG_ID" \
+    '{etl_run_id:$run,student_id:$student,form_id:"6a44a83d1184e717b920c499",af_session_id:"EnableStudents_6a44a83d1184e717b920c499",entry_grade:11,prompt_configuration_id:$config,state:$state}'
+}
+
+for state in queued running; do
+  status_body "$state" | curl -fsS -X POST \
+    -H "Authorization: Bearer $BEARER_TOKEN" -H 'content-type: application/json' \
+    "$BASE_URL/api/holistic-mentorship/profile-generation-statuses" -d @- \
+    | jq -e --arg state "$state" '.state == $state'
+done
+
+jq -nc --arg run "$ETL_RUN_ID" --arg user "$SOURCE_USER_ID" \
+  --argjson student "$STUDENT_ID" --argjson config "$CONFIG_ID" \
+  --argjson revision "$REVISION" \
+  '{etl_run_id:$run,student_id:$student,source_user_id:$user,form_id:"6a44a83d1184e717b920c499",af_session_id:"EnableStudents_6a44a83d1184e717b920c499",entry_grade:11,prompt_configuration_id:$config,schema_fingerprint:"staging-smoke-schema-v1",answer_fingerprint:"staging-smoke-answers-v1",warehouse_loaded_at:"2026-07-16T10:00:00Z",generated_at:"2026-07-16T10:05:00Z",expected_profile_revision:$revision,force:false,summaries:[range(1;6) as $n|{position:$n,question_set_title:("Question Set "+($n|tostring)),summary:("Smoke summary "+($n|tostring))}]}' \
+  | curl -fsS -X POST -H "Authorization: Bearer $BEARER_TOKEN" \
+      -H 'content-type: application/json' \
+      "$BASE_URL/api/holistic-mentorship/profiles/publish" -d @- \
+  | jq -e '.result == "published" or .result == "replaced"'
+
+psql "$STAGING_DATABASE_URL" -c \
+  "SELECT p.revision, count(s.id) FROM holistic_mentorship_student_profiles p JOIN holistic_mentorship_student_profile_summaries s ON s.student_profile_id=p.id WHERE p.last_successful_etl_run_id='$ETL_RUN_ID' GROUP BY p.id HAVING count(s.id)=5;"
+```
+
+For Student cleanup, create one active Mapping for a disposable synthetic
+Student, mutate the Student through the normal db-service API, and confirm in
+the same staging database that the canonical mutation committed, exactly that
+Mapping now has `ended_at`, `end_source = 'db_service_student_eligibility'`,
+the expected deterministic `end_reason`, and no replacement Mapping exists.
+
+```bash
+curl -fsS -X PUT -H "Authorization: Bearer $BEARER_TOKEN" \
+  -H 'content-type: application/json' "$BASE_URL/api/student/$STUDENT_ID" \
+  -d '{"status":"dropout"}' | jq -e '.status == "dropout"'
+
+psql "$STAGING_DATABASE_URL" -c \
+  "SELECT ended_at IS NOT NULL, end_source, end_reason FROM holistic_mentorship_mentor_mentee_mappings WHERE student_id=$STUDENT_ID ORDER BY started_at DESC LIMIT 1;"
+psql "$STAGING_DATABASE_URL" -c \
+  "SELECT count(*) FROM holistic_mentorship_mentor_mentee_mappings WHERE student_id=$STUDENT_ID AND ended_at IS NULL;"
+```
+
+Verify the sync guard before any production-to-staging refresh:
+
+```bash
+mix test test/dbservice/utils/fetch_data_script_test.exs
+```
+
+The command-fake test must show `--exclude-table-data=public.holistic_mentorship_*`
+for production-to-staging only. Production-to-local must remain available
+without that argument, and any production target must fail before `pg_dump` or
+`psql` runs.
+
+## Monitoring and reconciliation
+
+Monitor route, duration, HTTP status, correlation metadata, opaque `record_ref`,
+opaque request key, ETL run ID, safe state, and safe reason/error code only.
+Reconcile counts by those references and codes. Never emit source User IDs,
+canonical Student IDs, answers, template text, rendered prompts, summaries, or
+request bodies to logs, alerts, dashboards, or tickets.
+
+Alert on readiness failures, authentication failures above the expected probe
+baseline, elevated safe rejection/error codes, stuck `queued`/`running` states,
+and a production-to-staging sync whose captured `pg_dump` arguments lack the
+Holistic wildcard.
+
+## Application rollback
+
+1. Stop new `etl-next` Profile work and disable new `af_lms` Holistic writes.
+2. Retain the safe run/request references needed to reconcile in-flight work.
+3. Redeploy the prior known-good `af_lms`, `etl-next`, and db-service application
+   revisions, in that order where callers must be stopped before db-service.
+4. Recheck health, readiness, authentication isolation, and existing Profile
+   reads.
+5. Preserve all Holistic schema and data. Do not down-migrate populated tables;
+   forward-fix the application or apply a new additive migration.

--- a/docs/holistic_mentorship_rollout.md
+++ b/docs/holistic_mentorship_rollout.md
@@ -125,11 +125,12 @@ mix test test/dbservice/holistic_mentorship_privacy_schema_test.exs \
   test/dbservice_web/controllers/holistic_mentorship_regeneration_request_controller_test.exs
 ```
 
-For Student cleanup, create one active Mapping for a disposable synthetic
-Student, mutate the Student through the normal db-service API, and confirm in
-the same staging database that the canonical mutation committed, exactly that
-Mapping now has `ended_at`, `end_source = 'db_service_student_eligibility'`,
-the expected deterministic `end_reason`, and no replacement Mapping exists.
+For targeted Student status/Grade/dropout cleanup, create one active Mapping
+for a disposable synthetic Student, mutate the Student through the normal
+db-service API, and confirm in the same staging database that the canonical
+mutation committed, exactly that Mapping now has `ended_at`,
+`end_source = 'db_service_student_eligibility'`, the expected deterministic
+`end_reason`, and no replacement Mapping exists.
 
 ```bash
 curl -fsS -X PUT -H "Authorization: Bearer $BEARER_TOKEN" \
@@ -141,6 +142,11 @@ psql "$STAGING_DATABASE_URL" -c \
 psql "$STAGING_DATABASE_URL" -c \
   "SELECT count(*) FROM holistic_mentorship_mentor_mentee_mappings WHERE student_id=$STUDENT_ID AND ended_at IS NULL;"
 ```
+
+School and Program enrollment CRUD intentionally performs no Holistic query.
+For those changes, confirm the Mapping remains stored temporarily, then open
+the AF LMS Holistic roster or direct Student page and confirm AF LMS closes the
+stale row before returning protected data.
 
 Verify the sync guard before any production-to-staging refresh:
 

--- a/docs/holistic_mentorship_rollout.md
+++ b/docs/holistic_mentorship_rollout.md
@@ -24,6 +24,9 @@ staging migration workflow for this rollout.
 6. Deploy `af_lms` Holistic Mentorship workflows.
 
 Never run a down migration after Holistic Mentorship tables contain data.
+The privacy deletion migration is also additive: its one-per-Student tombstone
+and content guards must remain in place across application rollback so erased
+Profile or Notes content cannot be recreated.
 
 ## Staging smoke checks
 
@@ -109,6 +112,17 @@ jq -nc --arg run "$ETL_RUN_ID" --arg user "$SOURCE_USER_ID" \
 
 psql "$STAGING_DATABASE_URL" -c \
   "SELECT p.revision, count(s.id) FROM holistic_mentorship_student_profiles p JOIN holistic_mentorship_student_profile_summaries s ON s.student_profile_id=p.id WHERE p.last_successful_etl_run_id='$ETL_RUN_ID' GROUP BY p.id HAVING count(s.id)=5;"
+```
+
+Before enabling callers, run the privacy schema and Profile contract tests.
+They verify the unique immutable tombstone, guarded content tables, the
+`privacy_erased` Preflight result, and normal/forced publication rejection.
+
+```bash
+mix test test/dbservice/holistic_mentorship_privacy_schema_test.exs \
+  test/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller_test.exs \
+  test/dbservice_web/controllers/holistic_mentorship_profile_publish_controller_test.exs \
+  test/dbservice_web/controllers/holistic_mentorship_regeneration_request_controller_test.exs
 ```
 
 For Student cleanup, create one active Mapping for a disposable synthetic

--- a/lib/dbservice/enrollment_records.ex
+++ b/lib/dbservice/enrollment_records.ex
@@ -200,13 +200,22 @@ defmodule Dbservice.EnrollmentRecords do
   defp mutate_membership(user_ids, operation) do
     user_ids = user_ids |> Enum.reject(&is_nil/1) |> Enum.uniq()
 
+    if active_holistic_mapping?(user_ids) do
+      mutate_mapped_membership(user_ids, operation)
+    else
+      operation.()
+    end
+  end
+
+  defp mutate_mapped_membership(user_ids, operation) do
     Repo.transaction(fn ->
       before = Map.new(user_ids, &{&1, current_memberships(&1)})
 
       case operation.() do
         {:ok, result} ->
-          user_ids
-          |> Enum.each(fn user_id -> cleanup_membership_change(user_id, before[user_id]) end)
+          Enum.each(user_ids, fn user_id ->
+            cleanup_membership_change(user_id, before[user_id])
+          end)
 
           result
 
@@ -214,6 +223,15 @@ defmodule Dbservice.EnrollmentRecords do
           Repo.rollback(reason)
       end
     end)
+  end
+
+  defp active_holistic_mapping?(user_ids) do
+    Repo.exists?(
+      from student in Student,
+        join: mapping in "holistic_mentorship_mentor_mentee_mappings",
+        on: field(mapping, :student_id) == student.id,
+        where: student.user_id in ^user_ids and is_nil(field(mapping, :ended_at))
+    )
   end
 
   defp current_memberships(user_id) do

--- a/lib/dbservice/enrollment_records.ex
+++ b/lib/dbservice/enrollment_records.ex
@@ -8,9 +8,6 @@ defmodule Dbservice.EnrollmentRecords do
   alias Dbservice.Repo
 
   alias Dbservice.EnrollmentRecords.EnrollmentRecord
-  alias Dbservice.Users.Student
-
-  @holistic_membership_types ~w(program school)
 
   @doc """
   Returns the list of enrollment_record.
@@ -129,19 +126,9 @@ defmodule Dbservice.EnrollmentRecords do
 
   """
   def create_enrollment_record(attrs \\ %{}) do
-    enrollment_record = %EnrollmentRecord{}
-
-    if holistic_membership?(enrollment_record, attrs) do
-      mutate_membership([attr(attrs, :user_id)], fn ->
-        enrollment_record
-        |> EnrollmentRecord.changeset(attrs)
-        |> Repo.insert()
-      end)
-    else
-      enrollment_record
-      |> EnrollmentRecord.changeset(attrs)
-      |> Repo.insert()
-    end
+    %EnrollmentRecord{}
+    |> EnrollmentRecord.changeset(attrs)
+    |> Repo.insert()
   end
 
   @doc """
@@ -157,17 +144,9 @@ defmodule Dbservice.EnrollmentRecords do
 
   """
   def update_enrollment_record(%EnrollmentRecord{} = enrollment_record, attrs) do
-    if holistic_membership?(enrollment_record, attrs) do
-      mutate_membership([enrollment_record.user_id, attr(attrs, :user_id)], fn ->
-        enrollment_record
-        |> EnrollmentRecord.changeset(attrs)
-        |> Repo.update()
-      end)
-    else
-      enrollment_record
-      |> EnrollmentRecord.changeset(attrs)
-      |> Repo.update()
-    end
+    enrollment_record
+    |> EnrollmentRecord.changeset(attrs)
+    |> Repo.update()
   end
 
   @doc """
@@ -183,96 +162,7 @@ defmodule Dbservice.EnrollmentRecords do
 
   """
   def delete_enrollment_record(%EnrollmentRecord{} = enrollment_record) do
-    if enrollment_record.group_type in @holistic_membership_types do
-      mutate_membership([enrollment_record.user_id], fn -> Repo.delete(enrollment_record) end)
-    else
-      Repo.delete(enrollment_record)
-    end
-  end
-
-  defp holistic_membership?(enrollment_record, attrs) do
-    enrollment_record.group_type in @holistic_membership_types or
-      attr(attrs, :group_type) in @holistic_membership_types
-  end
-
-  defp attr(attrs, key), do: Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
-
-  defp mutate_membership(user_ids, operation) do
-    user_ids = user_ids |> Enum.reject(&is_nil/1) |> Enum.uniq()
-
-    if active_holistic_mapping?(user_ids) do
-      mutate_mapped_membership(user_ids, operation)
-    else
-      operation.()
-    end
-  end
-
-  defp mutate_mapped_membership(user_ids, operation) do
-    Repo.transaction(fn ->
-      before = Map.new(user_ids, &{&1, current_memberships(&1)})
-
-      case operation.() do
-        {:ok, result} ->
-          Enum.each(user_ids, fn user_id ->
-            cleanup_membership_change(user_id, before[user_id])
-          end)
-
-          result
-
-        {:error, reason} ->
-          Repo.rollback(reason)
-      end
-    end)
-  end
-
-  defp active_holistic_mapping?(user_ids) do
-    Repo.exists?(
-      from student in Student,
-        join: mapping in "holistic_mentorship_mentor_mentee_mappings",
-        on: field(mapping, :student_id) == student.id,
-        where: student.user_id in ^user_ids and is_nil(field(mapping, :ended_at))
-    )
-  end
-
-  defp current_memberships(user_id) do
-    Repo.one(from student in Student, where: student.user_id == ^user_id, lock: "FOR UPDATE")
-
-    from(enrollment in EnrollmentRecord,
-      where:
-        enrollment.user_id == ^user_id and enrollment.is_current and
-          enrollment.group_type in @holistic_membership_types,
-      select: {enrollment.group_type, enrollment.group_id}
-    )
-    |> Repo.all()
-    |> MapSet.new()
-  end
-
-  defp cleanup_membership_change(user_id, before) do
-    after_memberships = current_memberships(user_id)
-
-    reason =
-      cond do
-        membership_ids(before, "program") != membership_ids(after_memberships, "program") ->
-          :student_program_changed
-
-        membership_ids(before, "school") != membership_ids(after_memberships, "school") ->
-          :student_school_changed
-
-        true ->
-          nil
-      end
-
-    with reason when not is_nil(reason) <- reason,
-         %Student{id: student_id} <- Repo.get_by(Student, user_id: user_id),
-         {:error, error} <- Dbservice.HolisticMentorship.end_active_mappings(student_id, reason) do
-      Repo.rollback(error)
-    else
-      _ -> :ok
-    end
-  end
-
-  defp membership_ids(memberships, type) do
-    for {^type, id} <- memberships, into: MapSet.new(), do: id
+    Repo.delete(enrollment_record)
   end
 
   @doc """
@@ -317,12 +207,10 @@ defmodule Dbservice.EnrollmentRecords do
   logging/metrics or conditional logic.
   """
   def delete_all_by_user_id(user_id) do
-    mutate_membership([user_id], fn ->
-      {count, _} =
-        from(er in EnrollmentRecord, where: er.user_id == ^user_id) |> Repo.delete_all()
+    {count, _} =
+      from(er in EnrollmentRecord, where: er.user_id == ^user_id) |> Repo.delete_all()
 
-      {:ok, count}
-    end)
+    {:ok, count}
   end
 
   @doc """

--- a/lib/dbservice/enrollment_records.ex
+++ b/lib/dbservice/enrollment_records.ex
@@ -8,6 +8,9 @@ defmodule Dbservice.EnrollmentRecords do
   alias Dbservice.Repo
 
   alias Dbservice.EnrollmentRecords.EnrollmentRecord
+  alias Dbservice.Users.Student
+
+  @holistic_membership_types ~w(program school)
 
   @doc """
   Returns the list of enrollment_record.
@@ -126,9 +129,19 @@ defmodule Dbservice.EnrollmentRecords do
 
   """
   def create_enrollment_record(attrs \\ %{}) do
-    %EnrollmentRecord{}
-    |> EnrollmentRecord.changeset(attrs)
-    |> Repo.insert()
+    enrollment_record = %EnrollmentRecord{}
+
+    if holistic_membership?(enrollment_record, attrs) do
+      mutate_membership([attr(attrs, :user_id)], fn ->
+        enrollment_record
+        |> EnrollmentRecord.changeset(attrs)
+        |> Repo.insert()
+      end)
+    else
+      enrollment_record
+      |> EnrollmentRecord.changeset(attrs)
+      |> Repo.insert()
+    end
   end
 
   @doc """
@@ -144,9 +157,17 @@ defmodule Dbservice.EnrollmentRecords do
 
   """
   def update_enrollment_record(%EnrollmentRecord{} = enrollment_record, attrs) do
-    enrollment_record
-    |> EnrollmentRecord.changeset(attrs)
-    |> Repo.update()
+    if holistic_membership?(enrollment_record, attrs) do
+      mutate_membership([enrollment_record.user_id, attr(attrs, :user_id)], fn ->
+        enrollment_record
+        |> EnrollmentRecord.changeset(attrs)
+        |> Repo.update()
+      end)
+    else
+      enrollment_record
+      |> EnrollmentRecord.changeset(attrs)
+      |> Repo.update()
+    end
   end
 
   @doc """
@@ -162,7 +183,78 @@ defmodule Dbservice.EnrollmentRecords do
 
   """
   def delete_enrollment_record(%EnrollmentRecord{} = enrollment_record) do
-    Repo.delete(enrollment_record)
+    if enrollment_record.group_type in @holistic_membership_types do
+      mutate_membership([enrollment_record.user_id], fn -> Repo.delete(enrollment_record) end)
+    else
+      Repo.delete(enrollment_record)
+    end
+  end
+
+  defp holistic_membership?(enrollment_record, attrs) do
+    enrollment_record.group_type in @holistic_membership_types or
+      attr(attrs, :group_type) in @holistic_membership_types
+  end
+
+  defp attr(attrs, key), do: Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
+
+  defp mutate_membership(user_ids, operation) do
+    user_ids = user_ids |> Enum.reject(&is_nil/1) |> Enum.uniq()
+
+    Repo.transaction(fn ->
+      before = Map.new(user_ids, &{&1, current_memberships(&1)})
+
+      case operation.() do
+        {:ok, result} ->
+          user_ids
+          |> Enum.each(fn user_id -> cleanup_membership_change(user_id, before[user_id]) end)
+
+          result
+
+        {:error, reason} ->
+          Repo.rollback(reason)
+      end
+    end)
+  end
+
+  defp current_memberships(user_id) do
+    Repo.one(from student in Student, where: student.user_id == ^user_id, lock: "FOR UPDATE")
+
+    from(enrollment in EnrollmentRecord,
+      where:
+        enrollment.user_id == ^user_id and enrollment.is_current and
+          enrollment.group_type in @holistic_membership_types,
+      select: {enrollment.group_type, enrollment.group_id}
+    )
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
+  defp cleanup_membership_change(user_id, before) do
+    after_memberships = current_memberships(user_id)
+
+    reason =
+      cond do
+        membership_ids(before, "program") != membership_ids(after_memberships, "program") ->
+          :student_program_changed
+
+        membership_ids(before, "school") != membership_ids(after_memberships, "school") ->
+          :student_school_changed
+
+        true ->
+          nil
+      end
+
+    with reason when not is_nil(reason) <- reason,
+         %Student{id: student_id} <- Repo.get_by(Student, user_id: user_id),
+         {:error, error} <- Dbservice.HolisticMentorship.end_active_mappings(student_id, reason) do
+      Repo.rollback(error)
+    else
+      _ -> :ok
+    end
+  end
+
+  defp membership_ids(memberships, type) do
+    for {^type, id} <- memberships, into: MapSet.new(), do: id
   end
 
   @doc """
@@ -207,8 +299,12 @@ defmodule Dbservice.EnrollmentRecords do
   logging/metrics or conditional logic.
   """
   def delete_all_by_user_id(user_id) do
-    {count, _} = from(er in EnrollmentRecord, where: er.user_id == ^user_id) |> Repo.delete_all()
-    {:ok, count}
+    mutate_membership([user_id], fn ->
+      {count, _} =
+        from(er in EnrollmentRecord, where: er.user_id == ^user_id) |> Repo.delete_all()
+
+      {:ok, count}
+    end)
   end
 
   @doc """

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -94,26 +94,22 @@ defmodule Dbservice.HolisticMentorship do
     Postgrex.Error -> {:error, :invalid_request}
   end
 
-  defp publication_fields(
-         %{
-           "etl_run_id" => run_id,
-           "student_id" => student_id,
-           "source_user_id" => source_user_id,
-           "form_id" => form_id,
-           "af_session_id" => session_id,
-           "entry_grade" => grade,
-           "prompt_configuration_id" => configuration_id,
-           "schema_fingerprint" => schema_fingerprint,
-           "answer_fingerprint" => answer_fingerprint,
-           "warehouse_loaded_at" => warehouse_loaded_at,
-           "generated_at" => generated_at,
-           "expected_profile_revision" => expected_revision,
-           "force" => force,
-           "summaries" => summaries
-         } = params
-       ) do
-    request_key = params["regeneration_request_key"]
-
+  defp publication_fields(%{
+         "etl_run_id" => run_id,
+         "student_id" => student_id,
+         "source_user_id" => source_user_id,
+         "form_id" => form_id,
+         "af_session_id" => session_id,
+         "entry_grade" => grade,
+         "prompt_configuration_id" => configuration_id,
+         "schema_fingerprint" => schema_fingerprint,
+         "answer_fingerprint" => answer_fingerprint,
+         "warehouse_loaded_at" => warehouse_loaded_at,
+         "generated_at" => generated_at,
+         "expected_profile_revision" => expected_revision,
+         "force" => false,
+         "summaries" => summaries
+       }) do
     with {:ok, user_id} <- parse_source_user_id(source_user_id),
          {:ok, warehouse_loaded_at} <- parse_timestamp(warehouse_loaded_at),
          {:ok, generated_at} <- parse_timestamp(generated_at),
@@ -131,8 +127,6 @@ defmodule Dbservice.HolisticMentorship do
            warehouse_loaded_at: warehouse_loaded_at,
            generated_at: generated_at,
            expected_revision: expected_revision,
-           force: force,
-           regeneration_request_key: request_key,
            summaries: summaries
          },
          true <- valid_publication_fields?(fields) do
@@ -152,14 +146,9 @@ defmodule Dbservice.HolisticMentorship do
       bounded_string?(fields.schema_fingerprint, 255),
       bounded_string?(fields.answer_fingerprint, 255),
       is_nil(fields.expected_revision) or positive_integer?(fields.expected_revision),
-      valid_force?(fields.force, fields.regeneration_request_key),
       NaiveDateTime.compare(fields.generated_at, fields.warehouse_loaded_at) != :lt
     ])
   end
-
-  defp valid_force?(false, nil), do: true
-  defp valid_force?(true, request_key), do: present_string?(request_key)
-  defp valid_force?(_force, _request_key), do: false
 
   defp bounded_string?(value, maximum),
     do: is_binary(value) and byte_size(value) in 1..maximum
@@ -264,28 +253,23 @@ defmodule Dbservice.HolisticMentorship do
   end
 
   defp publish_running_profile!(journey_id, fields) do
-    validate_regeneration_request!(fields)
-
     case current_profile(journey_id, fields.configuration_id) do
       nil when is_nil(fields.expected_revision) ->
         profile_id = insert_profile!(journey_id, fields)
         insert_profile_summaries!(profile_id, fields.summaries)
         complete_generation_status!(fields, "published")
-        complete_regeneration_request!(fields)
         %{result: "published", revision: 1}
 
       {_profile_id, answer_fingerprint, revision}
       when revision == fields.expected_revision and
-             answer_fingerprint == fields.answer_fingerprint and not fields.force ->
+             answer_fingerprint == fields.answer_fingerprint ->
         complete_generation_status!(fields, "unchanged")
-        complete_regeneration_request!(fields)
         %{result: "unchanged", revision: revision}
 
       {profile_id, _answer_fingerprint, revision} when revision == fields.expected_revision ->
         revision = revision + 1
         replace_profile!(profile_id, fields, revision)
         complete_generation_status!(fields, "replaced")
-        complete_regeneration_request!(fields)
         %{result: "replaced", revision: revision}
 
       _ ->
@@ -400,32 +384,6 @@ defmodule Dbservice.HolisticMentorship do
     end
   end
 
-  defp validate_regeneration_request!(%{force: false}), do: :ok
-
-  defp validate_regeneration_request!(fields) do
-    case Repo.query!(
-           """
-           SELECT id
-           FROM holistic_mentorship_regeneration_requests
-           WHERE request_key = $1 AND student_id = $2 AND prompt_configuration_id = $3
-             AND force
-             AND ((state = 'queued' AND etl_run_id IS NULL)
-                  OR (state = 'running' AND etl_run_id = $4))
-           FOR UPDATE
-           """,
-           [
-             fields.regeneration_request_key,
-             fields.student_id,
-             fields.configuration_id,
-             fields.run_id
-           ],
-           log: false
-         ).rows do
-      [[_id]] -> :ok
-      [] -> Repo.rollback(:invalid_request)
-    end
-  end
-
   defp generation_status_row(fields) do
     Repo.query!(
       """
@@ -469,20 +427,6 @@ defmodule Dbservice.HolisticMentorship do
       WHERE id = $1
       """,
       [generation_status_row(fields) |> hd() |> hd(), outcome],
-      log: false
-    )
-  end
-
-  defp complete_regeneration_request!(%{force: false}), do: :ok
-
-  defp complete_regeneration_request!(fields) do
-    Repo.query!(
-      """
-      UPDATE holistic_mentorship_regeneration_requests
-      SET state = 'completed', etl_run_id = $2, updated_at = now()
-      WHERE request_key = $1
-      """,
-      [fields.regeneration_request_key, fields.run_id],
       log: false
     )
   end

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -110,7 +110,7 @@ defmodule Dbservice.HolisticMentorship do
          "force" => false,
          "summaries" => summaries
        }) do
-    with {:ok, user_id} <- parse_source_user_id(source_user_id),
+    with {:ok, user_id} <- source_user_id(%{"source_user_id" => source_user_id}),
          {:ok, warehouse_loaded_at} <- parse_timestamp(warehouse_loaded_at),
          {:ok, generated_at} <- parse_timestamp(generated_at),
          :ok <- valid_summaries(summaries),
@@ -152,15 +152,6 @@ defmodule Dbservice.HolisticMentorship do
 
   defp bounded_string?(value, maximum),
     do: is_binary(value) and byte_size(value) in 1..maximum
-
-  defp parse_source_user_id(value) do
-    case Integer.parse(value) do
-      {id, ""} when id > 0 and id <= 2_147_483_647 -> {:ok, id}
-      _ -> {:error, :invalid_request}
-    end
-  rescue
-    ArgumentError -> {:error, :invalid_request}
-  end
 
   defp parse_timestamp(value) when is_binary(value) do
     case DateTime.from_iso8601(value) do
@@ -234,17 +225,17 @@ defmodule Dbservice.HolisticMentorship do
       journey_id = insert_profile_journey!(fields)
 
       case generation_status_row(fields) do
-        [[_id, "completed", outcome]] ->
+        [[_id, "completed", outcome, revision]] when is_integer(revision) ->
           case current_profile(journey_id, fields.configuration_id) do
-            {_profile_id, _fingerprint, revision} ->
+            {_profile_id, _fingerprint, _current_revision} ->
               %{result: outcome, revision: revision}
 
             nil ->
               Repo.rollback(:invalid_request)
           end
 
-        [[_id, "running", nil]] ->
-          publish_running_profile!(journey_id, fields)
+        [[status_id, "running", nil, nil]] ->
+          publish_running_profile!(journey_id, status_id, fields)
 
         _ ->
           Repo.rollback(:invalid_request)
@@ -252,24 +243,24 @@ defmodule Dbservice.HolisticMentorship do
     end)
   end
 
-  defp publish_running_profile!(journey_id, fields) do
+  defp publish_running_profile!(journey_id, status_id, fields) do
     case current_profile(journey_id, fields.configuration_id) do
       nil when is_nil(fields.expected_revision) ->
         profile_id = insert_profile!(journey_id, fields)
         insert_profile_summaries!(profile_id, fields.summaries)
-        complete_generation_status!(fields, "published")
+        complete_generation_status!(status_id, "published", 1)
         %{result: "published", revision: 1}
 
       {_profile_id, answer_fingerprint, revision}
       when revision == fields.expected_revision and
              answer_fingerprint == fields.answer_fingerprint ->
-        complete_generation_status!(fields, "unchanged")
+        complete_generation_status!(status_id, "unchanged", revision)
         %{result: "unchanged", revision: revision}
 
       {profile_id, _answer_fingerprint, revision} when revision == fields.expected_revision ->
         revision = revision + 1
         replace_profile!(profile_id, fields, revision)
-        complete_generation_status!(fields, "replaced")
+        complete_generation_status!(status_id, "replaced", revision)
         %{result: "replaced", revision: revision}
 
       _ ->
@@ -387,7 +378,7 @@ defmodule Dbservice.HolisticMentorship do
   defp generation_status_row(fields) do
     Repo.query!(
       """
-      SELECT id, state, completed_outcome
+      SELECT id, state, completed_outcome, completed_profile_revision
       FROM holistic_mentorship_profile_generation_statuses
       WHERE etl_run_id = $1 AND student_id = $2 AND form_id = $3
         AND af_session_id = $4 AND entry_grade = $5 AND prompt_configuration_id = $6
@@ -419,14 +410,15 @@ defmodule Dbservice.HolisticMentorship do
     end)
   end
 
-  defp complete_generation_status!(fields, outcome) do
+  defp complete_generation_status!(status_id, outcome, revision) do
     Repo.query!(
       """
       UPDATE holistic_mentorship_profile_generation_statuses
-      SET state = 'completed', completed_outcome = $2, updated_at = now()
+      SET state = 'completed', completed_outcome = $2, completed_profile_revision = $3,
+          updated_at = now()
       WHERE id = $1
       """,
-      [generation_status_row(fields) |> hd() |> hd(), outcome],
+      [status_id, outcome, revision],
       log: false
     )
   end

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -86,6 +86,147 @@ defmodule Dbservice.HolisticMentorship do
     end
   end
 
+  def get_regeneration_request(request_key) when is_binary(request_key) do
+    case Repo.query!(
+           """
+           SELECT request.student_id, student.user_id, request.prompt_configuration_id,
+                  request.force, request.state, request.etl_run_id
+           FROM holistic_mentorship_regeneration_requests AS request
+           JOIN student ON student.id = request.student_id
+           WHERE request.request_key = $1
+           """,
+           [request_key],
+           log: false
+         ).rows do
+      [[student_id, user_id, configuration_id, force, state, etl_run_id]] ->
+        with :ok <- eligible_student(student_id, user_id) do
+          {:ok,
+           %{
+             student_id: student_id,
+             prompt_configuration_id: configuration_id,
+             force: force,
+             state: state,
+             etl_run_id: etl_run_id
+           }}
+        end
+
+      [] ->
+        {:error, :regeneration_request_not_found}
+    end
+  end
+
+  def get_regeneration_request(_request_key), do: {:error, :regeneration_request_not_found}
+
+  def update_regeneration_request_status(request_key, params) when is_binary(request_key) do
+    with {:ok, fields} <- regeneration_status_fields(params) do
+      Repo.transaction(fn -> transition_regeneration_request!(request_key, fields) end)
+    end
+  end
+
+  def update_regeneration_request_status(_request_key, _params), do: {:error, :invalid_request}
+
+  defp regeneration_status_fields(%{"etl_run_id" => run_id, "state" => state} = params) do
+    error_code = params["error_code"]
+    error_message = params["error_message"]
+
+    valid_result =
+      case state do
+        state when state in ["running", "completed"] ->
+          is_nil(error_code) and is_nil(error_message)
+
+        "failed" ->
+          bounded_optional_string?(error_code, 64) and
+            bounded_optional_string?(error_message, 500)
+
+        _ ->
+          false
+      end
+
+    if present_string?(run_id) and valid_result,
+      do: {:ok, {run_id, state, error_code, error_message}},
+      else: {:error, :invalid_request}
+  end
+
+  defp regeneration_status_fields(_params), do: {:error, :invalid_request}
+
+  defp transition_regeneration_request!(request_key, fields) when is_binary(request_key) do
+    case Repo.query!(
+           """
+           SELECT id, state, etl_run_id, error_code, error_message
+           FROM holistic_mentorship_regeneration_requests
+           WHERE request_key = $1
+           FOR UPDATE
+           """,
+           [request_key],
+           log: false
+         ).rows do
+      [[id, state, run_id, error_code, error_message]] ->
+        transition_regeneration_request!(
+          {id, state, run_id, error_code, error_message},
+          fields
+        )
+
+      [] ->
+        Repo.rollback(:regeneration_request_not_found)
+    end
+  end
+
+  defp transition_regeneration_request!(
+         {_id, state, run_id, error_code, error_message},
+         {run_id, state, error_code, error_message}
+       ),
+       do: regeneration_status_response(state, run_id, error_code, error_message)
+
+  defp transition_regeneration_request!({_id, _state, run_id, _, _}, {other_run_id, _, _, _})
+       when not is_nil(run_id) and run_id != other_run_id,
+       do: Repo.rollback(:etl_run_conflict)
+
+  defp transition_regeneration_request!(
+         {id, "queued", nil, nil, nil},
+         {run_id, "running", nil, nil}
+       ),
+       do: update_regeneration_request!(id, "running", run_id, nil, nil)
+
+  defp transition_regeneration_request!(
+         {id, "running", run_id, nil, nil},
+         {run_id, state, error_code, error_message}
+       )
+       when state in ["completed", "failed"],
+       do: update_regeneration_request!(id, state, run_id, error_code, error_message)
+
+  defp transition_regeneration_request!({_, state, _, _, _}, _fields)
+       when state in ["completed", "failed"],
+       do: Repo.rollback(:terminal_status_conflict)
+
+  defp transition_regeneration_request!(_request, _fields),
+    do: Repo.rollback(:invalid_transition)
+
+  defp update_regeneration_request!(id, state, run_id, error_code, error_message) do
+    [[state, run_id, error_code, error_message]] =
+      Repo.query!(
+        """
+        UPDATE holistic_mentorship_regeneration_requests
+        SET state = $2, etl_run_id = $3, error_code = $4, error_message = $5,
+            updated_at = now()
+        WHERE id = $1
+        RETURNING state, etl_run_id, error_code, error_message
+        """,
+        [id, state, run_id, error_code, error_message],
+        log: false
+      ).rows
+
+    regeneration_status_response(state, run_id, error_code, error_message)
+  end
+
+  defp regeneration_status_response(state, run_id, error_code, error_message) do
+    %{
+      state: state,
+      etl_run_id: run_id,
+      error_code: error_code,
+      error_message: error_message
+    }
+  end
+
   defp generation_status_references_exist({_, student_id, _, _, _, configuration_id, _, _, _, _}) do
     case Repo.query!(
            """

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -79,6 +79,204 @@ defmodule Dbservice.HolisticMentorship do
     end)
   end
 
+  def record_profile_generation_status(params) do
+    with {:ok, fields} <- generation_status_fields(params),
+         :ok <- generation_status_references_exist(fields) do
+      persist_generation_status(fields)
+    end
+  end
+
+  defp generation_status_references_exist({_, student_id, _, _, _, configuration_id, _, _, _, _}) do
+    case Repo.query!(
+           """
+           SELECT EXISTS(SELECT 1 FROM student WHERE id = $1),
+                  EXISTS(SELECT 1 FROM holistic_mentorship_prompt_configurations WHERE id = $2)
+           """,
+           [student_id, configuration_id],
+           log: false
+         ).rows do
+      [[true, true]] -> :ok
+      _ -> {:error, :invalid_request}
+    end
+  end
+
+  defp generation_status_fields(
+         %{
+           "etl_run_id" => etl_run_id,
+           "student_id" => student_id,
+           "form_id" => form_id,
+           "af_session_id" => af_session_id,
+           "entry_grade" => entry_grade,
+           "prompt_configuration_id" => configuration_id,
+           "state" => state
+         } = params
+       ) do
+    outcome = params["completed_outcome"]
+    error_code = params["error_code"]
+    error_message = params["error_message"]
+
+    if valid_generation_identity?(
+         etl_run_id,
+         student_id,
+         form_id,
+         af_session_id,
+         entry_grade,
+         configuration_id,
+         state
+       ) and
+         valid_generation_result?(state, outcome, error_code, error_message) do
+      {:ok,
+       {etl_run_id, student_id, form_id, af_session_id, entry_grade, configuration_id, state,
+        outcome, error_code, error_message}}
+    else
+      {:error, :invalid_request}
+    end
+  end
+
+  defp generation_status_fields(_params), do: {:error, :invalid_request}
+
+  defp valid_generation_identity?(
+         run_id,
+         student_id,
+         form_id,
+         session_id,
+         grade,
+         configuration_id,
+         state
+       ) do
+    Enum.all?([
+      present_string?(run_id),
+      positive_integer?(student_id),
+      Map.has_key?(@approved_profile_sources, {form_id, session_id, grade}),
+      positive_integer?(configuration_id),
+      state in ["queued", "running", "completed", "failed"]
+    ])
+  end
+
+  defp present_string?(value), do: is_binary(value) and value != ""
+  defp positive_integer?(value), do: is_integer(value) and value > 0
+
+  defp valid_generation_result?("completed", outcome, nil, nil),
+    do: outcome in ["published", "replaced", "unchanged"]
+
+  defp valid_generation_result?("failed", nil, error_code, error_message),
+    do: bounded_optional_string?(error_code, 64) and bounded_optional_string?(error_message, 500)
+
+  defp valid_generation_result?(state, nil, nil, nil) when state in ["queued", "running"],
+    do: true
+
+  defp valid_generation_result?(_state, _outcome, _error_code, _error_message), do: false
+
+  defp bounded_optional_string?(nil, _maximum), do: true
+
+  defp bounded_optional_string?(value, maximum),
+    do: is_binary(value) and byte_size(value) in 1..maximum
+
+  defp persist_generation_status(fields) do
+    Repo.transaction(fn ->
+      case generation_status(fields) do
+        nil -> insert_generation_status!(fields)
+        status -> transition_generation_status!(status, fields)
+      end
+    end)
+  end
+
+  defp generation_status(
+         {run_id, student_id, form_id, session_id, grade, configuration_id, _, _, _, _}
+       ) do
+    case Repo.query!(
+           """
+           SELECT id, state, completed_outcome, error_code, error_message
+           FROM holistic_mentorship_profile_generation_statuses
+           WHERE etl_run_id = $1 AND student_id = $2 AND form_id = $3
+             AND af_session_id = $4 AND entry_grade = $5 AND prompt_configuration_id = $6
+           FOR UPDATE
+           """,
+           [run_id, student_id, form_id, session_id, grade, configuration_id],
+           log: false
+         ).rows do
+      [[id, state, outcome, error_code, error_message]] ->
+        {id, state, outcome, error_code, error_message}
+
+      [] ->
+        nil
+    end
+  end
+
+  defp insert_generation_status!(
+         {run_id, student_id, form_id, session_id, grade, configuration_id, "queued", nil, nil,
+          nil}
+       ) do
+    [[state, outcome, error_code, error_message]] =
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_profile_generation_statuses
+          (etl_run_id, student_id, form_id, af_session_id, entry_grade,
+           prompt_configuration_id, state)
+        VALUES ($1, $2, $3, $4, $5, $6, 'queued')
+        RETURNING state, completed_outcome, error_code, error_message
+        """,
+        [run_id, student_id, form_id, session_id, grade, configuration_id],
+        log: false
+      ).rows
+
+    generation_status_response(state, outcome, error_code, error_message)
+  end
+
+  defp insert_generation_status!(_fields), do: Repo.rollback(:invalid_transition)
+
+  defp transition_generation_status!(
+         {_id, current_state, current_outcome, current_code, current_message},
+         {_, _, _, _, _, _, current_state, current_outcome, current_code, current_message}
+       ),
+       do:
+         generation_status_response(current_state, current_outcome, current_code, current_message)
+
+  defp transition_generation_status!(
+         {id, "queued", nil, nil, nil},
+         {_, _, _, _, _, _, "running", nil, nil, nil}
+       ),
+       do: update_generation_status!(id, "running", nil, nil, nil)
+
+  defp transition_generation_status!(
+         {id, "running", nil, nil, nil},
+         {_, _, _, _, _, _, state, outcome, error_code, error_message}
+       )
+       when state in ["completed", "failed"],
+       do: update_generation_status!(id, state, outcome, error_code, error_message)
+
+  defp transition_generation_status!({_, state, _, _, _}, _fields)
+       when state in ["completed", "failed"],
+       do: Repo.rollback(:terminal_status_conflict)
+
+  defp transition_generation_status!(_status, _fields), do: Repo.rollback(:invalid_transition)
+
+  defp update_generation_status!(id, state, outcome, error_code, error_message) do
+    [[state, outcome, error_code, error_message]] =
+      Repo.query!(
+        """
+        UPDATE holistic_mentorship_profile_generation_statuses
+        SET state = $2, completed_outcome = $3, error_code = $4, error_message = $5,
+            updated_at = now()
+        WHERE id = $1
+        RETURNING state, completed_outcome, error_code, error_message
+        """,
+        [id, state, outcome, error_code, error_message],
+        log: false
+      ).rows
+
+    generation_status_response(state, outcome, error_code, error_message)
+  end
+
+  defp generation_status_response(state, outcome, error_code, error_message) do
+    %{
+      state: state,
+      completed_outcome: outcome,
+      error_code: error_code,
+      error_message: error_message
+    }
+  end
+
   defp prompt_fields(%{
          "prompt_version" => version,
          "template_text" => template_text,

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -313,11 +313,11 @@ defmodule Dbservice.HolisticMentorship do
            log: false
          ).rows do
       [[id, _student_id, _configuration_id, true, "queued", nil]] ->
-        %{request_id: id, request_state: :active}
+        %{request_id: id, request_state: :queued}
 
       [[id, _student_id, _configuration_id, true, "running", run_id]]
       when run_id == fields.run_id ->
-        %{request_id: id, request_state: :active}
+        %{request_id: id, request_state: :running}
 
       [[id, _student_id, _configuration_id, true, "completed", run_id]]
       when run_id == fields.run_id ->
@@ -490,18 +490,11 @@ defmodule Dbservice.HolisticMentorship do
     complete_generation_status!(status_id, outcome, revision)
 
     if fields.request_id do
-      case Repo.query!(
-             """
-             UPDATE holistic_mentorship_regeneration_requests
-             SET state = 'completed', etl_run_id = $2, updated_at = now()
-             WHERE id = $1
-             """,
-             [fields.request_id, fields.run_id],
-             log: false
-           ).num_rows do
-        1 -> :ok
-        _ -> Repo.rollback(:invalid_request)
+      if fields.request_state == :queued do
+        update_regeneration_request!(fields.request_id, "running", fields.run_id, nil, nil)
       end
+
+      update_regeneration_request!(fields.request_id, "completed", fields.run_id, nil, nil)
     end
   end
 
@@ -621,20 +614,23 @@ defmodule Dbservice.HolisticMentorship do
     do: Repo.rollback(:invalid_transition)
 
   defp update_regeneration_request!(id, state, run_id, error_code, error_message) do
-    [[state, run_id, error_code, error_message]] =
-      Repo.query!(
-        """
-        UPDATE holistic_mentorship_regeneration_requests
-        SET state = $2, etl_run_id = $3, error_code = $4, error_message = $5,
-            updated_at = now()
-        WHERE id = $1
-        RETURNING state, etl_run_id, error_code, error_message
-        """,
-        [id, state, run_id, error_code, error_message],
-        log: false
-      ).rows
+    case Repo.query!(
+           """
+           UPDATE holistic_mentorship_regeneration_requests
+           SET state = $2, etl_run_id = $3, error_code = $4, error_message = $5,
+               updated_at = now()
+           WHERE id = $1
+           RETURNING state, etl_run_id, error_code, error_message
+           """,
+           [id, state, run_id, error_code, error_message],
+           log: false
+         ).rows do
+      [[state, run_id, error_code, error_message]] ->
+        regeneration_status_response(state, run_id, error_code, error_message)
 
-    regeneration_status_response(state, run_id, error_code, error_message)
+      _ ->
+        Repo.rollback(:invalid_request)
+    end
   end
 
   defp regeneration_status_response(state, run_id, error_code, error_message) do

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -11,6 +11,13 @@ defmodule Dbservice.HolisticMentorship do
     {"6a44a83d1184e717b920c499", "EnableStudents_6a44a83d1184e717b920c499", 11} => true,
     {"6a4deca8e030ebe34669fb0f", "EnableStudents_6a4deca8e030ebe34669fb0f", 12} => true
   }
+  @invalid_publication_database_codes [
+    :check_violation,
+    :foreign_key_violation,
+    :not_null_violation,
+    :string_data_right_truncation,
+    :unique_violation
+  ]
 
   def end_active_mappings(student_id, reason) when reason in @eligibility_end_reasons do
     reason = Atom.to_string(reason)
@@ -94,8 +101,15 @@ defmodule Dbservice.HolisticMentorship do
       persist_profile_publication(fields)
     end
   rescue
-    Postgrex.Error -> {:error, :invalid_request}
+    error in Postgrex.Error -> publication_database_error(error)
   end
+
+  defp publication_database_error(%Postgrex.Error{postgres: %{code: code}})
+       when code in @invalid_publication_database_codes,
+       do: {:error, :invalid_request}
+
+  defp publication_database_error(%Postgrex.Error{}),
+    do: {:error, :database_temporarily_unavailable}
 
   defp publication_fields(
          %{

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -36,7 +36,9 @@ defmodule Dbservice.HolisticMentorship do
   def end_active_mappings(_student_id, _reason), do: {:error, :invalid_end_reason}
 
   def profile_preflight(records) do
-    Enum.map(records, &preflight_record/1)
+    if Enum.all?(records, &valid_preflight_record?/1),
+      do: {:ok, Enum.map(records, &preflight_record/1)},
+      else: {:error, :invalid_request}
   end
 
   def register_prompt_configuration(params) do
@@ -702,7 +704,7 @@ defmodule Dbservice.HolisticMentorship do
          state
        ) do
     Enum.all?([
-      present_string?(run_id),
+      bounded_string?(run_id, 255),
       positive_integer?(student_id),
       Map.has_key?(@approved_profile_sources, {form_id, session_id, grade}),
       positive_integer?(configuration_id),
@@ -847,9 +849,10 @@ defmodule Dbservice.HolisticMentorship do
        }) do
     fields = {version, template_text, template_hash, model_id}
 
-    if fields |> Tuple.to_list() |> Enum.all?(&(is_binary(&1) and &1 != "")),
-      do: {:ok, fields},
-      else: {:error, :invalid_request}
+    if bounded_string?(version, 255) and present_string?(template_text) and
+         bounded_string?(template_hash, 64) and bounded_string?(model_id, 255),
+       do: {:ok, fields},
+       else: {:error, :invalid_request}
   end
 
   defp prompt_fields(_params), do: {:error, :invalid_request}
@@ -942,6 +945,14 @@ defmodule Dbservice.HolisticMentorship do
   end
 
   defp sha256(value), do: :crypto.hash(:sha256, value) |> Base.encode16(case: :lower)
+
+  defp valid_preflight_record?(%{
+         "record_ref" => record_ref,
+         "answer_fingerprint" => answer_fingerprint
+       }),
+       do: bounded_string?(record_ref, 255) and bounded_string?(answer_fingerprint, 255)
+
+  defp valid_preflight_record?(_record), do: false
 
   defp preflight_record(record) do
     record_ref = record["record_ref"]

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -504,21 +504,44 @@ defmodule Dbservice.HolisticMentorship do
   def get_regeneration_request(request_key) when is_binary(request_key) do
     case Repo.query!(
            """
-           SELECT request.student_id, student.user_id, request.prompt_configuration_id,
-                  request.force, request.state, request.etl_run_id
+           SELECT request.request_key, request.student_id, student.user_id,
+                  request.prompt_configuration_id, request.force, request.state,
+                  request.etl_run_id, version.version, version.template_hash,
+                  configuration.model_id
            FROM holistic_mentorship_regeneration_requests AS request
            JOIN student ON student.id = request.student_id
+           JOIN holistic_mentorship_prompt_configurations AS configuration
+             ON configuration.id = request.prompt_configuration_id
+           JOIN holistic_mentorship_prompt_versions AS version
+             ON version.id = configuration.prompt_version_id
            WHERE request.request_key = $1
            """,
            [request_key],
            log: false
          ).rows do
-      [[student_id, user_id, configuration_id, force, state, etl_run_id]] ->
+      [
+        [
+          request_key,
+          student_id,
+          user_id,
+          configuration_id,
+          force,
+          state,
+          etl_run_id,
+          prompt_version,
+          template_hash,
+          model_id
+        ]
+      ] ->
         with :ok <- eligible_student(student_id, user_id) do
           {:ok,
            %{
+             request_key: request_key,
              student_id: student_id,
              prompt_configuration_id: configuration_id,
+             prompt_version: prompt_version,
+             template_hash: template_hash,
+             model_id: model_id,
              force: force,
              state: state,
              etl_run_id: etl_run_id
@@ -546,7 +569,7 @@ defmodule Dbservice.HolisticMentorship do
 
     valid_result =
       case state do
-        state when state in ["running", "completed"] ->
+        state when state in ["queued", "running", "completed"] ->
           is_nil(error_code) and is_nil(error_message)
 
         "failed" ->
@@ -598,9 +621,27 @@ defmodule Dbservice.HolisticMentorship do
 
   defp transition_regeneration_request!(
          {id, "queued", nil, nil, nil},
+         {run_id, "queued", nil, nil}
+       ),
+       do: update_regeneration_request!(id, "queued", run_id, nil, nil)
+
+  defp transition_regeneration_request!(
+         {id, "queued", nil, nil, nil},
          {run_id, "running", nil, nil}
        ),
        do: update_regeneration_request!(id, "running", run_id, nil, nil)
+
+  defp transition_regeneration_request!(
+         {id, "queued", run_id, nil, nil},
+         {run_id, "running", nil, nil}
+       ),
+       do: update_regeneration_request!(id, "running", run_id, nil, nil)
+
+  defp transition_regeneration_request!(
+         {id, "queued", run_id, nil, nil},
+         {run_id, "failed", error_code, error_message}
+       ),
+       do: update_regeneration_request!(id, "failed", run_id, error_code, error_message)
 
   defp transition_regeneration_request!(
          {id, "running", run_id, nil, nil},

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -191,14 +191,22 @@ defmodule Dbservice.HolisticMentorship do
          :ok <- user_exists(user_id),
          {:ok, student_id} <- student_id(user_id),
          :ok <- approved_profile_source(record),
+         {:ok, journey_id} <- matching_profile_journey(student_id, record),
          :ok <- prompt_configuration_exists(record["prompt_configuration_id"]),
          :ok <- eligible_student(student_id, user_id) do
+      {profile_state, profile_revision} =
+        profile_state(
+          journey_id,
+          record["prompt_configuration_id"],
+          record["answer_fingerprint"]
+        )
+
       %{
         record_ref: record_ref,
         student_id: student_id,
         prompt_configuration_id: record["prompt_configuration_id"],
-        profile_state: "missing",
-        profile_revision: nil
+        profile_state: profile_state,
+        profile_revision: profile_revision
       }
     else
       {:error, reason_code} -> rejected(record_ref, reason_code)
@@ -244,6 +252,50 @@ defmodule Dbservice.HolisticMentorship do
 
       true ->
         {:error, :form_not_approved}
+    end
+  end
+
+  defp matching_profile_journey(student_id, record) do
+    form_id = record["form_id"]
+    af_session_id = record["af_session_id"]
+    entry_grade = record["entry_grade"]
+
+    case Repo.query!(
+           """
+           SELECT id, form_id, af_session_id, entry_grade
+           FROM holistic_mentorship_profile_journeys
+           WHERE student_id = $1
+           """,
+           [student_id],
+           log: false
+         ).rows do
+      [] ->
+        {:ok, nil}
+
+      [[journey_id, ^form_id, ^af_session_id, ^entry_grade]] ->
+        {:ok, journey_id}
+
+      _ ->
+        {:error, :journey_source_conflict}
+    end
+  end
+
+  defp profile_state(nil, _prompt_configuration_id, _answer_fingerprint),
+    do: {"missing", nil}
+
+  defp profile_state(journey_id, prompt_configuration_id, answer_fingerprint) do
+    case Repo.query!(
+           """
+           SELECT answer_fingerprint, revision
+           FROM holistic_mentorship_student_profiles
+           WHERE profile_journey_id = $1 AND prompt_configuration_id = $2
+           """,
+           [journey_id, prompt_configuration_id],
+           log: false
+         ).rows do
+      [] -> {"missing", nil}
+      [[^answer_fingerprint, revision]] -> {"unchanged", revision}
+      [[_stored_answer_fingerprint, revision]] -> {"changed_answers", revision}
     end
   end
 

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -1099,7 +1099,6 @@ defmodule Dbservice.HolisticMentorship do
 
     with :ok <- not_dropout(status),
          :ok <- eligible_grade_number(grade_number),
-         :ok <- eligible_program(user_id),
          :ok <- eligible_school(user_id) do
       consistent_grade(user_id, grade_id)
     end
@@ -1110,15 +1109,6 @@ defmodule Dbservice.HolisticMentorship do
 
   defp eligible_grade_number(grade_number) when grade_number in [11, 12], do: :ok
   defp eligible_grade_number(_grade_number), do: {:error, :grade_ineligible}
-
-  defp eligible_program(user_id) do
-    case current_enrollment_ids(user_id, "program") do
-      [[1]] -> :ok
-      [] -> {:error, :program_ineligible}
-      [[_other_program_id]] -> {:error, :program_ineligible}
-      _ -> {:error, :eligibility_inconsistent}
-    end
-  end
 
   defp eligible_school(user_id) do
     case Repo.query!(

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -1,0 +1,32 @@
+defmodule Dbservice.HolisticMentorship do
+  @moduledoc false
+
+  import Ecto.Query
+
+  alias Dbservice.Repo
+
+  @mapping_table "holistic_mentorship_mentor_mentee_mappings"
+  @eligibility_end_reasons ~w(student_dropout student_program_changed student_school_changed student_grade_changed)a
+
+  def end_active_mappings(student_id, reason) when reason in @eligibility_end_reasons do
+    ended_at = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+    {count, _} =
+      from(mapping in @mapping_table,
+        where: field(mapping, :student_id) == ^student_id and is_nil(field(mapping, :ended_at))
+      )
+      |> Repo.update_all(
+        set: [
+          ended_at: ended_at,
+          ended_by_user_id: nil,
+          end_source: "db_service_student_eligibility",
+          end_reason: Atom.to_string(reason),
+          updated_at: ended_at
+        ]
+      )
+
+    {:ok, count}
+  end
+
+  def end_active_mappings(_student_id, _reason), do: {:error, :invalid_end_reason}
+end

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -7,6 +7,10 @@ defmodule Dbservice.HolisticMentorship do
 
   @mapping_table "holistic_mentorship_mentor_mentee_mappings"
   @eligibility_end_reasons ~w(student_dropout student_program_changed student_school_changed student_grade_changed)a
+  @approved_profile_sources %{
+    {"6a44a83d1184e717b920c499", "EnableStudents_6a44a83d1184e717b920c499", 11} => true,
+    {"6a4deca8e030ebe34669fb0f", "EnableStudents_6a4deca8e030ebe34669fb0f", 12} => true
+  }
 
   def end_active_mappings(student_id, reason) when reason in @eligibility_end_reasons do
     ended_at = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
@@ -29,6 +33,10 @@ defmodule Dbservice.HolisticMentorship do
   end
 
   def end_active_mappings(_student_id, _reason), do: {:error, :invalid_end_reason}
+
+  def profile_preflight(records) do
+    Enum.map(records, &preflight_record/1)
+  end
 
   def register_prompt_configuration(params) do
     with {:ok, fields} <- prompt_fields(params),
@@ -174,4 +182,155 @@ defmodule Dbservice.HolisticMentorship do
   end
 
   defp sha256(value), do: :crypto.hash(:sha256, value) |> Base.encode16(case: :lower)
+
+  defp preflight_record(record) do
+    record_ref = record["record_ref"]
+
+    with :ok <- production_record(record),
+         {:ok, user_id} <- source_user_id(record),
+         :ok <- user_exists(user_id),
+         {:ok, student_id} <- student_id(user_id),
+         :ok <- approved_profile_source(record),
+         :ok <- prompt_configuration_exists(record["prompt_configuration_id"]),
+         :ok <- eligible_student(student_id, user_id) do
+      %{
+        record_ref: record_ref,
+        student_id: student_id,
+        prompt_configuration_id: record["prompt_configuration_id"],
+        profile_state: "missing",
+        profile_revision: nil
+      }
+    else
+      {:error, reason_code} -> rejected(record_ref, reason_code)
+    end
+  end
+
+  defp production_record(%{"source_record_type" => "production"}), do: :ok
+  defp production_record(_record), do: {:error, :test_record}
+
+  defp source_user_id(%{"source_user_id" => source_user_id}) when is_binary(source_user_id) do
+    case Integer.parse(source_user_id) do
+      {user_id, ""} when user_id > 0 and user_id <= 2_147_483_647 -> {:ok, user_id}
+      _ -> {:error, :malformed_source_id}
+    end
+  end
+
+  defp source_user_id(_record), do: {:error, :malformed_source_id}
+
+  defp user_exists(user_id) do
+    case Repo.query!("SELECT 1 FROM \"user\" WHERE id = $1", [user_id], log: false).rows do
+      [[1]] -> :ok
+      [] -> {:error, :user_not_found}
+    end
+  end
+
+  defp student_id(user_id) do
+    case Repo.query!("SELECT id FROM student WHERE user_id = $1", [user_id], log: false).rows do
+      [] -> {:error, :student_not_found}
+      [[student_id]] -> {:ok, student_id}
+      _ -> {:error, :ambiguous_student}
+    end
+  end
+
+  defp approved_profile_source(record) do
+    source = {record["form_id"], record["af_session_id"], record["entry_grade"]}
+
+    cond do
+      Map.has_key?(@approved_profile_sources, source) ->
+        :ok
+
+      record["form_id"] in ["6a44a83d1184e717b920c499", "6a4deca8e030ebe34669fb0f"] ->
+        {:error, :form_grade_mismatch}
+
+      true ->
+        {:error, :form_not_approved}
+    end
+  end
+
+  defp prompt_configuration_exists(prompt_configuration_id)
+       when is_integer(prompt_configuration_id) and prompt_configuration_id > 0 do
+    case Repo.query!(
+           "SELECT 1 FROM holistic_mentorship_prompt_configurations WHERE id = $1",
+           [prompt_configuration_id],
+           log: false
+         ).rows do
+      [[1]] -> :ok
+      [] -> {:error, :prompt_configuration_not_found}
+    end
+  end
+
+  defp prompt_configuration_exists(_prompt_configuration_id),
+    do: {:error, :prompt_configuration_not_found}
+
+  defp rejected(record_ref, reason_code) do
+    %{record_ref: record_ref, reason_code: Atom.to_string(reason_code)}
+  end
+
+  defp eligible_student(student_id, user_id) do
+    [[status, grade_id, grade_number]] =
+      Repo.query!(
+        "SELECT student.status, student.grade_id, grade.number FROM student LEFT JOIN grade ON grade.id = student.grade_id WHERE student.id = $1",
+        [student_id],
+        log: false
+      ).rows
+
+    with :ok <- not_dropout(status),
+         :ok <- eligible_grade_number(grade_number),
+         :ok <- eligible_program(user_id),
+         :ok <- eligible_school(user_id) do
+      consistent_grade(user_id, grade_id)
+    end
+  end
+
+  defp not_dropout("dropout"), do: {:error, :dropout}
+  defp not_dropout(_status), do: :ok
+
+  defp eligible_grade_number(grade_number) when grade_number in [11, 12], do: :ok
+  defp eligible_grade_number(_grade_number), do: {:error, :grade_ineligible}
+
+  defp eligible_program(user_id) do
+    case current_enrollment_ids(user_id, "program") do
+      [[1]] -> :ok
+      [] -> {:error, :program_ineligible}
+      [[_other_program_id]] -> {:error, :program_ineligible}
+      _ -> {:error, :eligibility_inconsistent}
+    end
+  end
+
+  defp eligible_school(user_id) do
+    case Repo.query!(
+           """
+           SELECT school.program_ids
+           FROM enrollment_record
+           LEFT JOIN school ON school.id = enrollment_record.group_id
+           WHERE enrollment_record.user_id = $1
+             AND enrollment_record.is_current
+             AND enrollment_record.group_type = 'school'
+           """,
+           [user_id],
+           log: false
+         ).rows do
+      [[program_ids]] when is_list(program_ids) ->
+        if 1 in program_ids, do: :ok, else: {:error, :program_ineligible}
+
+      _ ->
+        {:error, :school_missing_or_ambiguous}
+    end
+  end
+
+  defp consistent_grade(user_id, student_grade_id) do
+    case current_enrollment_ids(user_id, "grade") do
+      [] -> {:error, :grade_ineligible}
+      [[^student_grade_id]] -> :ok
+      _ -> {:error, :eligibility_inconsistent}
+    end
+  end
+
+  defp current_enrollment_ids(user_id, group_type) do
+    Repo.query!(
+      "SELECT group_id FROM enrollment_record WHERE user_id = $1 AND is_current AND group_type = $2",
+      [user_id, group_type],
+      log: false
+    ).rows
+  end
 end

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -94,26 +94,33 @@ defmodule Dbservice.HolisticMentorship do
     Postgrex.Error -> {:error, :invalid_request}
   end
 
-  defp publication_fields(%{
-         "etl_run_id" => run_id,
-         "student_id" => student_id,
-         "source_user_id" => source_user_id,
-         "form_id" => form_id,
-         "af_session_id" => session_id,
-         "entry_grade" => grade,
-         "prompt_configuration_id" => configuration_id,
-         "schema_fingerprint" => schema_fingerprint,
-         "answer_fingerprint" => answer_fingerprint,
-         "warehouse_loaded_at" => warehouse_loaded_at,
-         "generated_at" => generated_at,
-         "expected_profile_revision" => expected_revision,
-         "force" => false,
-         "summaries" => summaries
-       }) do
+  defp publication_fields(
+         %{
+           "etl_run_id" => run_id,
+           "student_id" => student_id,
+           "source_user_id" => source_user_id,
+           "form_id" => form_id,
+           "af_session_id" => session_id,
+           "entry_grade" => grade,
+           "prompt_configuration_id" => configuration_id,
+           "schema_fingerprint" => schema_fingerprint,
+           "answer_fingerprint" => answer_fingerprint,
+           "warehouse_loaded_at" => warehouse_loaded_at,
+           "generated_at" => generated_at,
+           "expected_profile_revision" => expected_revision,
+           "force" => force,
+           "summaries" => summaries
+         } = params
+       ) do
+    request_key = params["regeneration_request_key"]
+
     with {:ok, user_id} <- source_user_id(%{"source_user_id" => source_user_id}),
          {:ok, warehouse_loaded_at} <- parse_timestamp(warehouse_loaded_at),
          {:ok, generated_at} <- parse_timestamp(generated_at),
          :ok <- valid_summaries(summaries),
+         true <-
+           (force == false and is_nil(request_key)) or
+             (force == true and bounded_string?(request_key, 255)),
          fields = %{
            run_id: run_id,
            student_id: student_id,
@@ -127,6 +134,8 @@ defmodule Dbservice.HolisticMentorship do
            warehouse_loaded_at: warehouse_loaded_at,
            generated_at: generated_at,
            expected_revision: expected_revision,
+           force: force,
+           regeneration_request_key: request_key,
            summaries: summaries
          },
          true <- valid_publication_fields?(fields) do
@@ -222,25 +231,45 @@ defmodule Dbservice.HolisticMentorship do
         {:error, reason} -> Repo.rollback(reason)
       end
 
+      fields = Map.merge(fields, lock_regeneration_request!(fields))
+
       journey_id = insert_profile_journey!(fields)
-
-      case generation_status_row(fields) do
-        [[_id, "completed", outcome, revision]] when is_integer(revision) ->
-          case current_profile(journey_id, fields.configuration_id) do
-            {_profile_id, _fingerprint, _current_revision} ->
-              %{result: outcome, revision: revision}
-
-            nil ->
-              Repo.rollback(:invalid_request)
-          end
-
-        [[status_id, "running", nil, nil]] ->
-          publish_running_profile!(journey_id, status_id, fields)
-
-        _ ->
-          Repo.rollback(:invalid_request)
-      end
+      finish_profile_publication!(journey_id, generation_status_row(fields), fields)
     end)
+  end
+
+  defp finish_profile_publication!(
+         journey_id,
+         [[_, "completed", outcome, revision]],
+         %{force: false} = fields
+       )
+       when is_integer(revision),
+       do: completed_publication_result!(journey_id, outcome, revision, fields)
+
+  defp finish_profile_publication!(
+         journey_id,
+         [[_, "completed", outcome, revision]],
+         %{request_state: :completed} = fields
+       )
+       when is_integer(revision),
+       do: completed_publication_result!(journey_id, outcome, revision, fields)
+
+  defp finish_profile_publication!(
+         journey_id,
+         [[status_id, "running", nil, nil]],
+         %{request_state: request_state} = fields
+       )
+       when request_state != :completed,
+       do: publish_running_profile!(journey_id, status_id, fields)
+
+  defp finish_profile_publication!(_journey_id, _status, _fields),
+    do: Repo.rollback(:invalid_request)
+
+  defp completed_publication_result!(journey_id, outcome, revision, fields) do
+    case current_profile(journey_id, fields.configuration_id) do
+      {_profile_id, _fingerprint, _current_revision} -> %{result: outcome, revision: revision}
+      nil -> Repo.rollback(:invalid_request)
+    end
   end
 
   defp publish_running_profile!(journey_id, status_id, fields) do
@@ -248,23 +277,54 @@ defmodule Dbservice.HolisticMentorship do
       nil when is_nil(fields.expected_revision) ->
         profile_id = insert_profile!(journey_id, fields)
         insert_profile_summaries!(profile_id, fields.summaries)
-        complete_generation_status!(status_id, "published", 1)
+        complete_publication!(status_id, "published", 1, fields)
         %{result: "published", revision: 1}
 
       {_profile_id, answer_fingerprint, revision}
       when revision == fields.expected_revision and
-             answer_fingerprint == fields.answer_fingerprint ->
-        complete_generation_status!(status_id, "unchanged", revision)
+             answer_fingerprint == fields.answer_fingerprint and not fields.force ->
+        complete_publication!(status_id, "unchanged", revision, fields)
         %{result: "unchanged", revision: revision}
 
       {profile_id, _answer_fingerprint, revision} when revision == fields.expected_revision ->
         revision = revision + 1
         replace_profile!(profile_id, fields, revision)
-        complete_generation_status!(status_id, "replaced", revision)
+        complete_publication!(status_id, "replaced", revision, fields)
         %{result: "replaced", revision: revision}
 
       _ ->
         Repo.rollback(:stale_profile_revision)
+    end
+  end
+
+  defp lock_regeneration_request!(%{force: false}),
+    do: %{request_id: nil, request_state: nil}
+
+  defp lock_regeneration_request!(fields) do
+    case Repo.query!(
+           """
+           SELECT id, student_id, prompt_configuration_id, force, state, etl_run_id
+           FROM holistic_mentorship_regeneration_requests
+           WHERE request_key = $1 AND student_id = $2 AND prompt_configuration_id = $3
+             AND force = true
+           FOR UPDATE
+           """,
+           [fields.regeneration_request_key, fields.student_id, fields.configuration_id],
+           log: false
+         ).rows do
+      [[id, _student_id, _configuration_id, true, "queued", nil]] ->
+        %{request_id: id, request_state: :active}
+
+      [[id, _student_id, _configuration_id, true, "running", run_id]]
+      when run_id == fields.run_id ->
+        %{request_id: id, request_state: :active}
+
+      [[id, _student_id, _configuration_id, true, "completed", run_id]]
+      when run_id == fields.run_id ->
+        %{request_id: id, request_state: :completed}
+
+      _ ->
+        Repo.rollback(:invalid_request)
     end
   end
 
@@ -411,16 +471,38 @@ defmodule Dbservice.HolisticMentorship do
   end
 
   defp complete_generation_status!(status_id, outcome, revision) do
-    Repo.query!(
-      """
-      UPDATE holistic_mentorship_profile_generation_statuses
-      SET state = 'completed', completed_outcome = $2, completed_profile_revision = $3,
-          updated_at = now()
-      WHERE id = $1
-      """,
-      [status_id, outcome, revision],
-      log: false
-    )
+    case Repo.query!(
+           """
+           UPDATE holistic_mentorship_profile_generation_statuses
+           SET state = 'completed', completed_outcome = $2, completed_profile_revision = $3,
+               updated_at = now()
+           WHERE id = $1
+           """,
+           [status_id, outcome, revision],
+           log: false
+         ).num_rows do
+      1 -> :ok
+      _ -> Repo.rollback(:invalid_request)
+    end
+  end
+
+  defp complete_publication!(status_id, outcome, revision, fields) do
+    complete_generation_status!(status_id, outcome, revision)
+
+    if fields.request_id do
+      case Repo.query!(
+             """
+             UPDATE holistic_mentorship_regeneration_requests
+             SET state = 'completed', etl_run_id = $2, updated_at = now()
+             WHERE id = $1
+             """,
+             [fields.request_id, fields.run_id],
+             log: false
+           ).num_rows do
+        1 -> :ok
+        _ -> Repo.rollback(:invalid_request)
+      end
+    end
   end
 
   def get_regeneration_request(request_key) when is_binary(request_key) do

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -86,6 +86,407 @@ defmodule Dbservice.HolisticMentorship do
     end
   end
 
+  def publish_profile(params) do
+    with {:ok, fields} <- publication_fields(params) do
+      persist_profile_publication(fields)
+    end
+  rescue
+    Postgrex.Error -> {:error, :invalid_request}
+  end
+
+  defp publication_fields(
+         %{
+           "etl_run_id" => run_id,
+           "student_id" => student_id,
+           "source_user_id" => source_user_id,
+           "form_id" => form_id,
+           "af_session_id" => session_id,
+           "entry_grade" => grade,
+           "prompt_configuration_id" => configuration_id,
+           "schema_fingerprint" => schema_fingerprint,
+           "answer_fingerprint" => answer_fingerprint,
+           "warehouse_loaded_at" => warehouse_loaded_at,
+           "generated_at" => generated_at,
+           "expected_profile_revision" => expected_revision,
+           "force" => force,
+           "summaries" => summaries
+         } = params
+       ) do
+    request_key = params["regeneration_request_key"]
+
+    with {:ok, user_id} <- parse_source_user_id(source_user_id),
+         {:ok, warehouse_loaded_at} <- parse_timestamp(warehouse_loaded_at),
+         {:ok, generated_at} <- parse_timestamp(generated_at),
+         :ok <- valid_summaries(summaries),
+         fields = %{
+           run_id: run_id,
+           student_id: student_id,
+           user_id: user_id,
+           form_id: form_id,
+           session_id: session_id,
+           grade: grade,
+           configuration_id: configuration_id,
+           schema_fingerprint: schema_fingerprint,
+           answer_fingerprint: answer_fingerprint,
+           warehouse_loaded_at: warehouse_loaded_at,
+           generated_at: generated_at,
+           expected_revision: expected_revision,
+           force: force,
+           regeneration_request_key: request_key,
+           summaries: summaries
+         },
+         true <- valid_publication_fields?(fields) do
+      {:ok, fields}
+    else
+      _ -> {:error, :invalid_request}
+    end
+  end
+
+  defp publication_fields(_params), do: {:error, :invalid_request}
+
+  defp valid_publication_fields?(fields) do
+    Enum.all?([
+      positive_integer?(fields.student_id),
+      positive_integer?(fields.configuration_id),
+      bounded_string?(fields.run_id, 255),
+      bounded_string?(fields.schema_fingerprint, 255),
+      bounded_string?(fields.answer_fingerprint, 255),
+      is_nil(fields.expected_revision) or positive_integer?(fields.expected_revision),
+      valid_force?(fields.force, fields.regeneration_request_key),
+      NaiveDateTime.compare(fields.generated_at, fields.warehouse_loaded_at) != :lt
+    ])
+  end
+
+  defp valid_force?(false, nil), do: true
+  defp valid_force?(true, request_key), do: present_string?(request_key)
+  defp valid_force?(_force, _request_key), do: false
+
+  defp bounded_string?(value, maximum),
+    do: is_binary(value) and byte_size(value) in 1..maximum
+
+  defp parse_source_user_id(value) do
+    case Integer.parse(value) do
+      {id, ""} when id > 0 and id <= 2_147_483_647 -> {:ok, id}
+      _ -> {:error, :invalid_request}
+    end
+  rescue
+    ArgumentError -> {:error, :invalid_request}
+  end
+
+  defp parse_timestamp(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, datetime, _offset} -> {:ok, DateTime.to_naive(datetime)}
+      _ -> {:error, :invalid_request}
+    end
+  end
+
+  defp parse_timestamp(_value), do: {:error, :invalid_request}
+
+  defp valid_summaries(summaries) when is_list(summaries) and length(summaries) == 5 do
+    if Enum.with_index(summaries, 1)
+       |> Enum.all?(fn
+         {%{
+            "position" => position,
+            "question_set_title" => title,
+            "summary" => summary
+          }, position} ->
+           present_string?(String.trim(title)) and present_string?(String.trim(summary))
+
+         _ ->
+           false
+       end),
+       do: :ok,
+       else: {:error, :invalid_request}
+  rescue
+    FunctionClauseError -> {:error, :invalid_request}
+  end
+
+  defp valid_summaries(_summaries), do: {:error, :invalid_request}
+
+  defp publication_references(fields) do
+    with :ok <- approved_profile_source(publication_source(fields)),
+         :ok <- user_exists(fields.user_id),
+         {:ok, student_id} <- student_id(fields.user_id),
+         true <- student_id == fields.student_id,
+         :ok <- prompt_configuration_exists(fields.configuration_id),
+         :ok <- eligible_student(fields.student_id, fields.user_id) do
+      :ok
+    else
+      false -> {:error, :student_not_found}
+      error -> error
+    end
+  end
+
+  defp publication_source(fields) do
+    %{
+      "form_id" => fields.form_id,
+      "af_session_id" => fields.session_id,
+      "entry_grade" => fields.grade
+    }
+  end
+
+  defp persist_profile_publication(fields) do
+    Repo.transaction(fn ->
+      Repo.query!(
+        "SELECT pg_advisory_xact_lock($1, $2)",
+        [fields.student_id, 0],
+        log: false
+      )
+
+      Repo.query!("SELECT 1 FROM student WHERE id = $1 FOR UPDATE", [fields.student_id],
+        log: false
+      )
+
+      case publication_references(fields) do
+        :ok -> :ok
+        {:error, reason} -> Repo.rollback(reason)
+      end
+
+      journey_id = insert_profile_journey!(fields)
+
+      case generation_status_row(fields) do
+        [[_id, "completed", outcome]] ->
+          case current_profile(journey_id, fields.configuration_id) do
+            {_profile_id, _fingerprint, revision} ->
+              %{result: outcome, revision: revision}
+
+            nil ->
+              Repo.rollback(:invalid_request)
+          end
+
+        [[_id, "running", nil]] ->
+          publish_running_profile!(journey_id, fields)
+
+        _ ->
+          Repo.rollback(:invalid_request)
+      end
+    end)
+  end
+
+  defp publish_running_profile!(journey_id, fields) do
+    validate_regeneration_request!(fields)
+
+    case current_profile(journey_id, fields.configuration_id) do
+      nil when is_nil(fields.expected_revision) ->
+        profile_id = insert_profile!(journey_id, fields)
+        insert_profile_summaries!(profile_id, fields.summaries)
+        complete_generation_status!(fields, "published")
+        complete_regeneration_request!(fields)
+        %{result: "published", revision: 1}
+
+      {_profile_id, answer_fingerprint, revision}
+      when revision == fields.expected_revision and
+             answer_fingerprint == fields.answer_fingerprint and not fields.force ->
+        complete_generation_status!(fields, "unchanged")
+        complete_regeneration_request!(fields)
+        %{result: "unchanged", revision: revision}
+
+      {profile_id, _answer_fingerprint, revision} when revision == fields.expected_revision ->
+        revision = revision + 1
+        replace_profile!(profile_id, fields, revision)
+        complete_generation_status!(fields, "replaced")
+        complete_regeneration_request!(fields)
+        %{result: "replaced", revision: revision}
+
+      _ ->
+        Repo.rollback(:stale_profile_revision)
+    end
+  end
+
+  defp current_profile(journey_id, configuration_id) do
+    case Repo.query!(
+           """
+           SELECT id, answer_fingerprint, revision
+           FROM holistic_mentorship_student_profiles
+           WHERE profile_journey_id = $1 AND prompt_configuration_id = $2
+           FOR UPDATE
+           """,
+           [journey_id, configuration_id],
+           log: false
+         ).rows do
+      [[id, answer_fingerprint, revision]] -> {id, answer_fingerprint, revision}
+      [] -> nil
+    end
+  end
+
+  defp insert_profile!(journey_id, fields) do
+    [[profile_id]] =
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_student_profiles
+          (profile_journey_id, prompt_configuration_id, schema_fingerprint,
+           answer_fingerprint, warehouse_loaded_at, generated_at, revision,
+           last_successful_etl_run_id)
+        VALUES ($1, $2, $3, $4, $5, $6, 1, $7)
+        RETURNING id
+        """,
+        [
+          journey_id,
+          fields.configuration_id,
+          fields.schema_fingerprint,
+          fields.answer_fingerprint,
+          fields.warehouse_loaded_at,
+          fields.generated_at,
+          fields.run_id
+        ],
+        log: false
+      ).rows
+
+    profile_id
+  end
+
+  defp replace_profile!(profile_id, fields, revision) do
+    Repo.query!(
+      """
+      UPDATE holistic_mentorship_student_profiles
+      SET schema_fingerprint = $2, answer_fingerprint = $3, warehouse_loaded_at = $4,
+          generated_at = $5, revision = $6, last_successful_etl_run_id = $7,
+          updated_at = now()
+      WHERE id = $1
+      """,
+      [
+        profile_id,
+        fields.schema_fingerprint,
+        fields.answer_fingerprint,
+        fields.warehouse_loaded_at,
+        fields.generated_at,
+        revision,
+        fields.run_id
+      ],
+      log: false
+    )
+
+    Repo.query!(
+      "DELETE FROM holistic_mentorship_student_profile_summaries WHERE student_profile_id = $1",
+      [profile_id],
+      log: false
+    )
+
+    insert_profile_summaries!(profile_id, fields.summaries)
+  end
+
+  defp insert_profile_journey!(fields) do
+    case Repo.query!(
+           """
+           SELECT id, form_id, af_session_id, entry_grade
+           FROM holistic_mentorship_profile_journeys
+           WHERE student_id = $1
+           FOR UPDATE
+           """,
+           [fields.student_id],
+           log: false
+         ).rows do
+      [] ->
+        [[journey_id]] =
+          Repo.query!(
+            """
+            INSERT INTO holistic_mentorship_profile_journeys
+              (student_id, form_id, af_session_id, entry_grade)
+            VALUES ($1, $2, $3, $4)
+            RETURNING id
+            """,
+            [fields.student_id, fields.form_id, fields.session_id, fields.grade],
+            log: false
+          ).rows
+
+        journey_id
+
+      [[journey_id, form_id, session_id, grade]]
+      when form_id == fields.form_id and session_id == fields.session_id and grade == fields.grade ->
+        journey_id
+
+      _ ->
+        Repo.rollback(:journey_source_conflict)
+    end
+  end
+
+  defp validate_regeneration_request!(%{force: false}), do: :ok
+
+  defp validate_regeneration_request!(fields) do
+    case Repo.query!(
+           """
+           SELECT id
+           FROM holistic_mentorship_regeneration_requests
+           WHERE request_key = $1 AND student_id = $2 AND prompt_configuration_id = $3
+             AND force
+             AND ((state = 'queued' AND etl_run_id IS NULL)
+                  OR (state = 'running' AND etl_run_id = $4))
+           FOR UPDATE
+           """,
+           [
+             fields.regeneration_request_key,
+             fields.student_id,
+             fields.configuration_id,
+             fields.run_id
+           ],
+           log: false
+         ).rows do
+      [[_id]] -> :ok
+      [] -> Repo.rollback(:invalid_request)
+    end
+  end
+
+  defp generation_status_row(fields) do
+    Repo.query!(
+      """
+      SELECT id, state, completed_outcome
+      FROM holistic_mentorship_profile_generation_statuses
+      WHERE etl_run_id = $1 AND student_id = $2 AND form_id = $3
+        AND af_session_id = $4 AND entry_grade = $5 AND prompt_configuration_id = $6
+      FOR UPDATE
+      """,
+      [
+        fields.run_id,
+        fields.student_id,
+        fields.form_id,
+        fields.session_id,
+        fields.grade,
+        fields.configuration_id
+      ],
+      log: false
+    ).rows
+  end
+
+  defp insert_profile_summaries!(profile_id, summaries) do
+    Enum.each(summaries, fn summary ->
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_student_profile_summaries
+          (student_profile_id, position, question_set_title, summary)
+        VALUES ($1, $2, $3, $4)
+        """,
+        [profile_id, summary["position"], summary["question_set_title"], summary["summary"]],
+        log: false
+      )
+    end)
+  end
+
+  defp complete_generation_status!(fields, outcome) do
+    Repo.query!(
+      """
+      UPDATE holistic_mentorship_profile_generation_statuses
+      SET state = 'completed', completed_outcome = $2, updated_at = now()
+      WHERE id = $1
+      """,
+      [generation_status_row(fields) |> hd() |> hd(), outcome],
+      log: false
+    )
+  end
+
+  defp complete_regeneration_request!(%{force: false}), do: :ok
+
+  defp complete_regeneration_request!(fields) do
+    Repo.query!(
+      """
+      UPDATE holistic_mentorship_regeneration_requests
+      SET state = 'completed', etl_run_id = $2, updated_at = now()
+      WHERE request_key = $1
+      """,
+      [fields.regeneration_request_key, fields.run_id],
+      log: false
+    )
+  end
+
   def get_regeneration_request(request_key) when is_binary(request_key) do
     case Repo.query!(
            """

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -13,21 +13,22 @@ defmodule Dbservice.HolisticMentorship do
   }
 
   def end_active_mappings(student_id, reason) when reason in @eligibility_end_reasons do
-    ended_at = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    reason = Atom.to_string(reason)
 
     {count, _} =
       from(mapping in @mapping_table,
-        where: field(mapping, :student_id) == ^student_id and is_nil(field(mapping, :ended_at))
-      )
-      |> Repo.update_all(
-        set: [
-          ended_at: ended_at,
-          ended_by_user_id: nil,
-          end_source: "db_service_student_eligibility",
-          end_reason: Atom.to_string(reason),
-          updated_at: ended_at
+        where: field(mapping, :student_id) == ^student_id and is_nil(field(mapping, :ended_at)),
+        update: [
+          set: [
+            ended_at: fragment("timezone('UTC', now())"),
+            ended_by_user_id: nil,
+            end_source: "db_service_student_eligibility",
+            end_reason: ^reason,
+            updated_at: fragment("timezone('UTC', now())")
+          ]
         ]
       )
+      |> Repo.update_all([])
 
     {:ok, count}
   end

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -142,7 +142,7 @@ defmodule Dbservice.HolisticMentorship do
           false
       end
 
-    if present_string?(run_id) and valid_result,
+    if present_string?(run_id) and byte_size(run_id) <= 255 and valid_result,
       do: {:ok, {run_id, state, error_code, error_message}},
       else: {:error, :invalid_request}
   end

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -29,4 +29,148 @@ defmodule Dbservice.HolisticMentorship do
   end
 
   def end_active_mappings(_student_id, _reason), do: {:error, :invalid_end_reason}
+
+  def register_prompt_configuration(params) do
+    with {:ok, fields} <- prompt_fields(params),
+         :ok <- verify_template_hash(fields) do
+      persist_prompt_configuration(fields)
+    end
+  end
+
+  def activate_prompt_configuration(id) do
+    Repo.transaction(fn ->
+      Repo.query!(
+        "SELECT pg_advisory_xact_lock(hashtext('holistic_mentorship_prompt_activation'))"
+      )
+
+      case prompt_configuration(id) do
+        nil ->
+          Repo.rollback(:prompt_configuration_not_found)
+
+        _configuration ->
+          Repo.query!(
+            """
+            UPDATE holistic_mentorship_prompt_configurations
+            SET state = 'inactive', updated_at = now()
+            WHERE state = 'active' AND id <> $1
+            """,
+            [id]
+          )
+
+          Repo.query!(
+            """
+            UPDATE holistic_mentorship_prompt_configurations
+            SET state = 'active', updated_at = now()
+            WHERE id = $1 AND state <> 'active'
+            """,
+            [id]
+          )
+
+          prompt_configuration(id)
+      end
+    end)
+  end
+
+  defp prompt_fields(%{
+         "prompt_version" => version,
+         "template_text" => template_text,
+         "template_hash" => template_hash,
+         "model_id" => model_id
+       }) do
+    fields = {version, template_text, template_hash, model_id}
+
+    if fields |> Tuple.to_list() |> Enum.all?(&(is_binary(&1) and &1 != "")),
+      do: {:ok, fields},
+      else: {:error, :invalid_request}
+  end
+
+  defp prompt_fields(_params), do: {:error, :invalid_request}
+
+  defp verify_template_hash({_version, template_text, template_hash, _model_id}) do
+    if sha256(template_text) == template_hash,
+      do: :ok,
+      else: {:error, :template_hash_mismatch}
+  end
+
+  defp persist_prompt_configuration({version, template_text, template_hash, model_id}) do
+    Repo.transaction(fn ->
+      prompt_version_id = prompt_version_id!(version, template_text, template_hash)
+
+      [[id, state]] =
+        Repo.query!(
+          """
+          INSERT INTO holistic_mentorship_prompt_configurations (prompt_version_id, model_id)
+          VALUES ($1, $2)
+          ON CONFLICT (prompt_version_id, model_id) DO UPDATE SET model_id = EXCLUDED.model_id
+          RETURNING id, state
+          """,
+          [prompt_version_id, model_id]
+        ).rows
+
+      %{
+        id: id,
+        model_id: model_id,
+        prompt_version: version,
+        state: state,
+        template_hash: template_hash
+      }
+    end)
+  end
+
+  defp prompt_version_id!(version, template_text, template_hash) do
+    case Repo.query!(
+           """
+           INSERT INTO holistic_mentorship_prompt_versions (version, template_text, template_hash)
+           VALUES ($1, $2, $3)
+           ON CONFLICT (version) DO NOTHING
+           RETURNING id
+           """,
+           [version, template_text, template_hash]
+         ).rows do
+      [[id]] -> id
+      [] -> existing_prompt_version_id!(version, template_text, template_hash)
+    end
+  end
+
+  defp existing_prompt_version_id!(version, template_text, template_hash) do
+    case Repo.query!(
+           """
+           SELECT id, template_text, template_hash
+           FROM holistic_mentorship_prompt_versions
+           WHERE version = $1
+           """,
+           [version]
+         ).rows do
+      [[id, ^template_text, ^template_hash]] -> id
+      _ -> Repo.rollback(:prompt_version_conflict)
+    end
+  end
+
+  defp prompt_configuration(id) do
+    case Repo.query!(
+           """
+           SELECT configuration.id, configuration.model_id, version.version,
+                  configuration.state, version.template_hash
+           FROM holistic_mentorship_prompt_configurations AS configuration
+           JOIN holistic_mentorship_prompt_versions AS version
+             ON version.id = configuration.prompt_version_id
+           WHERE configuration.id = $1
+           """,
+           [id]
+         ).rows do
+      [[id, model_id, version, state, template_hash]] ->
+        %{
+          id: id,
+          model_id: model_id,
+          prompt_version: version,
+          state: state,
+          template_hash: template_hash
+        }
+
+      [] ->
+        nil
+    end
+  end
+
+  defp sha256(value), do: :crypto.hash(:sha256, value) |> Base.encode16(case: :lower)
 end

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -201,6 +201,7 @@ defmodule Dbservice.HolisticMentorship do
          {:ok, student_id} <- student_id(fields.user_id),
          true <- student_id == fields.student_id,
          :ok <- prompt_configuration_exists(fields.configuration_id),
+         :ok <- privacy_not_deleted(fields.student_id),
          :ok <- eligible_student(fields.student_id, fields.user_id) do
       :ok
     else
@@ -533,7 +534,8 @@ defmodule Dbservice.HolisticMentorship do
           model_id
         ]
       ] ->
-        with :ok <- eligible_student(student_id, user_id) do
+        with :ok <- privacy_not_deleted(student_id),
+             :ok <- eligible_student(student_id, user_id) do
           {:ok,
            %{
              request_key: request_key,
@@ -1003,6 +1005,7 @@ defmodule Dbservice.HolisticMentorship do
          :ok <- user_exists(user_id),
          {:ok, student_id} <- student_id(user_id),
          :ok <- approved_profile_source(record),
+         :ok <- privacy_not_deleted(student_id),
          {:ok, journey_id} <- matching_profile_journey(student_id, record),
          :ok <- prompt_configuration_exists(record["prompt_configuration_id"]),
          :ok <- eligible_student(student_id, user_id) do
@@ -1064,6 +1067,17 @@ defmodule Dbservice.HolisticMentorship do
 
       true ->
         {:error, :form_not_approved}
+    end
+  end
+
+  defp privacy_not_deleted(student_id) do
+    case Repo.query!(
+           "SELECT 1 FROM holistic_mentorship_privacy_deletions WHERE student_id = $1",
+           [student_id],
+           log: false
+         ).rows do
+      [] -> :ok
+      [[1]] -> {:error, :privacy_erased}
     end
   end
 

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -205,22 +205,27 @@ defmodule Dbservice.HolisticMentorship do
 
   defp insert_generation_status!(
          {run_id, student_id, form_id, session_id, grade, configuration_id, "queued", nil, nil,
-          nil}
+          nil} = fields
        ) do
-    [[state, outcome, error_code, error_message]] =
-      Repo.query!(
-        """
-        INSERT INTO holistic_mentorship_profile_generation_statuses
-          (etl_run_id, student_id, form_id, af_session_id, entry_grade,
-           prompt_configuration_id, state)
-        VALUES ($1, $2, $3, $4, $5, $6, 'queued')
-        RETURNING state, completed_outcome, error_code, error_message
-        """,
-        [run_id, student_id, form_id, session_id, grade, configuration_id],
-        log: false
-      ).rows
+    case Repo.query!(
+           """
+           INSERT INTO holistic_mentorship_profile_generation_statuses
+             (etl_run_id, student_id, form_id, af_session_id, entry_grade,
+              prompt_configuration_id, state)
+           VALUES ($1, $2, $3, $4, $5, $6, 'queued')
+           ON CONFLICT (etl_run_id, student_id, form_id, af_session_id, entry_grade,
+                        prompt_configuration_id) DO NOTHING
+           RETURNING state, completed_outcome, error_code, error_message
+           """,
+           [run_id, student_id, form_id, session_id, grade, configuration_id],
+           log: false
+         ).rows do
+      [[state, outcome, error_code, error_message]] ->
+        generation_status_response(state, outcome, error_code, error_message)
 
-    generation_status_response(state, outcome, error_code, error_message)
+      [] ->
+        generation_status(fields) |> transition_generation_status!(fields)
+    end
   end
 
   defp insert_generation_status!(_fields), do: Repo.rollback(:invalid_transition)

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -125,7 +125,8 @@ defmodule Dbservice.HolisticMentorship do
            ON CONFLICT (version) DO NOTHING
            RETURNING id
            """,
-           [version, template_text, template_hash]
+           [version, template_text, template_hash],
+           log: false
          ).rows do
       [[id]] -> id
       [] -> existing_prompt_version_id!(version, template_text, template_hash)

--- a/lib/dbservice/services/dropout_service.ex
+++ b/lib/dbservice/services/dropout_service.ex
@@ -36,7 +36,12 @@ defmodule Dbservice.Services.DropoutService do
     if student.status == "dropout" do
       {:error, "Student is already marked as dropout"}
     else
-      create_dropout_enrollment(student, start_date, academic_year)
+      Repo.transaction(fn ->
+        case create_dropout_enrollment(student, start_date, academic_year) do
+          {:ok, updated_student} -> updated_student
+          {:error, reason} -> Repo.rollback(reason)
+        end
+      end)
     end
   end
 

--- a/lib/dbservice/services/enrollment_service.ex
+++ b/lib/dbservice/services/enrollment_service.ex
@@ -129,24 +129,26 @@ defmodule Dbservice.Services.EnrollmentService do
   Creates a new group user with associated enrollment record.
   """
   def create_new_group_user(params) do
-    group = Groups.get_group!(params["group_id"])
-    academic_year = resolve_academic_year(group.type, params)
+    Repo.transaction(fn ->
+      group = Groups.get_group!(params["group_id"])
+      academic_year = resolve_academic_year(group.type, params)
 
-    enrollment_record = %{
-      "group_id" => group.child_id,
-      "group_type" => group.type,
-      "user_id" => params["user_id"],
-      "academic_year" => academic_year,
-      "start_date" => params["start_date"]
-    }
+      enrollment_record = %{
+        "group_id" => group.child_id,
+        "group_type" => group.type,
+        "user_id" => params["user_id"],
+        "academic_year" => academic_year,
+        "start_date" => params["start_date"]
+      }
 
-    with {:ok, %EnrollmentRecord{} = _} <-
-           EnrollmentRecords.create_enrollment_record(enrollment_record),
-         {:ok, %GroupUser{} = group_user} <- GroupUsers.create_group_user(params) do
-      {:ok, group_user}
-    else
-      {:error, _changeset} -> {:error, "Failed to create group user"}
-    end
+      with {:ok, %EnrollmentRecord{}} <-
+             EnrollmentRecords.create_enrollment_record(enrollment_record),
+           {:ok, %GroupUser{} = group_user} <- GroupUsers.create_group_user(params) do
+        group_user
+      else
+        {:error, _changeset} -> Repo.rollback("Failed to create group user")
+      end
+    end)
   end
 
   @doc """

--- a/lib/dbservice/services/group_update_service.ex
+++ b/lib/dbservice/services/group_update_service.ex
@@ -24,6 +24,15 @@ defmodule Dbservice.Services.GroupUpdateService do
   - `{:error, reason}` on failure
   """
   def update_user_group_by_type(params) do
+    Repo.transaction(fn ->
+      case do_update_user_group_by_type(params) do
+        {:ok, updated_group_user} -> updated_group_user
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+  end
+
+  defp do_update_user_group_by_type(params) do
     user_id = params["user_id"]
 
     with {:ok, type} <- fetch_type(params),

--- a/lib/dbservice/services/re_enrollment_service.ex
+++ b/lib/dbservice/services/re_enrollment_service.ex
@@ -25,6 +25,15 @@ defmodule Dbservice.Services.ReEnrollmentService do
   Returns {:ok, student} on success or {:error, reason} on failure.
   """
   def process_re_enrollment(student, params) do
+    Repo.transaction(fn ->
+      case do_process_re_enrollment(student, params) do
+        {:ok, updated_student} -> updated_student
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+  end
+
+  defp do_process_re_enrollment(student, params) do
     with :ok <- validate_dropout_status(student),
          :ok <- validate_auth_group_match(student, params),
          {:ok, _} <- create_re_enrollment_records(student, params) do

--- a/lib/dbservice/users.ex
+++ b/lib/dbservice/users.ex
@@ -256,9 +256,12 @@ defmodule Dbservice.Users do
 
   """
   def update_student(%Student{} = student, attrs) do
-    student
-    |> Student.changeset(attrs)
-    |> Repo.update()
+    Repo.transaction(fn ->
+      case update_student_in_transaction(student, attrs) do
+        {:ok, updated_student} -> updated_student
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
   end
 
   @doc """
@@ -312,16 +315,45 @@ defmodule Dbservice.Users do
 
   """
   def update_student_with_user(student, user, attrs \\ %{}) do
-    alias Dbservice.Users
+    Repo.transaction(fn ->
+      with {:ok, %User{} = user} <- update_user(user, attrs),
+           {:ok, %Student{} = student} <-
+             update_student_in_transaction(
+               student,
+               Map.merge(stringify_keys(attrs), %{"user_id" => user.id})
+             ) do
+        student
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+  end
 
-    with {:ok, %User{} = user} <- Users.update_user(user, attrs),
-         {:ok, %Student{} = student} <-
-           Users.update_student(
-             student,
-             Map.merge(stringify_keys(attrs), %{"user_id" => user.id})
-           ) do
-      {:ok, student}
+  defp update_student_in_transaction(student, attrs) do
+    student = Repo.get!(Student, student.id, lock: "FOR UPDATE")
+
+    with {:ok, updated_student} <- Repo.update(Student.changeset(student, attrs)),
+         {:ok, _count} <- cleanup_holistic_mappings(student, updated_student) do
+      {:ok, updated_student}
     end
+  end
+
+  defp cleanup_holistic_mappings(student, updated_student) do
+    reason =
+      cond do
+        student.status != updated_student.status and updated_student.status == "dropout" ->
+          :student_dropout
+
+        student.grade_id != updated_student.grade_id ->
+          :student_grade_changed
+
+        true ->
+          nil
+      end
+
+    if reason,
+      do: Dbservice.HolisticMentorship.end_active_mappings(student.id, reason),
+      else: {:ok, 0}
   end
 
   @doc """

--- a/lib/dbservice_web/controllers/holistic_mentorship_profile_generation_status_controller.ex
+++ b/lib/dbservice_web/controllers/holistic_mentorship_profile_generation_status_controller.ex
@@ -1,0 +1,44 @@
+defmodule DbserviceWeb.HolisticMentorshipProfileGenerationStatusController do
+  use DbserviceWeb, :controller
+
+  alias Dbservice.HolisticMentorship
+
+  def create(conn, params) do
+    case HolisticMentorship.record_profile_generation_status(params) do
+      {:ok, status} ->
+        json(conn, status)
+
+      {:error, :invalid_request} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{
+          error: %{
+            code: "invalid_request",
+            message: "Profile generation status fields are missing or invalid"
+          }
+        })
+
+      {:error, :invalid_transition} ->
+        error(
+          conn,
+          :conflict,
+          "invalid_status_transition",
+          "Profile generation status transition is invalid"
+        )
+
+      {:error, :terminal_status_conflict} ->
+        error(
+          conn,
+          :conflict,
+          "terminal_status_conflict",
+          "Profile generation status is terminal"
+        )
+    end
+  end
+
+  defp error(conn, status, code, message) do
+    conn
+    |> put_status(status)
+    |> json(%{error: %{code: code, message: message}})
+  end
+end

--- a/lib/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller.ex
+++ b/lib/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller.ex
@@ -1,0 +1,32 @@
+defmodule DbserviceWeb.HolisticMentorshipProfilePreflightController do
+  use DbserviceWeb, :controller
+
+  alias Dbservice.HolisticMentorship
+
+  def create(conn, %{"records" => records})
+      when is_list(records) and records != [] and length(records) <= 100 do
+    json(conn, %{results: HolisticMentorship.profile_preflight(records)})
+  end
+
+  def create(conn, %{"records" => records}) when is_list(records) and length(records) > 100 do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: %{
+        code: "batch_too_large",
+        message: "Profile Preflight accepts at most 100 records"
+      }
+    })
+  end
+
+  def create(conn, _params) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: %{
+        code: "invalid_request",
+        message: "Profile Preflight requires 1 through 100 records"
+      }
+    })
+  end
+end

--- a/lib/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller.ex
+++ b/lib/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller.ex
@@ -5,7 +5,11 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightController do
 
   def create(conn, %{"records" => records})
       when is_list(records) and records != [] and length(records) <= 100 do
-    json(conn, %{results: HolisticMentorship.profile_preflight(records)})
+    if Enum.all?(records, &is_map/1) do
+      json(conn, %{results: HolisticMentorship.profile_preflight(records)})
+    else
+      invalid_request(conn)
+    end
   end
 
   def create(conn, %{"records" => records}) when is_list(records) and length(records) > 100 do
@@ -19,7 +23,9 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightController do
     })
   end
 
-  def create(conn, _params) do
+  def create(conn, _params), do: invalid_request(conn)
+
+  defp invalid_request(conn) do
     conn
     |> put_status(:unprocessable_entity)
     |> json(%{

--- a/lib/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller.ex
+++ b/lib/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller.ex
@@ -6,7 +6,10 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightController do
   def create(conn, %{"records" => records})
       when is_list(records) and records != [] and length(records) <= 100 do
     if Enum.all?(records, &is_map/1) do
-      json(conn, %{results: HolisticMentorship.profile_preflight(records)})
+      case HolisticMentorship.profile_preflight(records) do
+        {:ok, results} -> json(conn, %{results: results})
+        {:error, :invalid_request} -> invalid_request(conn)
+      end
     else
       invalid_request(conn)
     end

--- a/lib/dbservice_web/controllers/holistic_mentorship_profile_publish_controller.ex
+++ b/lib/dbservice_web/controllers/holistic_mentorship_profile_publish_controller.ex
@@ -20,6 +20,11 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePublishController do
   defp error(:stale_profile_revision),
     do: {:conflict, "stale_profile_revision", "Profile revision is stale"}
 
+  defp error(:database_temporarily_unavailable),
+    do:
+      {:service_unavailable, "database_temporarily_unavailable",
+       "Profile publication is temporarily unavailable"}
+
   defp error(reason)
        when reason in [
               :dropout,

--- a/lib/dbservice_web/controllers/holistic_mentorship_profile_publish_controller.ex
+++ b/lib/dbservice_web/controllers/holistic_mentorship_profile_publish_controller.ex
@@ -28,6 +28,7 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePublishController do
               :form_not_approved,
               :grade_ineligible,
               :journey_source_conflict,
+              :privacy_erased,
               :program_ineligible,
               :school_missing_or_ambiguous,
               :student_not_found,

--- a/lib/dbservice_web/controllers/holistic_mentorship_profile_publish_controller.ex
+++ b/lib/dbservice_web/controllers/holistic_mentorship_profile_publish_controller.ex
@@ -1,0 +1,40 @@
+defmodule DbserviceWeb.HolisticMentorshipProfilePublishController do
+  use DbserviceWeb, :controller
+
+  alias Dbservice.HolisticMentorship
+
+  def create(conn, params) do
+    case HolisticMentorship.publish_profile(params) do
+      {:ok, result} ->
+        json(conn, result)
+
+      {:error, reason} ->
+        {status, code, message} = error(reason)
+
+        conn
+        |> put_status(status)
+        |> json(%{error: %{code: code, message: message}})
+    end
+  end
+
+  defp error(:stale_profile_revision),
+    do: {:conflict, "stale_profile_revision", "Profile revision is stale"}
+
+  defp error(reason)
+       when reason in [
+              :dropout,
+              :eligibility_inconsistent,
+              :form_grade_mismatch,
+              :form_not_approved,
+              :grade_ineligible,
+              :journey_source_conflict,
+              :program_ineligible,
+              :school_missing_or_ambiguous,
+              :student_not_found,
+              :user_not_found
+            ],
+       do: {:unprocessable_entity, Atom.to_string(reason), "Profile publication is not eligible"}
+
+  defp error(_reason),
+    do: {:unprocessable_entity, "invalid_request", "Profile publication request is invalid"}
+end

--- a/lib/dbservice_web/controllers/holistic_mentorship_prompt_configuration_controller.ex
+++ b/lib/dbservice_web/controllers/holistic_mentorship_prompt_configuration_controller.ex
@@ -1,0 +1,68 @@
+defmodule DbserviceWeb.HolisticMentorshipPromptConfigurationController do
+  use DbserviceWeb, :controller
+
+  alias Dbservice.HolisticMentorship
+
+  def create(conn, params) do
+    case HolisticMentorship.register_prompt_configuration(params) do
+      {:ok, configuration} ->
+        json(conn, configuration)
+
+      {:error, :template_hash_mismatch} ->
+        error(
+          conn,
+          :unprocessable_entity,
+          "template_hash_mismatch",
+          "Template hash does not match template text"
+        )
+
+      {:error, :prompt_version_conflict} ->
+        error(
+          conn,
+          :conflict,
+          "prompt_version_conflict",
+          "Prompt Version already exists with different content"
+        )
+
+      {:error, :invalid_request} ->
+        error(
+          conn,
+          :unprocessable_entity,
+          "invalid_request",
+          "Required prompt configuration fields are missing or invalid"
+        )
+    end
+  end
+
+  def activate(conn, %{"id" => id}) do
+    case Integer.parse(id) do
+      {configuration_id, ""} -> activate_configuration(conn, configuration_id)
+      _ -> prompt_configuration_not_found(conn)
+    end
+  end
+
+  defp activate_configuration(conn, id) do
+    case HolisticMentorship.activate_prompt_configuration(id) do
+      {:ok, configuration} ->
+        json(conn, configuration)
+
+      {:error, :prompt_configuration_not_found} ->
+        prompt_configuration_not_found(conn)
+    end
+  end
+
+  defp prompt_configuration_not_found(conn) do
+    error(
+      conn,
+      :not_found,
+      "prompt_configuration_not_found",
+      "Prompt Configuration not found"
+    )
+  end
+
+  defp error(conn, status, code, message) do
+    conn
+    |> put_status(status)
+    |> json(%{error: %{code: code, message: message}})
+  end
+end

--- a/lib/dbservice_web/controllers/holistic_mentorship_regeneration_request_controller.ex
+++ b/lib/dbservice_web/controllers/holistic_mentorship_regeneration_request_controller.ex
@@ -1,0 +1,61 @@
+defmodule DbserviceWeb.HolisticMentorshipRegenerationRequestController do
+  use DbserviceWeb, :controller
+
+  alias Dbservice.HolisticMentorship
+
+  def show(conn, %{"request_key" => request_key}) do
+    case HolisticMentorship.get_regeneration_request(request_key) do
+      {:ok, request} ->
+        json(conn, request)
+
+      {:error, :regeneration_request_not_found} ->
+        error(
+          conn,
+          :not_found,
+          "regeneration_request_not_found",
+          "Regeneration Request not found"
+        )
+
+      {:error, reason} ->
+        error(conn, :unprocessable_entity, Atom.to_string(reason), "Student is not eligible")
+    end
+  end
+
+  def update_status(conn, %{"request_key" => request_key} = params) do
+    case HolisticMentorship.update_regeneration_request_status(request_key, params) do
+      {:ok, request} ->
+        json(conn, request)
+
+      {:error, :regeneration_request_not_found} ->
+        error(
+          conn,
+          :not_found,
+          "regeneration_request_not_found",
+          "Regeneration Request not found"
+        )
+
+      {:error, :invalid_request} ->
+        error(
+          conn,
+          :unprocessable_entity,
+          "invalid_request",
+          "Status fields are missing or invalid"
+        )
+
+      {:error, :invalid_transition} ->
+        error(conn, :conflict, "invalid_status_transition", "Status transition is invalid")
+
+      {:error, :terminal_status_conflict} ->
+        error(conn, :conflict, "terminal_status_conflict", "Regeneration Request is terminal")
+
+      {:error, :etl_run_conflict} ->
+        error(conn, :conflict, "etl_run_conflict", "ETL run conflicts with this request")
+    end
+  end
+
+  defp error(conn, status, code, message) do
+    conn
+    |> put_status(status)
+    |> json(%{error: %{code: code, message: message}})
+  end
+end

--- a/lib/dbservice_web/controllers/student_controller.ex
+++ b/lib/dbservice_web/controllers/student_controller.ex
@@ -236,6 +236,18 @@ defmodule DbserviceWeb.StudentController do
   end
 
   def enrolled(conn, params) do
+    case Repo.transaction(fn -> enroll_student(params) end) do
+      {:ok, updated_student} ->
+        render(conn, :show, student: updated_student)
+
+      {:error, reason} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{errors: inspect(reason)})
+    end
+  end
+
+  defp enroll_student(params) do
     # Retrieve the student information based on the provided student ID
     student = Users.get_student_by_student_id(params["student_id"])
     user_id = student.user_id
@@ -301,10 +313,10 @@ defmodule DbserviceWeb.StudentController do
     # Always update the batch group user
     BatchEnrollmentService.update_batch_user(user_id, batch_group_id, group_users)
 
-    # Update the student's status to "enrolled" and render the response
-    with {:ok, %Student{} = updated_student} <-
-           Users.update_student(student, %{"status" => "enrolled"}) do
-      render(conn, :show, student: updated_student)
+    # Update the student's status to "enrolled"
+    case Users.update_student(student, %{"status" => "enrolled"}) do
+      {:ok, %Student{} = updated_student} -> updated_student
+      {:error, reason} -> Repo.rollback(reason)
     end
   end
 
@@ -635,6 +647,20 @@ defmodule DbserviceWeb.StudentController do
   This function removes the dropout status from both the enrollment records and the student table.
   """
   def remove_dropout_status(conn, %{"student_id" => student_id}) do
+    case Repo.transaction(fn -> remove_dropout_status_transaction(student_id) end) do
+      {:ok, :ok} ->
+        conn
+        |> put_status(:ok)
+        |> json(%{message: "Student status updated successfully"})
+
+      {:error, reason} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: reason})
+    end
+  end
+
+  defp remove_dropout_status_transaction(student_id) do
     with {:ok, student} <- get_student(student_id),
          enrollment_records <-
            EnrollmentRecords.get_enrollment_records_by_user_id(student.user_id),
@@ -642,14 +668,9 @@ defmodule DbserviceWeb.StudentController do
          {:ok, _} <- handle_status_record(status_record),
          {:ok, _} <- update_current_status(enrollment_records),
          {:ok, _} <- set_student_status_to_null(student) do
-      conn
-      |> put_status(:ok)
-      |> json(%{message: "Student status updated successfully"})
+      :ok
     else
-      {:error, reason} ->
-        conn
-        |> put_status(:unprocessable_entity)
-        |> json(%{error: reason})
+      {:error, reason} -> Repo.rollback(reason)
     end
   end
 
@@ -789,8 +810,8 @@ defmodule DbserviceWeb.StudentController do
          student when not is_nil(student) <-
            Users.get_student_by_student_id(params["student_id"]),
          :ok <- check_existing_status(student, status.title),
-         {:ok, %Student{} = updated_student} <- update_student_status_field(student, status),
-         {:ok, _enrollment_record} <- create_status_enrollment_record(student, status, params) do
+         {:ok, %Student{} = updated_student} <-
+           update_student_status_transaction(student, status, params) do
       conn
       |> put_status(:ok)
       |> render(:show, student: updated_student)
@@ -815,6 +836,18 @@ defmodule DbserviceWeb.StudentController do
         |> put_status(:bad_request)
         |> json(%{error: "Failed to update status", details: changeset.errors})
     end
+  end
+
+  defp update_student_status_transaction(student, status, params) do
+    Repo.transaction(fn ->
+      with {:ok, %Student{} = updated_student} <- update_student_status_field(student, status),
+           {:ok, _enrollment_record} <-
+             create_status_enrollment_record(student, status, params) do
+        updated_student
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
   end
 
   # Helper function to check if student already has the status

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -63,13 +63,15 @@ defmodule DbserviceWeb.Router do
     post(
       "/holistic-mentorship/prompt-configurations",
       HolisticMentorshipPromptConfigurationController,
-      :create
+      :create,
+      log: false
     )
 
     post(
       "/holistic-mentorship/prompt-configurations/:id/activate",
       HolisticMentorshipPromptConfigurationController,
-      :activate
+      :activate,
+      log: false
     )
 
     post(

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -60,6 +60,18 @@ defmodule DbserviceWeb.Router do
     get("/health", HealthController, :index)
     get("/health/ready", HealthController, :ready)
 
+    post(
+      "/holistic-mentorship/prompt-configurations",
+      HolisticMentorshipPromptConfigurationController,
+      :create
+    )
+
+    post(
+      "/holistic-mentorship/prompt-configurations/:id/activate",
+      HolisticMentorshipPromptConfigurationController,
+      :activate
+    )
+
     resources("/auth-group", AuthGroupController, except: [:new, :edit])
     post("/group/:id/update-users", GroupController, :update_users)
     post("/group/:id/update-sessions", GroupController, :update_sessions)

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -86,6 +86,13 @@ defmodule DbserviceWeb.Router do
       log: false
     )
 
+    post(
+      "/holistic-mentorship/profiles/publish",
+      HolisticMentorshipProfilePublishController,
+      :create,
+      log: false
+    )
+
     get(
       "/holistic-mentorship/regeneration-requests/:request_key",
       HolisticMentorshipRegenerationRequestController,

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -72,6 +72,13 @@ defmodule DbserviceWeb.Router do
       :activate
     )
 
+    post(
+      "/holistic-mentorship/profile-preflight",
+      HolisticMentorshipProfilePreflightController,
+      :create,
+      log: false
+    )
+
     resources("/auth-group", AuthGroupController, except: [:new, :edit])
     post("/group/:id/update-users", GroupController, :update_users)
     post("/group/:id/update-sessions", GroupController, :update_sessions)

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -79,6 +79,13 @@ defmodule DbserviceWeb.Router do
       log: false
     )
 
+    post(
+      "/holistic-mentorship/profile-generation-statuses",
+      HolisticMentorshipProfileGenerationStatusController,
+      :create,
+      log: false
+    )
+
     resources("/auth-group", AuthGroupController, except: [:new, :edit])
     post("/group/:id/update-users", GroupController, :update_users)
     post("/group/:id/update-sessions", GroupController, :update_sessions)

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -86,6 +86,20 @@ defmodule DbserviceWeb.Router do
       log: false
     )
 
+    get(
+      "/holistic-mentorship/regeneration-requests/:request_key",
+      HolisticMentorshipRegenerationRequestController,
+      :show,
+      log: false
+    )
+
+    post(
+      "/holistic-mentorship/regeneration-requests/:request_key/status",
+      HolisticMentorshipRegenerationRequestController,
+      :update_status,
+      log: false
+    )
+
     resources("/auth-group", AuthGroupController, except: [:new, :edit])
     post("/group/:id/update-users", GroupController, :update_users)
     post("/group/:id/update-sessions", GroupController, :update_sessions)

--- a/priv/repo/migrations/20260701120000_add_lms_student_ingestion.exs
+++ b/priv/repo/migrations/20260701120000_add_lms_student_ingestion.exs
@@ -1,4 +1,3 @@
-# This version must remain distinct from 20260701120000_add_user_session_indexes.exs.
 defmodule Dbservice.Repo.Migrations.AddLmsStudentIngestion do
   use Ecto.Migration
 

--- a/priv/repo/migrations/20260701121000_add_lms_student_ingestion.exs
+++ b/priv/repo/migrations/20260701121000_add_lms_student_ingestion.exs
@@ -1,3 +1,4 @@
+# This version must remain distinct from 20260701120000_add_user_session_indexes.exs.
 defmodule Dbservice.Repo.Migrations.AddLmsStudentIngestion do
   use Ecto.Migration
 

--- a/priv/repo/migrations/20260716090000_create_holistic_mentorship_phase_plans.exs
+++ b/priv/repo/migrations/20260716090000_create_holistic_mentorship_phase_plans.exs
@@ -1,0 +1,219 @@
+defmodule Dbservice.Repo.Migrations.CreateHolisticMentorshipPhasePlans do
+  use Ecto.Migration
+
+  def change do
+    create table(:holistic_mentorship_phase_plans) do
+      add :program_id, references(:program, on_delete: :nothing), null: false
+      add :academic_year, :string, null: false
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create table(:holistic_mentorship_phases) do
+      add :phase_plan_id,
+          references(:holistic_mentorship_phase_plans, on_delete: :nothing),
+          null: false
+
+      add :grade_id, references(:grade, on_delete: :nothing), null: false
+      add :title, :string, null: false
+      add :position, :integer, null: false
+      add :state, :string, null: false
+      add :guidance_markdown, :text, null: false
+      add :revision, :integer, null: false
+      add :frozen_at, :utc_datetime
+      add :frozen_by_user_id, references(:user, on_delete: :nothing)
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create table(:holistic_mentorship_phase_questions) do
+      add :phase_id, references(:holistic_mentorship_phases, on_delete: :nothing), null: false
+      add :text, :text, null: false
+      add :position, :integer, null: false
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create unique_index(:holistic_mentorship_phase_plans, [:program_id, :academic_year],
+             name: :hm_phase_plan_scope_unique
+           )
+
+    create index(:holistic_mentorship_phase_plans, [:program_id],
+             name: :hm_phase_plans_program_idx
+           )
+
+    create unique_index(:holistic_mentorship_phases, [:phase_plan_id, :position],
+             name: :hm_phases_plan_position_unique
+           )
+
+    create index(:holistic_mentorship_phases, [:phase_plan_id, :grade_id, :state, :position],
+             name: :hm_phases_plan_grade_state_position_idx
+           )
+
+    create index(:holistic_mentorship_phases, [:grade_id], name: :hm_phases_grade_idx)
+
+    create index(:holistic_mentorship_phases, [:frozen_by_user_id],
+             name: :hm_phases_frozen_by_user_idx
+           )
+
+    create unique_index(:holistic_mentorship_phase_questions, [:phase_id, :position],
+             name: :hm_phase_questions_phase_position_unique
+           )
+
+    create index(:holistic_mentorship_phase_questions, [:phase_id],
+             name: :hm_phase_questions_phase_idx
+           )
+
+    create constraint(:holistic_mentorship_phases, :hm_phases_position_check,
+             check: "position > 0"
+           )
+
+    create constraint(:holistic_mentorship_phases, :hm_phases_state_check,
+             check: "state IN ('locked', 'open')"
+           )
+
+    create constraint(:holistic_mentorship_phases, :hm_phases_revision_check,
+             check: "revision > 0"
+           )
+
+    create constraint(
+             :holistic_mentorship_phase_questions,
+             :hm_phase_questions_position_check,
+             check: "position BETWEEN 1 AND 4"
+           )
+
+    execute(
+      """
+      CREATE FUNCTION holistic_mentorship_validate_phase_grade()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM grade WHERE id = NEW.grade_id AND number IN (11, 12)) THEN
+          RAISE EXCEPTION 'Holistic Mentorship Phases require Grade 11 or 12'
+            USING ERRCODE = '23514';
+        END IF;
+
+        RETURN NEW;
+      END;
+      $$;
+      """,
+      "DROP FUNCTION holistic_mentorship_validate_phase_grade()"
+    )
+
+    execute(
+      """
+      CREATE TRIGGER hm_phases_grade_check
+      BEFORE INSERT OR UPDATE OF grade_id ON holistic_mentorship_phases
+      FOR EACH ROW EXECUTE FUNCTION holistic_mentorship_validate_phase_grade()
+      """,
+      "DROP TRIGGER hm_phases_grade_check ON holistic_mentorship_phases"
+    )
+
+    execute(
+      """
+      CREATE FUNCTION holistic_mentorship_protect_phase_grade()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        IF (NEW.number IS NULL OR NEW.number NOT IN (11, 12))
+          AND EXISTS (SELECT 1 FROM holistic_mentorship_phases WHERE grade_id = NEW.id)
+        THEN
+          RAISE EXCEPTION 'A Grade used by Holistic Mentorship Phases must remain Grade 11 or 12'
+            USING ERRCODE = '23514';
+        END IF;
+
+        RETURN NEW;
+      END;
+      $$;
+      """,
+      "DROP FUNCTION holistic_mentorship_protect_phase_grade()"
+    )
+
+    execute(
+      """
+      CREATE TRIGGER hm_grade_phase_scope_check
+      BEFORE UPDATE OF number ON grade
+      FOR EACH ROW EXECUTE FUNCTION holistic_mentorship_protect_phase_grade()
+      """,
+      "DROP TRIGGER hm_grade_phase_scope_check ON grade"
+    )
+
+    execute(
+      """
+      CREATE FUNCTION holistic_mentorship_validate_phase_question_count()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $$
+      DECLARE
+        target_phase_id bigint;
+        question_count integer;
+      BEGIN
+        IF TG_TABLE_NAME = 'holistic_mentorship_phase_questions' THEN
+          IF TG_OP = 'UPDATE'
+            AND OLD.phase_id <> NEW.phase_id
+            AND EXISTS (SELECT 1 FROM holistic_mentorship_phases WHERE id = OLD.phase_id)
+          THEN
+            SELECT count(*) INTO question_count
+            FROM holistic_mentorship_phase_questions
+            WHERE phase_id = OLD.phase_id;
+
+            IF question_count NOT BETWEEN 1 AND 4 THEN
+              RAISE EXCEPTION 'Holistic Mentorship Phase % must have one to four Questions', OLD.phase_id
+                USING ERRCODE = '23514';
+            END IF;
+          END IF;
+        END IF;
+
+        IF TG_TABLE_NAME = 'holistic_mentorship_phases' THEN
+          target_phase_id := NEW.id;
+        ELSIF TG_OP = 'DELETE' THEN
+          target_phase_id := OLD.phase_id;
+        ELSE
+          target_phase_id := NEW.phase_id;
+        END IF;
+
+        IF EXISTS (SELECT 1 FROM holistic_mentorship_phases WHERE id = target_phase_id) THEN
+          SELECT count(*) INTO question_count
+          FROM holistic_mentorship_phase_questions
+          WHERE phase_id = target_phase_id;
+
+          IF question_count NOT BETWEEN 1 AND 4 THEN
+            RAISE EXCEPTION 'Holistic Mentorship Phase % must have one to four Questions', target_phase_id
+              USING ERRCODE = '23514';
+          END IF;
+        END IF;
+
+        IF TG_OP = 'DELETE' THEN
+          RETURN OLD;
+        END IF;
+
+        RETURN NEW;
+      END;
+      $$;
+      """,
+      "DROP FUNCTION holistic_mentorship_validate_phase_question_count()"
+    )
+
+    execute(
+      """
+      CREATE CONSTRAINT TRIGGER hm_phases_question_count
+      AFTER INSERT OR UPDATE ON holistic_mentorship_phases
+      DEFERRABLE INITIALLY DEFERRED
+      FOR EACH ROW EXECUTE FUNCTION holistic_mentorship_validate_phase_question_count()
+      """,
+      "DROP TRIGGER hm_phases_question_count ON holistic_mentorship_phases"
+    )
+
+    execute(
+      """
+      CREATE CONSTRAINT TRIGGER hm_phase_questions_count
+      AFTER INSERT OR UPDATE OR DELETE ON holistic_mentorship_phase_questions
+      DEFERRABLE INITIALLY DEFERRED
+      FOR EACH ROW EXECUTE FUNCTION holistic_mentorship_validate_phase_question_count()
+      """,
+      "DROP TRIGGER hm_phase_questions_count ON holistic_mentorship_phase_questions"
+    )
+  end
+end

--- a/priv/repo/migrations/20260716100000_create_holistic_mentorship_mentor_mentee_mappings.exs
+++ b/priv/repo/migrations/20260716100000_create_holistic_mentorship_mentor_mentee_mappings.exs
@@ -1,0 +1,62 @@
+defmodule Dbservice.Repo.Migrations.CreateHolisticMentorshipMentorMenteeMappings do
+  use Ecto.Migration
+
+  def change do
+    create table(:holistic_mentorship_mentor_mentee_mappings) do
+      add :student_id, references(:student, on_delete: :nothing), null: false
+      add :mentor_user_id, references(:user, on_delete: :nothing), null: false
+      add :school_id, references(:school, on_delete: :nothing), null: false
+      add :program_id, references(:program, on_delete: :nothing), null: false
+      add :academic_year, :string, null: false
+      add :started_at, :utc_datetime, null: false
+      add :assigned_by_user_id, references(:user, on_delete: :nothing)
+      add :assignment_source, :string, null: false
+      add :ended_at, :utc_datetime
+      add :ended_by_user_id, references(:user, on_delete: :nothing)
+      add :end_source, :string
+      add :end_reason, :string
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create unique_index(
+             :holistic_mentorship_mentor_mentee_mappings,
+             [:student_id, :academic_year],
+             where: "ended_at IS NULL",
+             name: :hm_mappings_active_student_year_unique
+           )
+
+    create index(
+             :holistic_mentorship_mentor_mentee_mappings,
+             [:school_id, :academic_year, :student_id],
+             where: "ended_at IS NULL",
+             name: :hm_mappings_active_school_year_idx
+           )
+
+    create index(
+             :holistic_mentorship_mentor_mentee_mappings,
+             [:mentor_user_id, :academic_year, :student_id],
+             where: "ended_at IS NULL",
+             name: :hm_mappings_active_mentor_year_idx
+           )
+
+    create index(
+             :holistic_mentorship_mentor_mentee_mappings,
+             [:student_id, :academic_year, :started_at],
+             name: :hm_mappings_student_history_idx
+           )
+
+    create constraint(
+             :holistic_mentorship_mentor_mentee_mappings,
+             :hm_mappings_lifecycle_check,
+             check: """
+             assignment_source <> '' AND (
+               (ended_at IS NULL AND ended_by_user_id IS NULL AND end_source IS NULL AND end_reason IS NULL)
+               OR
+               (ended_at IS NOT NULL AND end_source IS NOT NULL AND end_source <> ''
+                 AND end_reason IS NOT NULL AND end_reason <> '' AND ended_at >= started_at)
+             )
+             """
+           )
+  end
+end

--- a/priv/repo/migrations/20260716110000_create_holistic_mentorship_post_session_notes.exs
+++ b/priv/repo/migrations/20260716110000_create_holistic_mentorship_post_session_notes.exs
@@ -119,6 +119,16 @@ defmodule Dbservice.Repo.Migrations.CreateHolisticMentorshipPostSessionNotes do
             RAISE EXCEPTION 'Post-Session Notes Phase conflicts with an Answer Question'
               USING ERRCODE = '23514';
           END IF;
+        ELSIF TG_TABLE_NAME = 'holistic_mentorship_phase_questions' THEN
+          IF EXISTS (
+            SELECT 1
+            FROM holistic_mentorship_post_session_answers AS answer
+            JOIN holistic_mentorship_post_session_notes AS notes ON notes.id = answer.notes_id
+            WHERE answer.question_id = NEW.id AND notes.phase_id <> NEW.phase_id
+          ) THEN
+            RAISE EXCEPTION 'Phase Question conflicts with existing Post-Session Notes Answers'
+              USING ERRCODE = '23514';
+          END IF;
         END IF;
 
         RETURN NEW;
@@ -144,6 +154,15 @@ defmodule Dbservice.Repo.Migrations.CreateHolisticMentorshipPostSessionNotes do
       FOR EACH ROW EXECUTE FUNCTION holistic_mentorship_validate_notes_answer_phase()
       """,
       "DROP TRIGGER hm_post_session_notes_answer_phase_check ON holistic_mentorship_post_session_notes"
+    )
+
+    execute(
+      """
+      CREATE TRIGGER hm_phase_questions_notes_answer_phase_check
+      BEFORE UPDATE OF phase_id ON holistic_mentorship_phase_questions
+      FOR EACH ROW EXECUTE FUNCTION holistic_mentorship_validate_notes_answer_phase()
+      """,
+      "DROP TRIGGER hm_phase_questions_notes_answer_phase_check ON holistic_mentorship_phase_questions"
     )
 
     execute(

--- a/priv/repo/migrations/20260716110000_create_holistic_mentorship_post_session_notes.exs
+++ b/priv/repo/migrations/20260716110000_create_holistic_mentorship_post_session_notes.exs
@@ -1,0 +1,173 @@
+defmodule Dbservice.Repo.Migrations.CreateHolisticMentorshipPostSessionNotes do
+  use Ecto.Migration
+
+  def change do
+    create table(:holistic_mentorship_post_session_notes) do
+      add :student_id, references(:student, on_delete: :nothing), null: false
+      add :phase_id, references(:holistic_mentorship_phases, on_delete: :nothing), null: false
+      add :author_user_id, references(:user, on_delete: :nothing), null: false
+      add :state, :string, null: false
+      add :revision, :integer, null: false
+      add :first_drafted_at, :utc_datetime, null: false
+      add :first_submitted_at, :utc_datetime
+      add :last_edited_at, :utc_datetime, null: false
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create table(:holistic_mentorship_post_session_answers) do
+      add :notes_id,
+          references(:holistic_mentorship_post_session_notes, on_delete: :nothing),
+          null: false
+
+      add :question_id,
+          references(:holistic_mentorship_phase_questions, on_delete: :nothing),
+          null: false
+
+      add :answer, :text, null: false
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create table(:holistic_mentorship_post_session_note_audits) do
+      add :notes_id,
+          references(:holistic_mentorship_post_session_notes, on_delete: :nothing),
+          null: false
+
+      add :actor_user_id, references(:user, on_delete: :nothing), null: false
+      add :action, :string, null: false
+      add :occurred_at, :utc_datetime, null: false
+      add :reason, :string
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create unique_index(:holistic_mentorship_post_session_notes, [:student_id, :phase_id],
+             name: :hm_post_session_notes_student_phase_unique
+           )
+
+    create index(:holistic_mentorship_post_session_notes, [:phase_id],
+             name: :hm_post_session_notes_phase_idx
+           )
+
+    create index(:holistic_mentorship_post_session_notes, [:author_user_id],
+             name: :hm_post_session_notes_author_idx
+           )
+
+    create unique_index(:holistic_mentorship_post_session_answers, [:notes_id, :question_id],
+             name: :hm_post_session_answers_notes_question_unique
+           )
+
+    create index(:holistic_mentorship_post_session_answers, [:question_id],
+             name: :hm_post_session_answers_question_idx
+           )
+
+    create index(:holistic_mentorship_post_session_note_audits, [:notes_id, :occurred_at],
+             name: :hm_post_session_note_audits_notes_time_idx
+           )
+
+    create index(:holistic_mentorship_post_session_note_audits, [:actor_user_id],
+             name: :hm_post_session_note_audits_actor_idx
+           )
+
+    create constraint(:holistic_mentorship_post_session_notes, :hm_post_session_notes_state_check,
+             check: "state IN ('draft', 'submitted')"
+           )
+
+    create constraint(
+             :holistic_mentorship_post_session_notes,
+             :hm_post_session_notes_revision_check,
+             check: "revision > 0"
+           )
+
+    create constraint(
+             :holistic_mentorship_post_session_notes,
+             :hm_post_session_notes_timeline_check,
+             check: """
+             last_edited_at >= first_drafted_at AND
+             ((state = 'draft' AND first_submitted_at IS NULL) OR
+              (state = 'submitted' AND first_submitted_at IS NOT NULL AND
+               first_submitted_at BETWEEN first_drafted_at AND last_edited_at))
+             """
+           )
+
+    execute(
+      """
+      CREATE FUNCTION holistic_mentorship_validate_notes_answer_phase()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        IF TG_TABLE_NAME = 'holistic_mentorship_post_session_answers' THEN
+          IF NOT EXISTS (
+            SELECT 1
+            FROM holistic_mentorship_post_session_notes AS notes
+            JOIN holistic_mentorship_phase_questions AS question
+              ON question.id = NEW.question_id AND question.phase_id = notes.phase_id
+            WHERE notes.id = NEW.notes_id
+          ) THEN
+            RAISE EXCEPTION 'Post-Session Answer Question must belong to the Notes Phase'
+              USING ERRCODE = '23514';
+          END IF;
+        ELSIF TG_TABLE_NAME = 'holistic_mentorship_post_session_notes' THEN
+          IF EXISTS (
+            SELECT 1
+            FROM holistic_mentorship_post_session_answers AS answer
+            JOIN holistic_mentorship_phase_questions AS question ON question.id = answer.question_id
+            WHERE answer.notes_id = NEW.id AND question.phase_id <> NEW.phase_id
+          ) THEN
+            RAISE EXCEPTION 'Post-Session Notes Phase conflicts with an Answer Question'
+              USING ERRCODE = '23514';
+          END IF;
+        END IF;
+
+        RETURN NEW;
+      END;
+      $$;
+      """,
+      "DROP FUNCTION holistic_mentorship_validate_notes_answer_phase()"
+    )
+
+    execute(
+      """
+      CREATE TRIGGER hm_post_session_answers_phase_check
+      BEFORE INSERT OR UPDATE OF notes_id, question_id ON holistic_mentorship_post_session_answers
+      FOR EACH ROW EXECUTE FUNCTION holistic_mentorship_validate_notes_answer_phase()
+      """,
+      "DROP TRIGGER hm_post_session_answers_phase_check ON holistic_mentorship_post_session_answers"
+    )
+
+    execute(
+      """
+      CREATE TRIGGER hm_post_session_notes_answer_phase_check
+      BEFORE UPDATE OF phase_id ON holistic_mentorship_post_session_notes
+      FOR EACH ROW EXECUTE FUNCTION holistic_mentorship_validate_notes_answer_phase()
+      """,
+      "DROP TRIGGER hm_post_session_notes_answer_phase_check ON holistic_mentorship_post_session_notes"
+    )
+
+    execute(
+      """
+      CREATE FUNCTION holistic_mentorship_protect_notes_audit()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        RAISE EXCEPTION 'Post-Session Notes mutation audits are immutable'
+          USING ERRCODE = '23514';
+      END;
+      $$;
+      """,
+      "DROP FUNCTION holistic_mentorship_protect_notes_audit()"
+    )
+
+    execute(
+      """
+      CREATE TRIGGER hm_post_session_note_audits_immutable
+      BEFORE UPDATE OR DELETE ON holistic_mentorship_post_session_note_audits
+      FOR EACH ROW EXECUTE FUNCTION holistic_mentorship_protect_notes_audit()
+      """,
+      "DROP TRIGGER hm_post_session_note_audits_immutable ON holistic_mentorship_post_session_note_audits"
+    )
+  end
+end

--- a/priv/repo/migrations/20260716120000_create_holistic_mentorship_historical_notes.exs
+++ b/priv/repo/migrations/20260716120000_create_holistic_mentorship_historical_notes.exs
@@ -1,0 +1,122 @@
+defmodule Dbservice.Repo.Migrations.CreateHolisticMentorshipHistoricalNotes do
+  use Ecto.Migration
+
+  def change do
+    create table(:holistic_mentorship_historical_notes) do
+      add :student_id, references(:student, on_delete: :nothing), null: false
+      add :mentor_user_id, references(:user, on_delete: :nothing)
+      add :source_system, :string, null: false
+      add :source_record_key, :string, null: false
+      add :source_fingerprint, :string, null: false
+      add :imported_by_user_id, references(:user, on_delete: :nothing), null: false
+      add :imported_at, :utc_datetime, null: false
+      add :reconciliation_metadata, :map, null: false
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create table(:holistic_mentorship_historical_note_answers) do
+      add :historical_note_id,
+          references(:holistic_mentorship_historical_notes, on_delete: :nothing),
+          null: false
+
+      add :position, :integer, null: false
+      add :question, :text, null: false
+      add :answer, :text
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create unique_index(:holistic_mentorship_historical_notes, [:student_id, :source_system],
+             name: :hm_historical_notes_student_source_unique
+           )
+
+    create unique_index(
+             :holistic_mentorship_historical_note_answers,
+             [:historical_note_id, :position],
+             name: :hm_historical_note_answers_note_position_unique
+           )
+
+    create constraint(
+             :holistic_mentorship_historical_note_answers,
+             :hm_historical_note_answers_position_check,
+             check: "position BETWEEN 1 AND 4"
+           )
+
+    execute(
+      """
+      CREATE FUNCTION holistic_mentorship_validate_historical_answer_count()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $$
+      DECLARE
+        target_note_id bigint;
+        answer_count integer;
+      BEGIN
+        IF TG_TABLE_NAME = 'holistic_mentorship_historical_note_answers' THEN
+          IF TG_OP = 'UPDATE'
+            AND OLD.historical_note_id <> NEW.historical_note_id
+            AND EXISTS (SELECT 1 FROM holistic_mentorship_historical_notes WHERE id = OLD.historical_note_id)
+          THEN
+            SELECT count(*) INTO answer_count
+            FROM holistic_mentorship_historical_note_answers
+            WHERE historical_note_id = OLD.historical_note_id;
+
+            IF answer_count <> 4 THEN
+              RAISE EXCEPTION 'Historical Notes must have exactly four source Questions'
+                USING ERRCODE = '23514';
+            END IF;
+          END IF;
+        END IF;
+
+        IF TG_TABLE_NAME = 'holistic_mentorship_historical_notes' THEN
+          target_note_id := NEW.id;
+        ELSIF TG_OP = 'DELETE' THEN
+          target_note_id := OLD.historical_note_id;
+        ELSE
+          target_note_id := NEW.historical_note_id;
+        END IF;
+
+        IF EXISTS (SELECT 1 FROM holistic_mentorship_historical_notes WHERE id = target_note_id) THEN
+          SELECT count(*) INTO answer_count
+          FROM holistic_mentorship_historical_note_answers
+          WHERE historical_note_id = target_note_id;
+
+          IF answer_count <> 4 THEN
+            RAISE EXCEPTION 'Historical Notes must have exactly four source Questions'
+              USING ERRCODE = '23514';
+          END IF;
+        END IF;
+
+        IF TG_OP = 'DELETE' THEN
+          RETURN OLD;
+        END IF;
+
+        RETURN NEW;
+      END;
+      $$;
+      """,
+      "DROP FUNCTION holistic_mentorship_validate_historical_answer_count()"
+    )
+
+    execute(
+      """
+      CREATE CONSTRAINT TRIGGER hm_historical_notes_answer_count
+      AFTER INSERT OR UPDATE ON holistic_mentorship_historical_notes
+      DEFERRABLE INITIALLY DEFERRED
+      FOR EACH ROW EXECUTE FUNCTION holistic_mentorship_validate_historical_answer_count()
+      """,
+      "DROP TRIGGER hm_historical_notes_answer_count ON holistic_mentorship_historical_notes"
+    )
+
+    execute(
+      """
+      CREATE CONSTRAINT TRIGGER hm_historical_note_answers_count
+      AFTER INSERT OR UPDATE OR DELETE ON holistic_mentorship_historical_note_answers
+      DEFERRABLE INITIALLY DEFERRED
+      FOR EACH ROW EXECUTE FUNCTION holistic_mentorship_validate_historical_answer_count()
+      """,
+      "DROP TRIGGER hm_historical_note_answers_count ON holistic_mentorship_historical_note_answers"
+    )
+  end
+end

--- a/priv/repo/migrations/20260716130000_create_holistic_mentorship_prompt_configurations.exs
+++ b/priv/repo/migrations/20260716130000_create_holistic_mentorship_prompt_configurations.exs
@@ -1,0 +1,89 @@
+defmodule Dbservice.Repo.Migrations.CreateHolisticMentorshipPromptConfigurations do
+  use Ecto.Migration
+
+  def change do
+    create table(:holistic_mentorship_prompt_versions) do
+      add :version, :string, null: false
+      add :template_text, :text, null: false
+      add :template_hash, :string, null: false
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create table(:holistic_mentorship_prompt_configurations) do
+      add :prompt_version_id,
+          references(:holistic_mentorship_prompt_versions, on_delete: :nothing),
+          null: false
+
+      add :model_id, :string, null: false
+      add :state, :string, null: false, default: "inactive"
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create unique_index(:holistic_mentorship_prompt_versions, [:version],
+             name: :hm_prompt_versions_version_unique
+           )
+
+    create unique_index(
+             :holistic_mentorship_prompt_configurations,
+             [:prompt_version_id, :model_id],
+             name: :hm_prompt_configurations_version_model_unique
+           )
+
+    create constraint(
+             :holistic_mentorship_prompt_configurations,
+             :hm_prompt_configurations_state_check,
+             check: "state IN ('inactive', 'active')"
+           )
+
+    create unique_index(:holistic_mentorship_prompt_configurations, [:state],
+             where: "state = 'active'",
+             name: :hm_prompt_configurations_single_active
+           )
+
+    execute(
+      """
+      CREATE FUNCTION holistic_mentorship_protect_prompt_content()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        IF TG_OP = 'DELETE'
+          OR (TG_TABLE_NAME = 'holistic_mentorship_prompt_versions'
+              AND ((to_jsonb(NEW) ->> 'version') IS DISTINCT FROM (to_jsonb(OLD) ->> 'version')
+                   OR (to_jsonb(NEW) ->> 'template_text') IS DISTINCT FROM (to_jsonb(OLD) ->> 'template_text')
+                   OR (to_jsonb(NEW) ->> 'template_hash') IS DISTINCT FROM (to_jsonb(OLD) ->> 'template_hash')))
+          OR (TG_TABLE_NAME = 'holistic_mentorship_prompt_configurations'
+              AND ((to_jsonb(NEW) ->> 'prompt_version_id') IS DISTINCT FROM (to_jsonb(OLD) ->> 'prompt_version_id')
+                   OR (to_jsonb(NEW) ->> 'model_id') IS DISTINCT FROM (to_jsonb(OLD) ->> 'model_id')))
+        THEN
+          RAISE EXCEPTION 'Prompt content is immutable' USING ERRCODE = '23514';
+        END IF;
+
+        RETURN NEW;
+      END;
+      $$;
+      """,
+      "DROP FUNCTION holistic_mentorship_protect_prompt_content()"
+    )
+
+    execute(
+      """
+      CREATE TRIGGER hm_prompt_versions_immutable
+      BEFORE UPDATE OR DELETE ON holistic_mentorship_prompt_versions
+      FOR EACH ROW EXECUTE FUNCTION holistic_mentorship_protect_prompt_content()
+      """,
+      "DROP TRIGGER hm_prompt_versions_immutable ON holistic_mentorship_prompt_versions"
+    )
+
+    execute(
+      """
+      CREATE TRIGGER hm_prompt_configurations_immutable
+      BEFORE UPDATE OR DELETE ON holistic_mentorship_prompt_configurations
+      FOR EACH ROW EXECUTE FUNCTION holistic_mentorship_protect_prompt_content()
+      """,
+      "DROP TRIGGER hm_prompt_configurations_immutable ON holistic_mentorship_prompt_configurations"
+    )
+  end
+end

--- a/priv/repo/migrations/20260716140000_create_holistic_mentorship_student_profiles.exs
+++ b/priv/repo/migrations/20260716140000_create_holistic_mentorship_student_profiles.exs
@@ -1,0 +1,196 @@
+defmodule Dbservice.Repo.Migrations.CreateHolisticMentorshipStudentProfiles do
+  use Ecto.Migration
+
+  def change do
+    create table(:holistic_mentorship_profile_journeys) do
+      add :student_id, references(:student, on_delete: :nothing), null: false
+      add :form_id, :string, null: false
+      add :af_session_id, :string, null: false
+      add :entry_grade, :integer, null: false
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create table(:holistic_mentorship_student_profiles) do
+      add :profile_journey_id,
+          references(:holistic_mentorship_profile_journeys, on_delete: :nothing),
+          null: false
+
+      add :prompt_configuration_id,
+          references(:holistic_mentorship_prompt_configurations, on_delete: :nothing),
+          null: false
+
+      add :schema_fingerprint, :string, null: false
+      add :answer_fingerprint, :string, null: false
+      add :warehouse_loaded_at, :utc_datetime, null: false
+      add :generated_at, :utc_datetime, null: false
+      add :revision, :integer, null: false
+      add :last_successful_etl_run_id, :string, null: false
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create table(:holistic_mentorship_student_profile_summaries) do
+      add :student_profile_id,
+          references(:holistic_mentorship_student_profiles, on_delete: :delete_all),
+          null: false
+
+      add :position, :integer, null: false
+      add :question_set_title, :string, null: false
+      add :summary, :text, null: false
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create unique_index(:holistic_mentorship_profile_journeys, [:student_id],
+             name: :hm_profile_journeys_student_unique
+           )
+
+    create unique_index(
+             :holistic_mentorship_student_profiles,
+             [:profile_journey_id, :prompt_configuration_id],
+             name: :hm_student_profiles_journey_configuration_unique
+           )
+
+    create constraint(:holistic_mentorship_student_profiles, :hm_student_profiles_revision_check,
+             check: "revision > 0"
+           )
+
+    create unique_index(
+             :holistic_mentorship_student_profile_summaries,
+             [:student_profile_id, :position],
+             name: :hm_student_profile_summaries_profile_position_unique
+           )
+
+    create constraint(
+             :holistic_mentorship_student_profile_summaries,
+             :hm_student_profile_summaries_position_check,
+             check: "position BETWEEN 1 AND 5"
+           )
+
+    create constraint(
+             :holistic_mentorship_student_profile_summaries,
+             :hm_student_profile_summaries_content_check,
+             check: "btrim(question_set_title) <> '' AND btrim(summary) <> ''"
+           )
+
+    create constraint(:holistic_mentorship_profile_journeys, :hm_profile_journeys_source_check,
+             check: """
+             (form_id = '6a44a83d1184e717b920c499'
+              AND af_session_id = 'EnableStudents_6a44a83d1184e717b920c499'
+              AND entry_grade = 11)
+             OR
+             (form_id = '6a4deca8e030ebe34669fb0f'
+              AND af_session_id = 'EnableStudents_6a4deca8e030ebe34669fb0f'
+              AND entry_grade = 12)
+             """
+           )
+
+    execute(
+      """
+      CREATE FUNCTION holistic_mentorship_protect_profile_journey()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        IF NEW.student_id IS DISTINCT FROM OLD.student_id
+          OR NEW.form_id IS DISTINCT FROM OLD.form_id
+          OR NEW.af_session_id IS DISTINCT FROM OLD.af_session_id
+          OR NEW.entry_grade IS DISTINCT FROM OLD.entry_grade
+        THEN
+          RAISE EXCEPTION 'Profile journey identity is immutable' USING ERRCODE = '23514';
+        END IF;
+
+        RETURN NEW;
+      END;
+      $$;
+      """,
+      "DROP FUNCTION holistic_mentorship_protect_profile_journey()"
+    )
+
+    execute(
+      """
+      CREATE TRIGGER hm_profile_journeys_immutable
+      BEFORE UPDATE ON holistic_mentorship_profile_journeys
+      FOR EACH ROW EXECUTE FUNCTION holistic_mentorship_protect_profile_journey()
+      """,
+      "DROP TRIGGER hm_profile_journeys_immutable ON holistic_mentorship_profile_journeys"
+    )
+
+    execute(
+      """
+      CREATE FUNCTION holistic_mentorship_validate_profile_summary_count()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $$
+      DECLARE
+        target_profile_id bigint;
+        summary_count integer;
+      BEGIN
+        IF TG_TABLE_NAME = 'holistic_mentorship_student_profile_summaries' THEN
+          IF TG_OP = 'UPDATE'
+            AND OLD.student_profile_id <> NEW.student_profile_id
+            AND EXISTS (SELECT 1 FROM holistic_mentorship_student_profiles WHERE id = OLD.student_profile_id)
+          THEN
+            SELECT count(*) INTO summary_count
+            FROM holistic_mentorship_student_profile_summaries
+            WHERE student_profile_id = OLD.student_profile_id;
+
+            IF summary_count <> 5 THEN
+              RAISE EXCEPTION 'Student Profile must have exactly five summaries'
+                USING ERRCODE = '23514';
+            END IF;
+          END IF;
+        END IF;
+
+        IF TG_TABLE_NAME = 'holistic_mentorship_student_profiles' THEN
+          target_profile_id := NEW.id;
+        ELSIF TG_OP = 'DELETE' THEN
+          target_profile_id := OLD.student_profile_id;
+        ELSE
+          target_profile_id := NEW.student_profile_id;
+        END IF;
+
+        IF EXISTS (SELECT 1 FROM holistic_mentorship_student_profiles WHERE id = target_profile_id) THEN
+          SELECT count(*) INTO summary_count
+          FROM holistic_mentorship_student_profile_summaries
+          WHERE student_profile_id = target_profile_id;
+
+          IF summary_count <> 5 THEN
+            RAISE EXCEPTION 'Student Profile must have exactly five summaries'
+              USING ERRCODE = '23514';
+          END IF;
+        END IF;
+
+        IF TG_OP = 'DELETE' THEN
+          RETURN OLD;
+        END IF;
+
+        RETURN NEW;
+      END;
+      $$;
+      """,
+      "DROP FUNCTION holistic_mentorship_validate_profile_summary_count()"
+    )
+
+    execute(
+      """
+      CREATE CONSTRAINT TRIGGER hm_student_profiles_summary_count
+      AFTER INSERT OR UPDATE ON holistic_mentorship_student_profiles
+      DEFERRABLE INITIALLY DEFERRED
+      FOR EACH ROW EXECUTE FUNCTION holistic_mentorship_validate_profile_summary_count()
+      """,
+      "DROP TRIGGER hm_student_profiles_summary_count ON holistic_mentorship_student_profiles"
+    )
+
+    execute(
+      """
+      CREATE CONSTRAINT TRIGGER hm_student_profile_summaries_count
+      AFTER INSERT OR UPDATE OR DELETE ON holistic_mentorship_student_profile_summaries
+      DEFERRABLE INITIALLY DEFERRED
+      FOR EACH ROW EXECUTE FUNCTION holistic_mentorship_validate_profile_summary_count()
+      """,
+      "DROP TRIGGER hm_student_profile_summaries_count ON holistic_mentorship_student_profile_summaries"
+    )
+  end
+end

--- a/priv/repo/migrations/20260716150000_create_holistic_mentorship_profile_generation_statuses.exs
+++ b/priv/repo/migrations/20260716150000_create_holistic_mentorship_profile_generation_statuses.exs
@@ -1,0 +1,81 @@
+defmodule Dbservice.Repo.Migrations.CreateHolisticMentorshipProfileGenerationStatuses do
+  use Ecto.Migration
+
+  def change do
+    create table(:holistic_mentorship_profile_generation_statuses) do
+      add :etl_run_id, :string, null: false
+      add :student_id, references(:student, on_delete: :nothing), null: false
+      add :form_id, :string, null: false
+      add :af_session_id, :string, null: false
+      add :entry_grade, :integer, null: false
+
+      add :prompt_configuration_id,
+          references(:holistic_mentorship_prompt_configurations, on_delete: :nothing),
+          null: false
+
+      add :state, :string, null: false
+      add :completed_outcome, :string
+      add :error_code, :string
+      add :error_message, :string
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create unique_index(
+             :holistic_mentorship_profile_generation_statuses,
+             [
+               :etl_run_id,
+               :student_id,
+               :form_id,
+               :af_session_id,
+               :entry_grade,
+               :prompt_configuration_id
+             ],
+             name: :hm_profile_generation_statuses_identity_unique
+           )
+
+    create constraint(
+             :holistic_mentorship_profile_generation_statuses,
+             :hm_profile_generation_statuses_source_check,
+             check: """
+             (form_id = '6a44a83d1184e717b920c499'
+              AND af_session_id = 'EnableStudents_6a44a83d1184e717b920c499'
+              AND entry_grade = 11)
+             OR
+             (form_id = '6a4deca8e030ebe34669fb0f'
+              AND af_session_id = 'EnableStudents_6a4deca8e030ebe34669fb0f'
+              AND entry_grade = 12)
+             """
+           )
+
+    create constraint(
+             :holistic_mentorship_profile_generation_statuses,
+             :hm_profile_generation_statuses_state_check,
+             check: "state IN ('queued', 'running', 'completed', 'failed')"
+           )
+
+    create constraint(
+             :holistic_mentorship_profile_generation_statuses,
+             :hm_profile_generation_statuses_result_check,
+             check: """
+             (state = 'completed'
+              AND completed_outcome IN ('published', 'replaced', 'unchanged')
+              AND error_code IS NULL AND error_message IS NULL)
+             OR
+             (state = 'failed' AND completed_outcome IS NULL)
+             OR
+             (state IN ('queued', 'running') AND completed_outcome IS NULL
+              AND error_code IS NULL AND error_message IS NULL)
+             """
+           )
+
+    create constraint(
+             :holistic_mentorship_profile_generation_statuses,
+             :hm_profile_generation_statuses_safe_error_check,
+             check: """
+             (error_code IS NULL OR char_length(error_code) BETWEEN 1 AND 64)
+             AND (error_message IS NULL OR char_length(error_message) BETWEEN 1 AND 500)
+             """
+           )
+  end
+end

--- a/priv/repo/migrations/20260716150000_create_holistic_mentorship_profile_generation_statuses.exs
+++ b/priv/repo/migrations/20260716150000_create_holistic_mentorship_profile_generation_statuses.exs
@@ -16,7 +16,7 @@ defmodule Dbservice.Repo.Migrations.CreateHolisticMentorshipProfileGenerationSta
       add :state, :string, null: false
       add :completed_outcome, :string
       add :error_code, :string
-      add :error_message, :string
+      add :error_message, :text
 
       timestamps(default: fragment("now()"), null: false)
     end

--- a/priv/repo/migrations/20260716160000_create_holistic_mentorship_regeneration_requests.exs
+++ b/priv/repo/migrations/20260716160000_create_holistic_mentorship_regeneration_requests.exs
@@ -1,0 +1,87 @@
+defmodule Dbservice.Repo.Migrations.CreateHolisticMentorshipRegenerationRequests do
+  use Ecto.Migration
+
+  def change do
+    create table(:holistic_mentorship_regeneration_requests) do
+      add :request_key, :string, null: false
+      add :requested_by_user_id, references(:user, on_delete: :nothing), null: false
+      add :student_id, references(:student, on_delete: :nothing), null: false
+
+      add :prompt_configuration_id,
+          references(:holistic_mentorship_prompt_configurations, on_delete: :nothing),
+          null: false
+
+      add :force, :boolean, null: false, default: false
+      add :state, :string, null: false, default: "queued"
+      add :etl_run_id, :string
+      add :error_code, :string
+      add :error_message, :text
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create unique_index(:holistic_mentorship_regeneration_requests, [:request_key],
+             name: :hm_regeneration_requests_key_unique
+           )
+
+    create constraint(
+             :holistic_mentorship_regeneration_requests,
+             :hm_regeneration_requests_state_check,
+             check: "state IN ('queued', 'running', 'completed', 'failed')"
+           )
+
+    create constraint(
+             :holistic_mentorship_regeneration_requests,
+             :hm_regeneration_requests_state_metadata_check,
+             check: """
+             (state = 'queued' AND etl_run_id IS NULL AND error_code IS NULL AND error_message IS NULL)
+             OR (state = 'running' AND etl_run_id IS NOT NULL
+                 AND error_code IS NULL AND error_message IS NULL)
+             OR (state = 'completed' AND etl_run_id IS NOT NULL
+                 AND error_code IS NULL AND error_message IS NULL)
+             OR (state = 'failed' AND etl_run_id IS NOT NULL)
+             """
+           )
+
+    create constraint(
+             :holistic_mentorship_regeneration_requests,
+             :hm_regeneration_requests_safe_error_check,
+             check: """
+             (error_code IS NULL OR char_length(error_code) BETWEEN 1 AND 64)
+             AND (error_message IS NULL OR char_length(error_message) BETWEEN 1 AND 500)
+             """
+           )
+
+    execute(
+      """
+      CREATE FUNCTION holistic_mentorship_protect_regeneration_request_identity()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        IF NEW.request_key IS DISTINCT FROM OLD.request_key
+          OR NEW.requested_by_user_id IS DISTINCT FROM OLD.requested_by_user_id
+          OR NEW.student_id IS DISTINCT FROM OLD.student_id
+          OR NEW.prompt_configuration_id IS DISTINCT FROM OLD.prompt_configuration_id
+          OR NEW.force IS DISTINCT FROM OLD.force
+        THEN
+          RAISE EXCEPTION 'Regeneration Request identity is immutable' USING ERRCODE = '23514';
+        END IF;
+
+        RETURN NEW;
+      END;
+      $$;
+      """,
+      "DROP FUNCTION IF EXISTS holistic_mentorship_protect_regeneration_request_identity()"
+    )
+
+    execute(
+      """
+      CREATE TRIGGER hm_regeneration_requests_identity_immutable
+      BEFORE UPDATE ON holistic_mentorship_regeneration_requests
+      FOR EACH ROW EXECUTE FUNCTION holistic_mentorship_protect_regeneration_request_identity()
+      """,
+      "DROP TRIGGER IF EXISTS hm_regeneration_requests_identity_immutable ON holistic_mentorship_regeneration_requests"
+    )
+  end
+end

--- a/priv/repo/migrations/20260716170000_add_completed_revision_to_holistic_profile_generation_statuses.exs
+++ b/priv/repo/migrations/20260716170000_add_completed_revision_to_holistic_profile_generation_statuses.exs
@@ -1,0 +1,15 @@
+defmodule Dbservice.Repo.Migrations.AddCompletedRevisionToHolisticProfileGenerationStatuses do
+  use Ecto.Migration
+
+  def change do
+    alter table(:holistic_mentorship_profile_generation_statuses) do
+      add :completed_profile_revision, :integer
+    end
+
+    create constraint(
+             :holistic_mentorship_profile_generation_statuses,
+             :hm_profile_generation_statuses_completed_revision_check,
+             check: "completed_profile_revision IS NULL OR completed_profile_revision > 0"
+           )
+  end
+end

--- a/priv/repo/migrations/20260717100000_create_holistic_mentorship_phase_state_transitions.exs
+++ b/priv/repo/migrations/20260717100000_create_holistic_mentorship_phase_state_transitions.exs
@@ -1,0 +1,30 @@
+defmodule Dbservice.Repo.Migrations.CreateHolisticMentorshipPhaseStateTransitions do
+  use Ecto.Migration
+
+  def change do
+    create table(:holistic_mentorship_phase_state_transitions) do
+      add :phase_id, references(:holistic_mentorship_phases, on_delete: :nothing), null: false
+      add :from_state, :string, null: false
+      add :to_state, :string, null: false
+      add :actor_user_id, references(:user, on_delete: :nothing), null: false
+      add :occurred_at, :utc_datetime, null: false
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create index(:holistic_mentorship_phase_state_transitions, [:phase_id, :occurred_at, :id],
+             name: :hm_phase_state_transitions_timeline_idx
+           )
+
+    create index(:holistic_mentorship_phase_state_transitions, [:actor_user_id],
+             name: :hm_phase_state_transitions_actor_idx
+           )
+
+    create constraint(
+             :holistic_mentorship_phase_state_transitions,
+             :hm_phase_state_transitions_states_check,
+             check:
+               "from_state IN ('locked', 'open') AND to_state IN ('locked', 'open') AND from_state <> to_state"
+           )
+  end
+end

--- a/priv/repo/migrations/20260717101000_create_holistic_mentorship_phase_mutation_audits.exs
+++ b/priv/repo/migrations/20260717101000_create_holistic_mentorship_phase_mutation_audits.exs
@@ -1,0 +1,43 @@
+defmodule Dbservice.Repo.Migrations.CreateHolisticMentorshipPhaseMutationAudits do
+  use Ecto.Migration
+
+  def change do
+    create table(:holistic_mentorship_phase_mutation_audits) do
+      add :phase_plan_id,
+          references(:holistic_mentorship_phase_plans, on_delete: :nothing),
+          null: false
+
+      # Deliberately not an FK: deletion audits must outlive never-opened Phase rows.
+      add :phase_id, :bigint, null: false
+      add :action, :string, null: false
+      add :actor_user_id, references(:user, on_delete: :nothing), null: false
+      add :occurred_at, :utc_datetime, null: false
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create index(:holistic_mentorship_phase_mutation_audits, [:phase_id, :occurred_at, :id],
+             name: :hm_phase_mutation_audits_timeline_idx
+           )
+
+    create index(:holistic_mentorship_phase_mutation_audits, [:phase_plan_id],
+             name: :hm_phase_mutation_audits_plan_idx
+           )
+
+    create index(:holistic_mentorship_phase_mutation_audits, [:actor_user_id],
+             name: :hm_phase_mutation_audits_actor_idx
+           )
+
+    create constraint(
+             :holistic_mentorship_phase_mutation_audits,
+             :hm_phase_mutation_audits_phase_id_check,
+             check: "phase_id > 0"
+           )
+
+    create constraint(
+             :holistic_mentorship_phase_mutation_audits,
+             :hm_phase_mutation_audits_action_check,
+             check: "action IN ('created', 'definition_updated', 'reordered', 'deleted')"
+           )
+  end
+end

--- a/priv/repo/migrations/20260718090000_allow_regeneration_request_run_binding.exs
+++ b/priv/repo/migrations/20260718090000_allow_regeneration_request_run_binding.exs
@@ -1,0 +1,44 @@
+defmodule Dbservice.Repo.Migrations.AllowRegenerationRequestRunBinding do
+  use Ecto.Migration
+
+  def up do
+    drop constraint(
+           :holistic_mentorship_regeneration_requests,
+           :hm_regeneration_requests_state_metadata_check
+         )
+
+    create constraint(
+             :holistic_mentorship_regeneration_requests,
+             :hm_regeneration_requests_state_metadata_check,
+             check: """
+             (state = 'queued' AND error_code IS NULL AND error_message IS NULL)
+             OR (state = 'running' AND etl_run_id IS NOT NULL
+                 AND error_code IS NULL AND error_message IS NULL)
+             OR (state = 'completed' AND etl_run_id IS NOT NULL
+                 AND error_code IS NULL AND error_message IS NULL)
+             OR (state = 'failed' AND etl_run_id IS NOT NULL)
+             """
+           )
+  end
+
+  def down do
+    drop constraint(
+           :holistic_mentorship_regeneration_requests,
+           :hm_regeneration_requests_state_metadata_check
+         )
+
+    create constraint(
+             :holistic_mentorship_regeneration_requests,
+             :hm_regeneration_requests_state_metadata_check,
+             check: """
+             (state = 'queued' AND etl_run_id IS NULL
+                 AND error_code IS NULL AND error_message IS NULL)
+             OR (state = 'running' AND etl_run_id IS NOT NULL
+                 AND error_code IS NULL AND error_message IS NULL)
+             OR (state = 'completed' AND etl_run_id IS NOT NULL
+                 AND error_code IS NULL AND error_message IS NULL)
+             OR (state = 'failed' AND etl_run_id IS NOT NULL)
+             """
+           )
+  end
+end

--- a/priv/repo/migrations/20260718091000_protect_regeneration_request_run_binding.exs
+++ b/priv/repo/migrations/20260718091000_protect_regeneration_request_run_binding.exs
@@ -1,0 +1,39 @@
+defmodule Dbservice.Repo.Migrations.ProtectRegenerationRequestRunBinding do
+  use Ecto.Migration
+
+  def up do
+    execute(regeneration_request_guard(true))
+  end
+
+  def down do
+    execute(regeneration_request_guard(false))
+  end
+
+  defp regeneration_request_guard(protect_run_binding?) do
+    run_binding_guard =
+      if protect_run_binding?,
+        do: "OR (OLD.etl_run_id IS NOT NULL AND NEW.etl_run_id IS DISTINCT FROM OLD.etl_run_id)",
+        else: ""
+
+    """
+    CREATE OR REPLACE FUNCTION holistic_mentorship_protect_regeneration_request_identity()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      IF NEW.request_key IS DISTINCT FROM OLD.request_key
+        OR NEW.requested_by_user_id IS DISTINCT FROM OLD.requested_by_user_id
+        OR NEW.student_id IS DISTINCT FROM OLD.student_id
+        OR NEW.prompt_configuration_id IS DISTINCT FROM OLD.prompt_configuration_id
+        OR NEW.force IS DISTINCT FROM OLD.force
+        #{run_binding_guard}
+      THEN
+        RAISE EXCEPTION 'Regeneration Request identity is immutable' USING ERRCODE = '23514';
+      END IF;
+
+      RETURN NEW;
+    END;
+    $$;
+    """
+  end
+end

--- a/priv/repo/migrations/20260718092000_create_holistic_mentorship_privacy_deletions.exs
+++ b/priv/repo/migrations/20260718092000_create_holistic_mentorship_privacy_deletions.exs
@@ -1,0 +1,117 @@
+defmodule Dbservice.Repo.Migrations.CreateHolisticMentorshipPrivacyDeletions do
+  use Ecto.Migration
+
+  def change do
+    create table(:holistic_mentorship_privacy_deletions) do
+      add :student_id, references(:student, on_delete: :nothing), null: false
+      add :actor_user_id, references(:user, on_delete: :nothing), null: false
+      add :reason, :text, null: false
+      add :profile_summaries_erased, :integer, null: false
+      add :post_session_answers_erased, :integer, null: false
+      add :historical_answers_erased, :integer, null: false
+      add :occurred_at, :utc_datetime, null: false
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create unique_index(
+             :holistic_mentorship_privacy_deletions,
+             [:student_id],
+             name: :hm_privacy_deletions_student_uidx
+           )
+
+    create constraint(
+             :holistic_mentorship_privacy_deletions,
+             :hm_privacy_deletions_content_check,
+             check: """
+             btrim(reason) <> ''
+             AND profile_summaries_erased >= 0
+             AND post_session_answers_erased >= 0
+             AND historical_answers_erased >= 0
+             """
+           )
+
+    execute(
+      """
+      CREATE FUNCTION holistic_mentorship_protect_privacy_deletion()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        RAISE EXCEPTION 'Holistic Mentorship privacy deletions are immutable'
+          USING ERRCODE = '23514';
+      END;
+      $$;
+      """,
+      "DROP FUNCTION holistic_mentorship_protect_privacy_deletion()"
+    )
+
+    execute(
+      """
+      CREATE TRIGGER hm_privacy_deletions_immutable
+      BEFORE UPDATE OR DELETE ON holistic_mentorship_privacy_deletions
+      FOR EACH ROW EXECUTE FUNCTION holistic_mentorship_protect_privacy_deletion()
+      """,
+      "DROP TRIGGER hm_privacy_deletions_immutable ON holistic_mentorship_privacy_deletions"
+    )
+
+    execute(
+      """
+      CREATE FUNCTION holistic_mentorship_reject_erased_student_content()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $$
+      DECLARE
+        target_student_id bigint;
+      BEGIN
+        IF TG_TABLE_NAME = 'holistic_mentorship_student_profile_summaries' THEN
+          SELECT journey.student_id INTO target_student_id
+          FROM holistic_mentorship_student_profiles profile
+          JOIN holistic_mentorship_profile_journeys journey
+            ON journey.id = profile.profile_journey_id
+          WHERE profile.id = NEW.student_profile_id;
+        ELSIF TG_TABLE_NAME = 'holistic_mentorship_post_session_answers' THEN
+          SELECT notes.student_id INTO target_student_id
+          FROM holistic_mentorship_post_session_notes notes
+          WHERE notes.id = NEW.notes_id;
+        ELSIF TG_TABLE_NAME = 'holistic_mentorship_historical_note_answers' THEN
+          SELECT notes.student_id INTO target_student_id
+          FROM holistic_mentorship_historical_notes notes
+          WHERE notes.id = NEW.historical_note_id;
+        END IF;
+
+        -- Serialize every content writer with privacy deletion for this Student.
+        PERFORM pg_advisory_xact_lock(target_student_id::integer, 0);
+
+        IF EXISTS (
+          SELECT 1 FROM holistic_mentorship_privacy_deletions deletion
+          WHERE deletion.student_id = target_student_id
+        ) THEN
+          RAISE EXCEPTION 'Holistic Mentorship content is blocked after privacy deletion'
+            USING ERRCODE = '23514';
+        END IF;
+
+        RETURN NEW;
+      END;
+      $$;
+      """,
+      "DROP FUNCTION holistic_mentorship_reject_erased_student_content()"
+    )
+
+    for {table, trigger} <- [
+          {:holistic_mentorship_student_profile_summaries, :hm_profile_summaries_privacy_guard},
+          {:holistic_mentorship_post_session_answers, :hm_post_session_answers_privacy_guard},
+          {:holistic_mentorship_historical_note_answers,
+           :hm_historical_note_answers_privacy_guard}
+        ] do
+      execute(
+        """
+        CREATE TRIGGER #{trigger}
+        BEFORE INSERT OR UPDATE ON #{table}
+        FOR EACH ROW EXECUTE FUNCTION holistic_mentorship_reject_erased_student_content()
+        """,
+        "DROP TRIGGER #{trigger} ON #{table}"
+      )
+    end
+  end
+end

--- a/priv/repo/migrations/20260721170000_allow_email_only_holistic_phase_audit_actors.exs
+++ b/priv/repo/migrations/20260721170000_allow_email_only_holistic_phase_audit_actors.exs
@@ -1,0 +1,31 @@
+defmodule Dbservice.Repo.Migrations.AllowEmailOnlyHolisticPhaseAuditActors do
+  use Ecto.Migration
+
+  @tables [
+    "holistic_mentorship_phase_state_transitions",
+    "holistic_mentorship_phase_mutation_audits"
+  ]
+
+  def up do
+    for table <- @tables do
+      execute("ALTER TABLE #{table} ADD COLUMN actor_email varchar(255)")
+
+      execute("""
+      UPDATE #{table} audit
+      SET actor_email = LOWER(TRIM(actor.email))
+      FROM "user" actor
+      WHERE actor.id = audit.actor_user_id
+      """)
+
+      execute("ALTER TABLE #{table} ALTER COLUMN actor_email SET NOT NULL")
+      execute("ALTER TABLE #{table} ALTER COLUMN actor_user_id DROP NOT NULL")
+    end
+  end
+
+  def down do
+    for table <- Enum.reverse(@tables) do
+      execute("ALTER TABLE #{table} ALTER COLUMN actor_user_id SET NOT NULL")
+      execute("ALTER TABLE #{table} DROP COLUMN actor_email")
+    end
+  end
+end

--- a/priv/repo/migrations/20260724110000_add_user_session_indexes.exs
+++ b/priv/repo/migrations/20260724110000_add_user_session_indexes.exs
@@ -1,3 +1,4 @@
+# 20260701120000 is already deployed as AddLmsStudentIngestion.
 defmodule Dbservice.Repo.Migrations.AddUserSessionIndexes do
   use Ecto.Migration
 

--- a/test/dbservice/holistic_mentorship_historical_notes_schema_test.exs
+++ b/test/dbservice/holistic_mentorship_historical_notes_schema_test.exs
@@ -1,0 +1,279 @@
+defmodule Dbservice.HolisticMentorshipHistoricalNotesSchemaTest do
+  use Dbservice.DataCase, async: false
+
+  @notes "holistic_mentorship_historical_notes"
+  @answers "holistic_mentorship_historical_note_answers"
+
+  test "defines the namespaced Historical Notes provenance contract" do
+    assert column_types(@notes) == %{
+             "id" => "bigint",
+             "imported_at" => "timestamp without time zone",
+             "imported_by_user_id" => "bigint",
+             "inserted_at" => "timestamp without time zone",
+             "mentor_user_id" => "bigint",
+             "reconciliation_metadata" => "jsonb",
+             "source_fingerprint" => "character varying",
+             "source_record_key" => "character varying",
+             "source_system" => "character varying",
+             "student_id" => "bigint",
+             "updated_at" => "timestamp without time zone"
+           }
+
+    assert column_types(@answers) == %{
+             "answer" => "text",
+             "historical_note_id" => "bigint",
+             "id" => "bigint",
+             "inserted_at" => "timestamp without time zone",
+             "position" => "integer",
+             "question" => "text",
+             "updated_at" => "timestamp without time zone"
+           }
+
+    assert nullable_columns(@notes) == ["mentor_user_id"]
+    assert nullable_columns(@answers) == ["answer"]
+
+    assert foreign_keys(@notes) == [
+             {"imported_by_user_id", "user", "NO ACTION"},
+             {"mentor_user_id", "user", "NO ACTION"},
+             {"student_id", "student", "NO ACTION"}
+           ]
+
+    assert foreign_keys(@answers) == [
+             {"historical_note_id", @notes, "NO ACTION"}
+           ]
+  end
+
+  test "uses Student and source system as the idempotent provenance identity" do
+    scope = insert_scope()
+    assert {:ok, _} = insert_note(scope, "legacy-row-1")
+
+    assert_constraint(:unique_violation, fn ->
+      insert_note(scope, "different-legacy-row")
+    end)
+  end
+
+  test "requires exactly four ordered source Questions and permits partial answers" do
+    {incomplete_result, rows} =
+      Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+        incomplete_scope = insert_scope()
+        scope = insert_scope()
+
+        try do
+          incomplete_result = commit_note(incomplete_scope, "incomplete", [nil, nil, nil])
+
+          {:ok, note_id} =
+            commit_note(scope, "complete", [nil, "A partial answer", nil, nil])
+
+          rows =
+            Repo.query!(
+              """
+              SELECT position, question, answer
+              FROM holistic_mentorship_historical_note_answers
+              WHERE historical_note_id = $1
+              ORDER BY position
+              """,
+              [note_id]
+            ).rows
+
+          {incomplete_result, rows}
+        after
+          delete_scope(incomplete_scope)
+          delete_scope(scope)
+        end
+      end)
+
+    assert {:error, %Postgrex.Error{postgres: %{code: :check_violation}}} = incomplete_result
+
+    assert rows == [
+             [1, "Legacy question 1", nil],
+             [2, "Legacy question 2", "A partial answer"],
+             [3, "Legacy question 3", nil],
+             [4, "Legacy question 4", nil]
+           ]
+  end
+
+  test "allows an unmatched Mentor and restricts canonical provenance deletion" do
+    nullable_mentor_scope = insert_scope() |> Map.put(:mentor_user_id, nil)
+    nullable_note_id = insert_note_id!(nullable_mentor_scope, "nullable-mentor")
+
+    for position <- 1..4 do
+      insert_answer!(nullable_note_id, position, nil)
+    end
+
+    assert Repo.query!(
+             "SELECT mentor_user_id FROM holistic_mentorship_historical_notes WHERE id = $1",
+             [nullable_note_id]
+           ).rows == [[nil]]
+
+    scope = insert_scope()
+    note_id = insert_note_id!(scope, "protected-provenance")
+
+    for position <- 1..4 do
+      insert_answer!(note_id, position, nil)
+    end
+
+    for {table, id} <- [
+          {"student", scope.student_id},
+          {"user", scope.mentor_user_id},
+          {"user", scope.imported_by_user_id}
+        ] do
+      assert_constraint(:foreign_key_violation, fn ->
+        Repo.query("DELETE FROM \"#{table}\" WHERE id = $1", [id])
+      end)
+    end
+  end
+
+  test "limits each Historical Notes source position to one row from one through four" do
+    scope = insert_scope()
+    note_id = insert_note_id!(scope, "ordered-source")
+
+    assert_constraint(:check_violation, fn -> insert_answer(note_id, 0, nil) end)
+
+    insert_answer!(note_id, 1, nil)
+
+    assert_constraint(:unique_violation, fn ->
+      insert_answer(note_id, 1, "Duplicate position")
+    end)
+  end
+
+  defp column_types(table) do
+    Repo.query!(
+      """
+      SELECT column_name, data_type
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = $1
+      """,
+      [table]
+    ).rows
+    |> Map.new(fn [name, type] -> {name, type} end)
+  end
+
+  defp nullable_columns(table) do
+    Repo.query!(
+      """
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = $1 AND is_nullable = 'YES'
+      ORDER BY column_name
+      """,
+      [table]
+    ).rows
+    |> Enum.map(fn [name] -> name end)
+  end
+
+  defp foreign_keys(table) do
+    Repo.query!(
+      """
+      SELECT kcu.column_name, ccu.table_name, rc.delete_rule
+      FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+        ON kcu.constraint_name = tc.constraint_name AND kcu.table_schema = tc.table_schema
+      JOIN information_schema.constraint_column_usage ccu
+        ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema
+      JOIN information_schema.referential_constraints rc
+        ON rc.constraint_name = tc.constraint_name AND rc.constraint_schema = tc.table_schema
+      WHERE tc.constraint_type = 'FOREIGN KEY'
+        AND tc.table_schema = 'public'
+        AND tc.table_name = $1
+      ORDER BY kcu.column_name
+      """,
+      [table]
+    ).rows
+    |> Enum.map(fn [column, referenced_table, delete_rule] ->
+      {column, referenced_table, delete_rule}
+    end)
+  end
+
+  defp insert_scope do
+    [[student_user_id], [mentor_user_id], [imported_by_user_id]] =
+      Repo.query!(
+        "INSERT INTO \"user\" (inserted_at, updated_at) VALUES (now(), now()), (now(), now()), (now(), now()) RETURNING id"
+      ).rows
+
+    [[student_id]] =
+      Repo.query!(
+        "INSERT INTO student (user_id, inserted_at, updated_at) VALUES ($1, now(), now()) RETURNING id",
+        [student_user_id]
+      ).rows
+
+    %{
+      imported_by_user_id: imported_by_user_id,
+      mentor_user_id: mentor_user_id,
+      student_id: student_id,
+      student_user_id: student_user_id
+    }
+  end
+
+  defp insert_note(scope, source_record_key) do
+    Repo.query(
+      """
+      INSERT INTO holistic_mentorship_historical_notes
+        (student_id, mentor_user_id, source_system, source_record_key, source_fingerprint,
+         imported_by_user_id, imported_at, reconciliation_metadata)
+      VALUES ($1, $2, 'legacy_holistic_notes', $3, 'sha256:known', $4,
+              '2026-07-16 10:00:00', '{"match":"canonical_user"}')
+      RETURNING id
+      """,
+      [scope.student_id, scope.mentor_user_id, source_record_key, scope.imported_by_user_id]
+    )
+  end
+
+  defp insert_note_id!(scope, source_record_key) do
+    {:ok, %{rows: [[id]]}} = insert_note(scope, source_record_key)
+    id
+  end
+
+  defp insert_answer!(note_id, position, answer) do
+    {:ok, result} = insert_answer(note_id, position, answer)
+    result
+  end
+
+  defp insert_answer(note_id, position, answer) do
+    Repo.query(
+      """
+      INSERT INTO holistic_mentorship_historical_note_answers
+        (historical_note_id, position, question, answer)
+      VALUES ($1, $2, $3, $4)
+      """,
+      [note_id, position, "Legacy question #{position}", answer]
+    )
+  end
+
+  defp commit_note(scope, source_record_key, answers) do
+    Repo.transaction(fn ->
+      note_id = insert_note_id!(scope, source_record_key)
+
+      answers
+      |> Enum.with_index(1)
+      |> Enum.each(fn {answer, position} -> insert_answer!(note_id, position, answer) end)
+
+      note_id
+    end)
+  rescue
+    error in Postgrex.Error -> {:error, error}
+  end
+
+  defp delete_scope(scope) do
+    Repo.transaction(fn ->
+      Repo.query!(
+        "DELETE FROM holistic_mentorship_historical_note_answers WHERE historical_note_id IN (SELECT id FROM holistic_mentorship_historical_notes WHERE student_id = $1)",
+        [scope.student_id]
+      )
+
+      Repo.query!("DELETE FROM holistic_mentorship_historical_notes WHERE student_id = $1", [
+        scope.student_id
+      ])
+    end)
+
+    Repo.query!("DELETE FROM student WHERE id = $1", [scope.student_id])
+
+    Repo.query!("DELETE FROM \"user\" WHERE id = ANY($1)", [
+      [scope.student_user_id, scope.mentor_user_id, scope.imported_by_user_id]
+    ])
+  end
+
+  defp assert_constraint(code, query) do
+    assert {:error, {:error, %Postgrex.Error{postgres: %{code: ^code}}}} =
+             Repo.transaction(fn -> Repo.rollback(query.()) end, mode: :savepoint)
+  end
+end

--- a/test/dbservice/holistic_mentorship_mapping_schema_test.exs
+++ b/test/dbservice/holistic_mentorship_mapping_schema_test.exs
@@ -1,0 +1,384 @@
+defmodule Dbservice.HolisticMentorshipMappingSchemaTest do
+  use Dbservice.DataCase, async: false
+
+  alias Dbservice.HolisticMentorship
+
+  @table "holistic_mentorship_mentor_mentee_mappings"
+
+  test "defines the canonical Mapping contract and indexes" do
+    assert column_types() == %{
+             "academic_year" => "character varying",
+             "assigned_by_user_id" => "bigint",
+             "assignment_source" => "character varying",
+             "end_reason" => "character varying",
+             "end_source" => "character varying",
+             "ended_at" => "timestamp without time zone",
+             "ended_by_user_id" => "bigint",
+             "id" => "bigint",
+             "inserted_at" => "timestamp without time zone",
+             "mentor_user_id" => "bigint",
+             "program_id" => "bigint",
+             "school_id" => "bigint",
+             "started_at" => "timestamp without time zone",
+             "student_id" => "bigint",
+             "updated_at" => "timestamp without time zone"
+           }
+
+    assert nullable_columns() == [
+             "assigned_by_user_id",
+             "end_reason",
+             "end_source",
+             "ended_at",
+             "ended_by_user_id"
+           ]
+
+    assert foreign_keys() == [
+             {"assigned_by_user_id", "user", "NO ACTION"},
+             {"ended_by_user_id", "user", "NO ACTION"},
+             {"mentor_user_id", "user", "NO ACTION"},
+             {"program_id", "program", "NO ACTION"},
+             {"school_id", "school", "NO ACTION"},
+             {"student_id", "student", "NO ACTION"}
+           ]
+
+    assert check_names() == ["hm_mappings_lifecycle_check"]
+
+    assert indexes() == [
+             {"hm_mappings_active_mentor_year_idx", false,
+              ["mentor_user_id", "academic_year", "student_id"], "(ended_at IS NULL)"},
+             {"hm_mappings_active_school_year_idx", false,
+              ["school_id", "academic_year", "student_id"], "(ended_at IS NULL)"},
+             {"hm_mappings_active_student_year_unique", true, ["student_id", "academic_year"],
+              "(ended_at IS NULL)"},
+             {"hm_mappings_student_history_idx", false,
+              ["student_id", "academic_year", "started_at"], nil},
+             {"holistic_mentorship_mentor_mentee_mappings_pkey", true, ["id"], nil}
+           ]
+  end
+
+  test "enforces active and ended Mapping lifecycle states" do
+    scope = insert_scope()
+
+    invalid_lifecycles = [
+      [nil, nil, "manual_removal", nil],
+      [~N[2025-12-31 09:59:59], nil, "manual_removal", "af_lms"],
+      [~N[2026-07-16 10:01:00], nil, nil, "af_lms"],
+      [~N[2026-07-16 10:01:00], nil, "manual_removal", nil]
+    ]
+
+    for lifecycle <- invalid_lifecycles do
+      assert_check_violation(fn -> insert_mapping(scope, lifecycle) end)
+    end
+
+    assert {:ok, %{rows: [[mapping_id]]}} =
+             insert_mapping(scope, [
+               ~N[2026-07-16 10:01:00],
+               nil,
+               "student_dropout",
+               "db_service_student_eligibility"
+             ])
+
+    assert Repo.query!(
+             "SELECT ended_by_user_id FROM #{@table} WHERE id = $1",
+             [mapping_id]
+           ).rows == [[nil]]
+
+    assert_check_violation(fn ->
+      Repo.query("UPDATE #{@table} SET assignment_source = '' WHERE id = $1", [mapping_id])
+    end)
+  end
+
+  test "ends active Mappings once through the shared eligibility operation" do
+    scope = insert_scope()
+    assert {:ok, %{rows: [[mapping_id]]}} = insert_mapping(scope, [nil, nil, nil, nil])
+
+    assert {:error, :invalid_end_reason} =
+             HolisticMentorship.end_active_mappings(scope.student_id, :manual_removal)
+
+    assert Repo.query!("SELECT ended_at FROM #{@table} WHERE id = $1", [mapping_id]).rows == [
+             [nil]
+           ]
+
+    assert {:ok, {:ok, 1}} =
+             Repo.transaction(fn ->
+               HolisticMentorship.end_active_mappings(scope.student_id, :student_dropout)
+             end)
+
+    assert Repo.query!(
+             "SELECT id, ended_at IS NOT NULL, ended_by_user_id, end_source, end_reason FROM #{@table}",
+             []
+           ).rows == [
+             [
+               mapping_id,
+               true,
+               nil,
+               "db_service_student_eligibility",
+               "student_dropout"
+             ]
+           ]
+
+    assert {:ok, {:ok, 0}} =
+             Repo.transaction(fn ->
+               HolisticMentorship.end_active_mappings(scope.student_id, :student_dropout)
+             end)
+
+    assert Repo.query!("SELECT count(*) FROM #{@table}").rows == [[1]]
+  end
+
+  test "retains ended assignment history and restricts canonical deletion" do
+    scope = insert_scope()
+    assert {:ok, %{rows: [[first_id]]}} = insert_mapping(scope, [nil, nil, nil, nil])
+
+    [[other_school_id]] =
+      Repo.query!(
+        "INSERT INTO school (inserted_at, updated_at) VALUES (now(), now()) RETURNING id"
+      ).rows
+
+    assert_unique_violation(fn ->
+      insert_mapping(%{scope | school_id: other_school_id}, [nil, nil, nil, nil])
+    end)
+
+    Repo.query!(
+      """
+      UPDATE #{@table}
+      SET ended_at = '2026-01-02 10:00:00', ended_by_user_id = $1,
+          end_source = 'af_lms', end_reason = 'reassigned'
+      WHERE id = $2
+      """,
+      [scope.mentor_user_id, first_id]
+    )
+
+    assert {:ok, %{rows: [[second_id]]}} = insert_mapping(scope, [nil, nil, nil, nil])
+
+    assert Repo.query!(
+             "SELECT id, ended_at IS NULL FROM #{@table} ORDER BY id",
+             []
+           ).rows == [[first_id, false], [second_id, true]]
+
+    assert_foreign_key_violation(fn ->
+      Repo.query("DELETE FROM student WHERE id = $1", [scope.student_id])
+    end)
+
+    assert_foreign_key_violation(fn ->
+      Repo.query("DELETE FROM \"user\" WHERE id = $1", [scope.mentor_user_id])
+    end)
+  end
+
+  test "concurrent assignment is first-write-wins" do
+    results =
+      Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+        scope = insert_scope()
+
+        try do
+          parent = self()
+
+          tasks =
+            for _ <- 1..2 do
+              Task.async(fn ->
+                Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+                  send(parent, {:ready, self()})
+                  receive do: (:go -> insert_mapping(scope, [nil, nil, nil, nil]))
+                end)
+              end)
+            end
+
+          task_pids =
+            for _ <- tasks do
+              assert_receive {:ready, task_pid}
+              task_pid
+            end
+
+          Enum.each(task_pids, &send(&1, :go))
+          Enum.map(tasks, &Task.await/1)
+        after
+          delete_scope(scope)
+        end
+      end)
+
+    assert Enum.count(results, &match?({:ok, _}, &1)) == 1
+
+    assert Enum.count(results, fn
+             {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} -> true
+             _ -> false
+           end) == 1
+  end
+
+  defp column_types do
+    Repo.query!(
+      """
+      SELECT column_name, data_type
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = $1
+      """,
+      [@table]
+    ).rows
+    |> Map.new(fn [name, type] -> {name, type} end)
+  end
+
+  defp nullable_columns do
+    Repo.query!(
+      """
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = $1 AND is_nullable = 'YES'
+      ORDER BY column_name
+      """,
+      [@table]
+    ).rows
+    |> Enum.map(fn [name] -> name end)
+  end
+
+  defp foreign_keys do
+    Repo.query!(
+      """
+      SELECT kcu.column_name, ccu.table_name, rc.delete_rule
+      FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+        ON kcu.constraint_name = tc.constraint_name AND kcu.table_schema = tc.table_schema
+      JOIN information_schema.constraint_column_usage ccu
+        ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema
+      JOIN information_schema.referential_constraints rc
+        ON rc.constraint_name = tc.constraint_name AND rc.constraint_schema = tc.table_schema
+      WHERE tc.constraint_type = 'FOREIGN KEY'
+        AND tc.table_schema = 'public'
+        AND tc.table_name = $1
+      ORDER BY kcu.column_name
+      """,
+      [@table]
+    ).rows
+    |> Enum.map(fn [column, referenced_table, delete_rule] ->
+      {column, referenced_table, delete_rule}
+    end)
+  end
+
+  defp check_names do
+    Repo.query!(
+      """
+      SELECT constraint_record.conname
+      FROM pg_constraint AS constraint_record
+      JOIN pg_class AS relation ON relation.oid = constraint_record.conrelid
+      JOIN pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+      WHERE namespace.nspname = 'public'
+        AND relation.relname = $1
+        AND constraint_record.contype = 'c'
+      ORDER BY constraint_record.conname
+      """,
+      [@table]
+    ).rows
+    |> Enum.map(fn [name] -> name end)
+  end
+
+  defp indexes do
+    Repo.query!(
+      """
+      SELECT index_record.relname,
+             index.indisunique,
+             array_agg(attribute.attname ORDER BY key.ordinality),
+             pg_get_expr(index.indpred, index.indrelid)
+      FROM pg_index AS index
+      JOIN pg_class AS table_record ON table_record.oid = index.indrelid
+      JOIN pg_class AS index_record ON index_record.oid = index.indexrelid
+      JOIN LATERAL unnest(index.indkey) WITH ORDINALITY AS key(attnum, ordinality) ON true
+      JOIN pg_attribute AS attribute
+        ON attribute.attrelid = table_record.oid AND attribute.attnum = key.attnum
+      WHERE table_record.relname = $1
+      GROUP BY index_record.relname, index.indisunique, index.indpred, index.indrelid
+      ORDER BY index_record.relname
+      """,
+      [@table]
+    ).rows
+    |> Enum.map(fn [name, unique, columns, predicate] ->
+      {name, unique, columns, predicate}
+    end)
+  end
+
+  defp insert_scope do
+    [[student_user_id], [mentor_user_id]] =
+      Repo.query!(
+        "INSERT INTO \"user\" (inserted_at, updated_at) VALUES (now(), now()), (now(), now()) RETURNING id"
+      ).rows
+
+    [[student_id]] =
+      Repo.query!(
+        "INSERT INTO student (user_id, inserted_at, updated_at) VALUES ($1, now(), now()) RETURNING id",
+        [student_user_id]
+      ).rows
+
+    [[school_id]] =
+      Repo.query!(
+        "INSERT INTO school (inserted_at, updated_at) VALUES (now(), now()) RETURNING id"
+      ).rows
+
+    [[product_id]] =
+      Repo.query!(
+        "INSERT INTO product (name, inserted_at, updated_at) VALUES ('HM Mapping', now(), now()) RETURNING id"
+      ).rows
+
+    [[program_id]] =
+      Repo.query!(
+        "INSERT INTO program (name, product_id, inserted_at, updated_at) VALUES ('HM Mapping', $1, now(), now()) RETURNING id",
+        [product_id]
+      ).rows
+
+    %{
+      mentor_user_id: mentor_user_id,
+      product_id: product_id,
+      program_id: program_id,
+      school_id: school_id,
+      student_id: student_id,
+      student_user_id: student_user_id
+    }
+  end
+
+  defp delete_scope(scope) do
+    Repo.query!("DELETE FROM #{@table} WHERE student_id = $1", [scope.student_id])
+    Repo.query!("DELETE FROM student WHERE id = $1", [scope.student_id])
+
+    Repo.query!("DELETE FROM \"user\" WHERE id IN ($1, $2)", [
+      scope.student_user_id,
+      scope.mentor_user_id
+    ])
+
+    Repo.query!("DELETE FROM school WHERE id = $1", [scope.school_id])
+    Repo.query!("DELETE FROM program WHERE id = $1", [scope.program_id])
+    Repo.query!("DELETE FROM product WHERE id = $1", [scope.product_id])
+  end
+
+  defp insert_mapping(scope, [ended_at, ended_by_user_id, end_reason, end_source]) do
+    Repo.query(
+      """
+      INSERT INTO #{@table}
+        (student_id, mentor_user_id, school_id, program_id, academic_year, started_at,
+         assignment_source, ended_at, ended_by_user_id, end_reason, end_source)
+      VALUES ($1, $2, $3, $4, '2026-27', $5, 'af_lms', $6, $7, $8, $9)
+      RETURNING id
+      """,
+      [
+        scope.student_id,
+        scope.mentor_user_id,
+        scope.school_id,
+        scope.program_id,
+        ~N[2026-01-01 10:00:00],
+        ended_at,
+        ended_by_user_id,
+        end_reason,
+        end_source
+      ]
+    )
+  end
+
+  defp assert_check_violation(query) do
+    assert {:error, {:error, %Postgrex.Error{postgres: %{code: :check_violation}}}} =
+             Repo.transaction(fn -> Repo.rollback(query.()) end, mode: :savepoint)
+  end
+
+  defp assert_foreign_key_violation(query) do
+    assert {:error, {:error, %Postgrex.Error{postgres: %{code: :foreign_key_violation}}}} =
+             Repo.transaction(fn -> Repo.rollback(query.()) end, mode: :savepoint)
+  end
+
+  defp assert_unique_violation(query) do
+    assert {:error, {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}}} =
+             Repo.transaction(fn -> Repo.rollback(query.()) end, mode: :savepoint)
+  end
+end

--- a/test/dbservice/holistic_mentorship_notes_schema_test.exs
+++ b/test/dbservice/holistic_mentorship_notes_schema_test.exs
@@ -86,6 +86,13 @@ defmodule Dbservice.HolisticMentorshipNotesSchemaTest do
     assert_constraint(:check_violation, fn ->
       insert_answer(notes_id, Enum.at(other_scope.question_ids, 0), "Wrong Phase")
     end)
+
+    assert_constraint(:check_violation, fn ->
+      Repo.query(
+        "UPDATE holistic_mentorship_phase_questions SET phase_id = $1, position = 3 WHERE id = $2",
+        [other_scope.phase_id, Enum.at(scope.question_ids, 0)]
+      )
+    end)
   end
 
   test "defines a content-free Post-Session Notes mutation audit" do

--- a/test/dbservice/holistic_mentorship_notes_schema_test.exs
+++ b/test/dbservice/holistic_mentorship_notes_schema_test.exs
@@ -1,0 +1,346 @@
+defmodule Dbservice.HolisticMentorshipNotesSchemaTest do
+  use Dbservice.DataCase, async: false
+
+  test "rejects stale Post-Session Notes revisions" do
+    scope = insert_scope()
+
+    [[notes_id]] =
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_post_session_notes
+          (student_id, phase_id, author_user_id, state, revision,
+           first_drafted_at, last_edited_at)
+        VALUES ($1, $2, $3, 'draft', 1, now(), now())
+        RETURNING id
+        """,
+        [scope.student_id, scope.phase_id, scope.author_user_id]
+      ).rows
+
+    assert Repo.query!(
+             """
+             UPDATE holistic_mentorship_post_session_notes
+             SET revision = revision + 1, last_edited_at = now()
+             WHERE id = $1 AND revision = $2
+             RETURNING revision
+             """,
+             [notes_id, 1]
+           ).rows == [[2]]
+
+    assert Repo.query!(
+             """
+             UPDATE holistic_mentorship_post_session_notes
+             SET revision = revision + 1, last_edited_at = now()
+             WHERE id = $1 AND revision = $2
+             RETURNING revision
+             """,
+             [notes_id, 1]
+           ).rows == []
+  end
+
+  test "enforces one valid Notes lifecycle per Student and Phase" do
+    scope = insert_scope()
+    assert {:ok, _} = insert_note(scope, "draft", 1, nil)
+
+    assert_constraint(:unique_violation, fn -> insert_note(scope, "draft", 1, nil) end)
+
+    other_scope = insert_scope()
+
+    assert_constraint(:check_violation, fn ->
+      insert_note(other_scope, "reviewed", 1, nil)
+    end)
+
+    assert_constraint(:check_violation, fn ->
+      insert_note(other_scope, "draft", 0, nil)
+    end)
+
+    assert_constraint(:check_violation, fn ->
+      insert_note(other_scope, "submitted", 1, nil)
+    end)
+
+    assert {:ok, _} = insert_note(other_scope, "submitted", 1, ~N[2026-07-16 12:00:00])
+  end
+
+  test "stores one current answer per configured Question from the Notes Phase" do
+    scope = insert_scope()
+    other_scope = insert_scope()
+    {:ok, %{rows: [[notes_id]]}} = insert_note(scope, "draft", 1, nil)
+
+    assert {:ok, _} = insert_answer(notes_id, Enum.at(scope.question_ids, 1), "Second")
+    assert {:ok, _} = insert_answer(notes_id, Enum.at(scope.question_ids, 0), "First")
+
+    assert Repo.query!(
+             """
+             SELECT answer.answer
+             FROM holistic_mentorship_post_session_answers AS answer
+             JOIN holistic_mentorship_phase_questions AS question ON question.id = answer.question_id
+             WHERE answer.notes_id = $1
+             ORDER BY question.position
+             """,
+             [notes_id]
+           ).rows == [["First"], ["Second"]]
+
+    assert_constraint(:unique_violation, fn ->
+      insert_answer(notes_id, Enum.at(scope.question_ids, 0), "Replacement")
+    end)
+
+    assert_constraint(:check_violation, fn ->
+      insert_answer(notes_id, Enum.at(other_scope.question_ids, 0), "Wrong Phase")
+    end)
+  end
+
+  test "defines a content-free Post-Session Notes mutation audit" do
+    assert column_types("holistic_mentorship_post_session_note_audits") == %{
+             "action" => "character varying",
+             "actor_user_id" => "bigint",
+             "id" => "bigint",
+             "inserted_at" => "timestamp without time zone",
+             "notes_id" => "bigint",
+             "occurred_at" => "timestamp without time zone",
+             "reason" => "character varying",
+             "updated_at" => "timestamp without time zone"
+           }
+  end
+
+  test "defines the required namespaced Notes, Answer, and audit contract" do
+    assert column_types("holistic_mentorship_post_session_notes") == %{
+             "author_user_id" => "bigint",
+             "first_drafted_at" => "timestamp without time zone",
+             "first_submitted_at" => "timestamp without time zone",
+             "id" => "bigint",
+             "inserted_at" => "timestamp without time zone",
+             "last_edited_at" => "timestamp without time zone",
+             "phase_id" => "bigint",
+             "revision" => "integer",
+             "state" => "character varying",
+             "student_id" => "bigint",
+             "updated_at" => "timestamp without time zone"
+           }
+
+    assert column_types("holistic_mentorship_post_session_answers") == %{
+             "answer" => "text",
+             "id" => "bigint",
+             "inserted_at" => "timestamp without time zone",
+             "notes_id" => "bigint",
+             "question_id" => "bigint",
+             "updated_at" => "timestamp without time zone"
+           }
+
+    assert nullable_columns("holistic_mentorship_post_session_notes") == [
+             "first_submitted_at"
+           ]
+
+    assert nullable_columns("holistic_mentorship_post_session_answers") == []
+
+    assert nullable_columns("holistic_mentorship_post_session_note_audits") == ["reason"]
+
+    assert foreign_keys("holistic_mentorship_post_session_notes") == [
+             {"author_user_id", "user", "NO ACTION"},
+             {"phase_id", "holistic_mentorship_phases", "NO ACTION"},
+             {"student_id", "student", "NO ACTION"}
+           ]
+
+    assert foreign_keys("holistic_mentorship_post_session_answers") == [
+             {"notes_id", "holistic_mentorship_post_session_notes", "NO ACTION"},
+             {"question_id", "holistic_mentorship_phase_questions", "NO ACTION"}
+           ]
+
+    assert foreign_keys("holistic_mentorship_post_session_note_audits") == [
+             {"actor_user_id", "user", "NO ACTION"},
+             {"notes_id", "holistic_mentorship_post_session_notes", "NO ACTION"}
+           ]
+  end
+
+  test "retains used Notes records and mutation audits" do
+    scope = insert_scope()
+    {:ok, %{rows: [[notes_id]]}} = insert_note(scope, "draft", 1, nil)
+    assert {:ok, _} = insert_answer(notes_id, Enum.at(scope.question_ids, 0), "Current answer")
+
+    [[audit_id]] =
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_post_session_note_audits
+          (notes_id, actor_user_id, action, occurred_at)
+        VALUES ($1, $2, 'draft_saved', now())
+        RETURNING id
+        """,
+        [notes_id, scope.author_user_id]
+      ).rows
+
+    assert_constraint(:check_violation, fn ->
+      Repo.query("DELETE FROM holistic_mentorship_post_session_note_audits WHERE id = $1", [
+        audit_id
+      ])
+    end)
+
+    assert_constraint(:check_violation, fn ->
+      Repo.query(
+        "UPDATE holistic_mentorship_post_session_note_audits SET action = 'changed' WHERE id = $1",
+        [audit_id]
+      )
+    end)
+
+    for {table, id} <- [
+          {"student", scope.student_id},
+          {"user", scope.author_user_id},
+          {"holistic_mentorship_phases", scope.phase_id},
+          {"holistic_mentorship_phase_questions", Enum.at(scope.question_ids, 0)},
+          {"holistic_mentorship_post_session_notes", notes_id}
+        ] do
+      assert_constraint(:foreign_key_violation, fn ->
+        Repo.query("DELETE FROM \"#{table}\" WHERE id = $1", [id])
+      end)
+    end
+  end
+
+  defp insert_scope do
+    [[student_user_id], [author_user_id]] =
+      Repo.query!(
+        "INSERT INTO \"user\" (inserted_at, updated_at) VALUES (now(), now()), (now(), now()) RETURNING id"
+      ).rows
+
+    [[student_id]] =
+      Repo.query!(
+        "INSERT INTO student (user_id, inserted_at, updated_at) VALUES ($1, now(), now()) RETURNING id",
+        [student_user_id]
+      ).rows
+
+    [[product_id]] =
+      Repo.query!(
+        "INSERT INTO product (name, inserted_at, updated_at) VALUES ('HM Notes', now(), now()) RETURNING id"
+      ).rows
+
+    [[program_id]] =
+      Repo.query!(
+        "INSERT INTO program (name, product_id, inserted_at, updated_at) VALUES ('HM Notes', $1, now(), now()) RETURNING id",
+        [product_id]
+      ).rows
+
+    [[grade_id]] =
+      Repo.query!(
+        "INSERT INTO grade (number, inserted_at, updated_at) VALUES (11, now(), now()) RETURNING id"
+      ).rows
+
+    {:ok, {phase_id, question_ids}} =
+      Repo.transaction(fn ->
+        [[plan_id]] =
+          Repo.query!(
+            "INSERT INTO holistic_mentorship_phase_plans (program_id, academic_year) VALUES ($1, '2026-27') RETURNING id",
+            [program_id]
+          ).rows
+
+        [[phase_id]] =
+          Repo.query!(
+            """
+            INSERT INTO holistic_mentorship_phases
+              (phase_plan_id, grade_id, title, position, state, guidance_markdown, revision)
+            VALUES ($1, $2, 'HM Notes Phase', 1, 'open', 'Guidance', 1)
+            RETURNING id
+            """,
+            [plan_id, grade_id]
+          ).rows
+
+        question_ids =
+          Repo.query!(
+            """
+            INSERT INTO holistic_mentorship_phase_questions (phase_id, text, position)
+            VALUES ($1, 'Reflect', 1), ($1, 'Plan', 2)
+            RETURNING id
+            """,
+            [phase_id]
+          ).rows
+          |> Enum.map(fn [id] -> id end)
+
+        {phase_id, question_ids}
+      end)
+
+    %{
+      author_user_id: author_user_id,
+      phase_id: phase_id,
+      question_ids: question_ids,
+      student_id: student_id
+    }
+  end
+
+  defp insert_note(scope, state, revision, first_submitted_at) do
+    Repo.query(
+      """
+      INSERT INTO holistic_mentorship_post_session_notes
+        (student_id, phase_id, author_user_id, state, revision,
+         first_drafted_at, first_submitted_at, last_edited_at)
+      VALUES ($1, $2, $3, $4, $5, '2026-07-16 10:00:00', $6, '2026-07-16 12:00:00')
+      RETURNING id
+      """,
+      [
+        scope.student_id,
+        scope.phase_id,
+        scope.author_user_id,
+        state,
+        revision,
+        first_submitted_at
+      ]
+    )
+  end
+
+  defp insert_answer(notes_id, question_id, answer) do
+    Repo.query(
+      """
+      INSERT INTO holistic_mentorship_post_session_answers (notes_id, question_id, answer)
+      VALUES ($1, $2, $3)
+      """,
+      [notes_id, question_id, answer]
+    )
+  end
+
+  defp column_types(table) do
+    Repo.query!(
+      """
+      SELECT column_name, data_type
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = $1
+      """,
+      [table]
+    ).rows
+    |> Map.new(fn [name, type] -> {name, type} end)
+  end
+
+  defp nullable_columns(table) do
+    Repo.query!(
+      """
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = $1 AND is_nullable = 'YES'
+      ORDER BY column_name
+      """,
+      [table]
+    ).rows
+    |> Enum.map(fn [name] -> name end)
+  end
+
+  defp foreign_keys(table) do
+    Repo.query!(
+      """
+      SELECT kcu.column_name, ccu.table_name, rc.delete_rule
+      FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+        ON kcu.constraint_name = tc.constraint_name AND kcu.table_schema = tc.table_schema
+      JOIN information_schema.constraint_column_usage ccu
+        ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema
+      JOIN information_schema.referential_constraints rc
+        ON rc.constraint_name = tc.constraint_name AND rc.constraint_schema = tc.table_schema
+      WHERE tc.constraint_type = 'FOREIGN KEY'
+        AND tc.table_schema = 'public'
+        AND tc.table_name = $1
+      ORDER BY kcu.column_name
+      """,
+      [table]
+    ).rows
+    |> Enum.map(fn [column, referenced_table, delete_rule] ->
+      {column, referenced_table, delete_rule}
+    end)
+  end
+
+  defp assert_constraint(code, query) do
+    assert {:error, {:error, %Postgrex.Error{postgres: %{code: ^code}}}} =
+             Repo.transaction(fn -> Repo.rollback(query.()) end, mode: :savepoint)
+  end
+end

--- a/test/dbservice/holistic_mentorship_phase_schema_test.exs
+++ b/test/dbservice/holistic_mentorship_phase_schema_test.exs
@@ -33,11 +33,66 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
     ]
   }
 
+  @expected_column_types %{
+    "holistic_mentorship_phase_plans" => %{
+      "academic_year" => "character varying",
+      "id" => "bigint",
+      "inserted_at" => "timestamp without time zone",
+      "program_id" => "bigint",
+      "updated_at" => "timestamp without time zone"
+    },
+    "holistic_mentorship_phases" => %{
+      "frozen_at" => "timestamp without time zone",
+      "frozen_by_user_id" => "bigint",
+      "grade_id" => "bigint",
+      "guidance_markdown" => "text",
+      "id" => "bigint",
+      "inserted_at" => "timestamp without time zone",
+      "phase_plan_id" => "bigint",
+      "position" => "integer",
+      "revision" => "integer",
+      "state" => "character varying",
+      "title" => "character varying",
+      "updated_at" => "timestamp without time zone"
+    },
+    "holistic_mentorship_phase_questions" => %{
+      "id" => "bigint",
+      "inserted_at" => "timestamp without time zone",
+      "phase_id" => "bigint",
+      "position" => "integer",
+      "text" => "text",
+      "updated_at" => "timestamp without time zone"
+    }
+  }
+
+  @expected_checks %{
+    "holistic_mentorship_phase_plans" => [],
+    "holistic_mentorship_phases" => [
+      "hm_phases_position_check",
+      "hm_phases_revision_check",
+      "hm_phases_state_check"
+    ],
+    "holistic_mentorship_phase_questions" => ["hm_phase_questions_position_check"]
+  }
+
   describe "Holistic Mentorship Phase Plan schema" do
     test "creates only the required Phase Plan tables and columns" do
       for {table, expected_columns} <- @expected_columns do
         assert column_names(table) == expected_columns
+        assert column_types(table) == @expected_column_types[table]
+        assert check_names(table) == @expected_checks[table]
       end
+    end
+
+    test "uses deferred Question-cardinality constraint triggers" do
+      assert trigger_properties("holistic_mentorship_phases") == [
+               {"hm_phases_grade_check", false, false},
+               {"hm_phases_question_count", true, true}
+             ]
+
+      assert trigger_properties("holistic_mentorship_phase_questions") == [
+               {"hm_phase_questions_count", true, true}
+             ]
     end
 
     test "uses restrictive canonical relationships, timestamps, and lookup indexes" do
@@ -245,6 +300,52 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
     |> Enum.map(fn [name] -> name end)
   end
 
+  defp column_types(table) do
+    Repo.query!(
+      """
+      SELECT column_name, data_type
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = $1
+      """,
+      [table]
+    ).rows
+    |> Map.new(fn [name, type] -> {name, type} end)
+  end
+
+  defp check_names(table) do
+    Repo.query!(
+      """
+      SELECT constraint_record.conname
+      FROM pg_constraint AS constraint_record
+      JOIN pg_class AS relation ON relation.oid = constraint_record.conrelid
+      JOIN pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+      WHERE namespace.nspname = 'public'
+        AND relation.relname = $1
+        AND constraint_record.contype = 'c'
+      ORDER BY constraint_record.conname
+      """,
+      [table]
+    ).rows
+    |> Enum.map(fn [name] -> name end)
+  end
+
+  defp trigger_properties(table) do
+    Repo.query!(
+      """
+      SELECT trigger.tgname, trigger.tgdeferrable, trigger.tginitdeferred
+      FROM pg_trigger AS trigger
+      JOIN pg_class AS relation ON relation.oid = trigger.tgrelid
+      JOIN pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+      WHERE namespace.nspname = 'public' AND relation.relname = $1 AND NOT trigger.tgisinternal
+      ORDER BY trigger.tgname
+      """,
+      [table]
+    ).rows
+    |> Enum.map(fn [name, deferrable, initially_deferred] ->
+      {name, deferrable, initially_deferred}
+    end)
+  end
+
   defp assert_required(table, expected) do
     nullable =
       Repo.query!(
@@ -299,21 +400,8 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
   end
 
   defp insert_scope do
-    [[product_id]] =
-      Repo.query!(
-        "INSERT INTO product (name, inserted_at, updated_at) VALUES ('HM test', now(), now()) RETURNING id"
-      ).rows
-
-    [[program_id]] =
-      Repo.query!(
-        "INSERT INTO program (name, product_id, inserted_at, updated_at) VALUES ('HM test', $1, now(), now()) RETURNING id",
-        [product_id]
-      ).rows
-
-    [[grade_11_id]] =
-      Repo.query!(
-        "INSERT INTO grade (number, inserted_at, updated_at) VALUES (11, now(), now()) RETURNING id"
-      ).rows
+    %{program_id: program_id, grade_id: grade_11_id} =
+      canonical = insert_committed_canonical_scope("HM test")
 
     [[grade_10_id]] =
       Repo.query!(
@@ -330,12 +418,11 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
         [program_id]
       ).rows
 
-    %{
+    Map.merge(canonical, %{
       plan_id: plan_id,
-      program_id: program_id,
       grade_11_id: grade_11_id,
       grade_10_id: grade_10_id
-    }
+    })
   end
 
   defp insert_phase(plan_id, grade_id, position, state \\ "open") do
@@ -364,16 +451,17 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
     assert code in [:check_violation, :foreign_key_violation, :raise_exception, :unique_violation]
   end
 
-  defp insert_committed_canonical_scope do
+  defp insert_committed_canonical_scope(label \\ "HM cardinality") do
     [[product_id]] =
       Repo.query!(
-        "INSERT INTO product (name, inserted_at, updated_at) VALUES ('HM cardinality', now(), now()) RETURNING id"
+        "INSERT INTO product (name, inserted_at, updated_at) VALUES ($1, now(), now()) RETURNING id",
+        [label]
       ).rows
 
     [[program_id]] =
       Repo.query!(
-        "INSERT INTO program (name, product_id, inserted_at, updated_at) VALUES ('HM cardinality', $1, now(), now()) RETURNING id",
-        [product_id]
+        "INSERT INTO program (name, product_id, inserted_at, updated_at) VALUES ($1, $2, now(), now()) RETURNING id",
+        [label, product_id]
       ).rows
 
     [[grade_id]] =

--- a/test/dbservice/holistic_mentorship_phase_schema_test.exs
+++ b/test/dbservice/holistic_mentorship_phase_schema_test.exs
@@ -91,7 +91,8 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
              ]
 
       assert trigger_properties("holistic_mentorship_phase_questions") == [
-               {"hm_phase_questions_count", true, true}
+               {"hm_phase_questions_count", true, true},
+               {"hm_phase_questions_notes_answer_phase_check", false, false}
              ]
     end
 

--- a/test/dbservice/holistic_mentorship_phase_schema_test.exs
+++ b/test/dbservice/holistic_mentorship_phase_schema_test.exs
@@ -40,6 +40,16 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
       "phase_id",
       "to_state",
       "updated_at"
+    ],
+    "holistic_mentorship_phase_mutation_audits" => [
+      "action",
+      "actor_user_id",
+      "id",
+      "inserted_at",
+      "occurred_at",
+      "phase_id",
+      "phase_plan_id",
+      "updated_at"
     ]
   }
 
@@ -82,6 +92,16 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
       "phase_id" => "bigint",
       "to_state" => "character varying",
       "updated_at" => "timestamp without time zone"
+    },
+    "holistic_mentorship_phase_mutation_audits" => %{
+      "action" => "character varying",
+      "actor_user_id" => "bigint",
+      "id" => "bigint",
+      "inserted_at" => "timestamp without time zone",
+      "occurred_at" => "timestamp without time zone",
+      "phase_id" => "bigint",
+      "phase_plan_id" => "bigint",
+      "updated_at" => "timestamp without time zone"
     }
   }
 
@@ -95,6 +115,10 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
     "holistic_mentorship_phase_questions" => ["hm_phase_questions_position_check"],
     "holistic_mentorship_phase_state_transitions" => [
       "hm_phase_state_transitions_states_check"
+    ],
+    "holistic_mentorship_phase_mutation_audits" => [
+      "hm_phase_mutation_audits_action_check",
+      "hm_phase_mutation_audits_phase_id_check"
     ]
   }
 
@@ -139,6 +163,11 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
                {"phase_id", "holistic_mentorship_phases", "NO ACTION"}
              ]
 
+      assert foreign_keys("holistic_mentorship_phase_mutation_audits") == [
+               {"actor_user_id", "user", "NO ACTION"},
+               {"phase_plan_id", "holistic_mentorship_phase_plans", "NO ACTION"}
+             ]
+
       for table <- Map.keys(@expected_columns) do
         assert_required(table, ["id", "inserted_at", "updated_at"])
       end
@@ -161,6 +190,14 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
         "phase_id",
         "from_state",
         "to_state",
+        "actor_user_id",
+        "occurred_at"
+      ])
+
+      assert_required("holistic_mentorship_phase_mutation_audits", [
+        "phase_plan_id",
+        "phase_id",
+        "action",
         "actor_user_id",
         "occurred_at"
       ])
@@ -189,6 +226,13 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
                "hm_phase_state_transitions_actor_idx",
                "hm_phase_state_transitions_timeline_idx",
                "holistic_mentorship_phase_state_transitions_pkey"
+             ]
+
+      assert index_names("holistic_mentorship_phase_mutation_audits") == [
+               "hm_phase_mutation_audits_actor_idx",
+               "hm_phase_mutation_audits_plan_idx",
+               "hm_phase_mutation_audits_timeline_idx",
+               "holistic_mentorship_phase_mutation_audits_pkey"
              ]
     end
 
@@ -349,6 +393,50 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
           )
         end)
       end
+    end
+
+    test "retains content-free mutation audit after a never-opened Phase is deleted" do
+      %{plan_id: plan_id, grade_11_id: grade_11_id} = insert_scope()
+      phase_id = insert_phase(plan_id, grade_11_id, 1, "locked")
+      actor = Dbservice.UsersFixtures.user_fixture(%{email: "hm-phase-audit@test.local"})
+
+      Repo.query!(
+        "INSERT INTO holistic_mentorship_phase_questions (phase_id, text, position) VALUES ($1, 'Question', 1)",
+        [phase_id]
+      )
+
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_phase_mutation_audits
+          (phase_plan_id, phase_id, action, actor_user_id, occurred_at)
+        VALUES ($1, $2, 'created', $3, now())
+        """,
+        [plan_id, phase_id, actor.id]
+      )
+
+      Repo.transaction(fn ->
+        Repo.query!("DELETE FROM holistic_mentorship_phase_questions WHERE phase_id = $1", [
+          phase_id
+        ])
+
+        Repo.query!("DELETE FROM holistic_mentorship_phases WHERE id = $1", [phase_id])
+      end)
+
+      assert Repo.query!(
+               "SELECT action, actor_user_id FROM holistic_mentorship_phase_mutation_audits WHERE phase_id = $1",
+               [phase_id]
+             ).rows == [["created", actor.id]]
+
+      assert_constraint_violation(fn ->
+        Repo.query(
+          """
+          INSERT INTO holistic_mentorship_phase_mutation_audits
+            (phase_plan_id, phase_id, action, actor_user_id, occurred_at)
+          VALUES ($1, 0, 'unknown', $2, now())
+          """,
+          [plan_id, actor.id]
+        )
+      end)
     end
 
     test "defers Question cardinality until commit" do

--- a/test/dbservice/holistic_mentorship_phase_schema_test.exs
+++ b/test/dbservice/holistic_mentorship_phase_schema_test.exs
@@ -1,0 +1,467 @@
+defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
+  use Dbservice.DataCase, async: false
+
+  @expected_columns %{
+    "holistic_mentorship_phase_plans" => [
+      "academic_year",
+      "id",
+      "inserted_at",
+      "program_id",
+      "updated_at"
+    ],
+    "holistic_mentorship_phases" => [
+      "frozen_at",
+      "frozen_by_user_id",
+      "grade_id",
+      "guidance_markdown",
+      "id",
+      "inserted_at",
+      "phase_plan_id",
+      "position",
+      "revision",
+      "state",
+      "title",
+      "updated_at"
+    ],
+    "holistic_mentorship_phase_questions" => [
+      "id",
+      "inserted_at",
+      "phase_id",
+      "position",
+      "text",
+      "updated_at"
+    ]
+  }
+
+  describe "Holistic Mentorship Phase Plan schema" do
+    test "creates only the required Phase Plan tables and columns" do
+      for {table, expected_columns} <- @expected_columns do
+        assert column_names(table) == expected_columns
+      end
+    end
+
+    test "uses restrictive canonical relationships, timestamps, and lookup indexes" do
+      assert foreign_keys("holistic_mentorship_phase_plans") == [
+               {"program_id", "program", "NO ACTION"}
+             ]
+
+      assert foreign_keys("holistic_mentorship_phases") == [
+               {"frozen_by_user_id", "user", "NO ACTION"},
+               {"grade_id", "grade", "NO ACTION"},
+               {"phase_plan_id", "holistic_mentorship_phase_plans", "NO ACTION"}
+             ]
+
+      assert foreign_keys("holistic_mentorship_phase_questions") == [
+               {"phase_id", "holistic_mentorship_phases", "NO ACTION"}
+             ]
+
+      for table <- Map.keys(@expected_columns) do
+        assert_required(table, ["id", "inserted_at", "updated_at"])
+      end
+
+      assert_required("holistic_mentorship_phase_plans", ["program_id", "academic_year"])
+
+      assert_required("holistic_mentorship_phases", [
+        "phase_plan_id",
+        "grade_id",
+        "title",
+        "position",
+        "state",
+        "guidance_markdown",
+        "revision"
+      ])
+
+      assert_required("holistic_mentorship_phase_questions", ["phase_id", "text", "position"])
+
+      assert index_names("holistic_mentorship_phase_plans") == [
+               "hm_phase_plan_scope_unique",
+               "hm_phase_plans_program_idx",
+               "holistic_mentorship_phase_plans_pkey"
+             ]
+
+      assert index_names("holistic_mentorship_phases") == [
+               "hm_phases_frozen_by_user_idx",
+               "hm_phases_grade_idx",
+               "hm_phases_plan_grade_state_position_idx",
+               "hm_phases_plan_position_unique",
+               "holistic_mentorship_phases_pkey"
+             ]
+
+      assert index_names("holistic_mentorship_phase_questions") == [
+               "hm_phase_questions_phase_idx",
+               "hm_phase_questions_phase_position_unique",
+               "holistic_mentorship_phase_questions_pkey"
+             ]
+    end
+
+    test "rejects invalid Phase and Question values" do
+      %{plan_id: plan_id, grade_11_id: grade_11_id, grade_10_id: grade_10_id} = insert_scope()
+
+      invalid_phases = [
+        [plan_id, grade_10_id, "open", 1, 1],
+        [plan_id, grade_11_id, "draft", 1, 1],
+        [plan_id, grade_11_id, "open", 0, 1],
+        [plan_id, grade_11_id, "open", 1, 0]
+      ]
+
+      for params <- invalid_phases do
+        assert_constraint_violation(fn ->
+          Repo.query(
+            """
+            INSERT INTO holistic_mentorship_phases
+              (phase_plan_id, grade_id, title, position, state, guidance_markdown, revision)
+            VALUES ($1, $2, 'Invalid phase', $4, $3, 'Guidance', $5)
+            """,
+            params
+          )
+        end)
+      end
+
+      phase_id = insert_phase(plan_id, grade_11_id, 1)
+
+      Repo.query!(
+        "INSERT INTO holistic_mentorship_phase_questions (phase_id, text, position) VALUES ($1, 'Question', 1)",
+        [phase_id]
+      )
+
+      for position <- [0, 5] do
+        assert_constraint_violation(fn ->
+          Repo.query(
+            """
+            INSERT INTO holistic_mentorship_phase_questions (phase_id, text, position)
+            VALUES ($1, 'Invalid question', $2)
+            """,
+            [phase_id, position]
+          )
+        end)
+      end
+
+      assert_constraint_violation(fn ->
+        Repo.query("UPDATE grade SET number = 10 WHERE id = $1", [grade_11_id])
+      end)
+    end
+
+    test "enforces Plan-wide ordering and derives the latest Open Phase" do
+      %{plan_id: plan_id, grade_11_id: grade_11_id, program_id: program_id} = insert_scope()
+
+      assert_constraint_violation(fn ->
+        Repo.query(
+          """
+          INSERT INTO holistic_mentorship_phase_plans (program_id, academic_year)
+          VALUES ($1, '2026-27')
+          """,
+          [program_id]
+        )
+      end)
+
+      first_phase_id = insert_phase(plan_id, grade_11_id, 1)
+
+      assert_constraint_violation(fn ->
+        Repo.query(
+          """
+          INSERT INTO holistic_mentorship_phases
+            (phase_plan_id, grade_id, title, position, state, guidance_markdown, revision)
+          VALUES ($1, $2, 'Duplicate position', 1, 'locked', 'Guidance', 1)
+          """,
+          [plan_id, grade_11_id]
+        )
+      end)
+
+      locked_phase_id = insert_phase(plan_id, grade_11_id, 2, "locked")
+      active_phase_id = insert_phase(plan_id, grade_11_id, 3)
+
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_phase_questions (phase_id, text, position)
+        VALUES ($1, 'First?', 1), ($2, 'Second?', 1), ($3, 'Third?', 1)
+        """,
+        [first_phase_id, locked_phase_id, active_phase_id]
+      )
+
+      assert Repo.query!(
+               """
+               SELECT id
+               FROM holistic_mentorship_phases
+               WHERE phase_plan_id = $1 AND grade_id = $2 AND state = 'open'
+               ORDER BY position DESC
+               LIMIT 1
+               """,
+               [plan_id, grade_11_id]
+             ).rows == [[active_phase_id]]
+    end
+
+    test "defers Question cardinality until commit" do
+      {empty_result, complete_result, overfull_result, moved_result} =
+        Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+          canonical = insert_committed_canonical_scope()
+
+          try do
+            {
+              commit_phase(canonical, "cardinality-empty", 0),
+              commit_phase(canonical, "cardinality-complete", 1),
+              commit_phase(canonical, "cardinality-overfull", 5),
+              move_only_question(canonical)
+            }
+          after
+            delete_committed_canonical_scope(canonical)
+          end
+        end)
+
+      assert {:error, %Postgrex.Error{postgres: %{code: :check_violation}}} = empty_result
+      assert {:ok, _phase_id} = complete_result
+      assert {:error, %Postgrex.Error{postgres: %{code: :check_violation}}} = overfull_result
+      assert {:error, %Postgrex.Error{postgres: %{code: :check_violation}}} = moved_result
+    end
+
+    test "restricts deletion of Phase definitions in use" do
+      %{plan_id: plan_id, grade_11_id: grade_11_id} = insert_scope()
+      phase_id = insert_phase(plan_id, grade_11_id, 1)
+
+      Repo.query!(
+        "INSERT INTO holistic_mentorship_phase_questions (phase_id, text, position) VALUES ($1, 'Question', 1)",
+        [phase_id]
+      )
+
+      assert_constraint_violation(fn ->
+        Repo.query("DELETE FROM holistic_mentorship_phases WHERE id = $1", [phase_id])
+      end)
+
+      assert_constraint_violation(fn ->
+        Repo.query("DELETE FROM holistic_mentorship_phase_plans WHERE id = $1", [plan_id])
+      end)
+    end
+  end
+
+  defp column_names(table) do
+    Repo.query!(
+      """
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = $1
+      ORDER BY column_name
+      """,
+      [table]
+    ).rows
+    |> Enum.map(fn [name] -> name end)
+  end
+
+  defp assert_required(table, expected) do
+    nullable =
+      Repo.query!(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = $1 AND is_nullable = 'YES'
+        """,
+        [table]
+      ).rows
+      |> Enum.map(fn [name] -> name end)
+
+    for column <- expected do
+      refute column in nullable, "#{table}.#{column} should be NOT NULL"
+    end
+  end
+
+  defp foreign_keys(table) do
+    Repo.query!(
+      """
+      SELECT kcu.column_name, ccu.table_name, rc.delete_rule
+      FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+        ON kcu.constraint_name = tc.constraint_name AND kcu.table_schema = tc.table_schema
+      JOIN information_schema.constraint_column_usage ccu
+        ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema
+      JOIN information_schema.referential_constraints rc
+        ON rc.constraint_name = tc.constraint_name AND rc.constraint_schema = tc.table_schema
+      WHERE tc.constraint_type = 'FOREIGN KEY'
+        AND tc.table_schema = 'public'
+        AND tc.table_name = $1
+      ORDER BY kcu.column_name
+      """,
+      [table]
+    ).rows
+    |> Enum.map(fn [column, referenced_table, delete_rule] ->
+      {column, referenced_table, delete_rule}
+    end)
+  end
+
+  defp index_names(table) do
+    Repo.query!(
+      """
+      SELECT indexname
+      FROM pg_indexes
+      WHERE schemaname = 'public' AND tablename = $1
+      ORDER BY indexname
+      """,
+      [table]
+    ).rows
+    |> Enum.map(fn [name] -> name end)
+  end
+
+  defp insert_scope do
+    [[product_id]] =
+      Repo.query!(
+        "INSERT INTO product (name, inserted_at, updated_at) VALUES ('HM test', now(), now()) RETURNING id"
+      ).rows
+
+    [[program_id]] =
+      Repo.query!(
+        "INSERT INTO program (name, product_id, inserted_at, updated_at) VALUES ('HM test', $1, now(), now()) RETURNING id",
+        [product_id]
+      ).rows
+
+    [[grade_11_id]] =
+      Repo.query!(
+        "INSERT INTO grade (number, inserted_at, updated_at) VALUES (11, now(), now()) RETURNING id"
+      ).rows
+
+    [[grade_10_id]] =
+      Repo.query!(
+        "INSERT INTO grade (number, inserted_at, updated_at) VALUES (10, now(), now()) RETURNING id"
+      ).rows
+
+    [[plan_id]] =
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_phase_plans (program_id, academic_year)
+        VALUES ($1, '2026-27')
+        RETURNING id
+        """,
+        [program_id]
+      ).rows
+
+    %{
+      plan_id: plan_id,
+      program_id: program_id,
+      grade_11_id: grade_11_id,
+      grade_10_id: grade_10_id
+    }
+  end
+
+  defp insert_phase(plan_id, grade_id, position, state \\ "open") do
+    [[id]] =
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_phases
+          (phase_plan_id, grade_id, title, position, state, guidance_markdown, revision)
+        VALUES ($1, $2, 'Check-in', $3, $4, '## Guidance', 1)
+        RETURNING id
+        """,
+        [plan_id, grade_id, position, state]
+      ).rows
+
+    id
+  end
+
+  defp assert_constraint_violation(query) do
+    {:error, result} =
+      Repo.transaction(
+        fn -> Repo.rollback(query.()) end,
+        mode: :savepoint
+      )
+
+    assert {:error, %Postgrex.Error{postgres: %{code: code}}} = result
+    assert code in [:check_violation, :foreign_key_violation, :raise_exception, :unique_violation]
+  end
+
+  defp insert_committed_canonical_scope do
+    [[product_id]] =
+      Repo.query!(
+        "INSERT INTO product (name, inserted_at, updated_at) VALUES ('HM cardinality', now(), now()) RETURNING id"
+      ).rows
+
+    [[program_id]] =
+      Repo.query!(
+        "INSERT INTO program (name, product_id, inserted_at, updated_at) VALUES ('HM cardinality', $1, now(), now()) RETURNING id",
+        [product_id]
+      ).rows
+
+    [[grade_id]] =
+      Repo.query!(
+        "INSERT INTO grade (number, inserted_at, updated_at) VALUES (11, now(), now()) RETURNING id"
+      ).rows
+
+    %{product_id: product_id, program_id: program_id, grade_id: grade_id}
+  end
+
+  defp commit_phase(scope, academic_year, question_count) do
+    Repo.transaction(fn ->
+      [[plan_id]] =
+        Repo.query!(
+          "INSERT INTO holistic_mentorship_phase_plans (program_id, academic_year) VALUES ($1, $2) RETURNING id",
+          [scope.program_id, academic_year]
+        ).rows
+
+      phase_id = insert_phase(plan_id, scope.grade_id, 1)
+
+      for position <- 1..question_count//1 do
+        Repo.query!(
+          "INSERT INTO holistic_mentorship_phase_questions (phase_id, text, position) VALUES ($1, 'Question', $2)",
+          [phase_id, position]
+        )
+      end
+
+      phase_id
+    end)
+  rescue
+    error in Postgrex.Error -> {:error, error}
+  end
+
+  defp move_only_question(scope) do
+    {:ok, {question_id, target_phase_id}} =
+      Repo.transaction(fn ->
+        [[plan_id]] =
+          Repo.query!(
+            "INSERT INTO holistic_mentorship_phase_plans (program_id, academic_year) VALUES ($1, 'cardinality-move') RETURNING id",
+            [scope.program_id]
+          ).rows
+
+        source_phase_id = insert_phase(plan_id, scope.grade_id, 1)
+        target_phase_id = insert_phase(plan_id, scope.grade_id, 2)
+
+        [[question_id]] =
+          Repo.query!(
+            "INSERT INTO holistic_mentorship_phase_questions (phase_id, text, position) VALUES ($1, 'Source', 1) RETURNING id",
+            [source_phase_id]
+          ).rows
+
+        Repo.query!(
+          "INSERT INTO holistic_mentorship_phase_questions (phase_id, text, position) VALUES ($1, 'Target', 1)",
+          [target_phase_id]
+        )
+
+        {question_id, target_phase_id}
+      end)
+
+    Repo.transaction(fn ->
+      Repo.query!(
+        "UPDATE holistic_mentorship_phase_questions SET phase_id = $1, position = 2 WHERE id = $2",
+        [target_phase_id, question_id]
+      )
+    end)
+  rescue
+    error in Postgrex.Error -> {:error, error}
+  end
+
+  defp delete_committed_canonical_scope(scope) do
+    Repo.transaction(fn ->
+      Repo.query!(
+        "DELETE FROM holistic_mentorship_phase_questions WHERE phase_id IN (SELECT id FROM holistic_mentorship_phases WHERE phase_plan_id IN (SELECT id FROM holistic_mentorship_phase_plans WHERE program_id = $1))",
+        [scope.program_id]
+      )
+
+      Repo.query!(
+        "DELETE FROM holistic_mentorship_phases WHERE phase_plan_id IN (SELECT id FROM holistic_mentorship_phase_plans WHERE program_id = $1)",
+        [scope.program_id]
+      )
+
+      Repo.query!("DELETE FROM holistic_mentorship_phase_plans WHERE program_id = $1", [
+        scope.program_id
+      ])
+
+      Repo.query!("DELETE FROM grade WHERE id = $1", [scope.grade_id])
+      Repo.query!("DELETE FROM program WHERE id = $1", [scope.program_id])
+      Repo.query!("DELETE FROM product WHERE id = $1", [scope.product_id])
+    end)
+  end
+end

--- a/test/dbservice/holistic_mentorship_phase_schema_test.exs
+++ b/test/dbservice/holistic_mentorship_phase_schema_test.exs
@@ -32,6 +32,7 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
       "updated_at"
     ],
     "holistic_mentorship_phase_state_transitions" => [
+      "actor_email",
       "actor_user_id",
       "from_state",
       "id",
@@ -43,6 +44,7 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
     ],
     "holistic_mentorship_phase_mutation_audits" => [
       "action",
+      "actor_email",
       "actor_user_id",
       "id",
       "inserted_at",
@@ -84,6 +86,7 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
       "updated_at" => "timestamp without time zone"
     },
     "holistic_mentorship_phase_state_transitions" => %{
+      "actor_email" => "character varying",
       "actor_user_id" => "bigint",
       "from_state" => "character varying",
       "id" => "bigint",
@@ -95,6 +98,7 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
     },
     "holistic_mentorship_phase_mutation_audits" => %{
       "action" => "character varying",
+      "actor_email" => "character varying",
       "actor_user_id" => "bigint",
       "id" => "bigint",
       "inserted_at" => "timestamp without time zone",
@@ -190,7 +194,7 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
         "phase_id",
         "from_state",
         "to_state",
-        "actor_user_id",
+        "actor_email",
         "occurred_at"
       ])
 
@@ -198,7 +202,7 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
         "phase_plan_id",
         "phase_id",
         "action",
-        "actor_user_id",
+        "actor_email",
         "occurred_at"
       ])
 
@@ -349,10 +353,10 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
         Repo.query!(
           """
           INSERT INTO holistic_mentorship_phase_state_transitions
-            (phase_id, from_state, to_state, actor_user_id, occurred_at)
-          VALUES ($1, $2, $3, $4, $5)
+            (phase_id, from_state, to_state, actor_user_id, actor_email, occurred_at)
+          VALUES ($1, $2, $3, $4, $5, $6)
           """,
-          [phase_id, from_state, to_state, actor.id, occurred_at]
+          [phase_id, from_state, to_state, actor.id, actor.email, occurred_at]
         )
       end
 
@@ -386,13 +390,51 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
           Repo.query(
             """
             INSERT INTO holistic_mentorship_phase_state_transitions
-              (phase_id, from_state, to_state, actor_user_id, occurred_at)
-            VALUES ($1, $2, $3, $4, now())
+              (phase_id, from_state, to_state, actor_user_id, actor_email, occurred_at)
+            VALUES ($1, $2, $3, $4, $5, now())
             """,
-            [phase_id, from_state, to_state, actor.id]
+            [phase_id, from_state, to_state, actor.id, actor.email]
           )
         end)
       end
+    end
+
+    test "accepts an authenticated audit email without a canonical User" do
+      %{plan_id: plan_id, grade_11_id: grade_11_id} = insert_scope()
+      phase_id = insert_phase(plan_id, grade_11_id, 1, "locked")
+
+      Repo.query!(
+        "INSERT INTO holistic_mentorship_phase_questions (phase_id, text, position) VALUES ($1, 'Question', 1)",
+        [phase_id]
+      )
+
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_phase_state_transitions
+          (phase_id, from_state, to_state, actor_email, occurred_at)
+        VALUES ($1, 'locked', 'open', $2, now())
+        """,
+        [phase_id, "lms-admin@example.com"]
+      )
+
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_phase_mutation_audits
+          (phase_plan_id, phase_id, action, actor_email, occurred_at)
+        VALUES ($1, $2, 'definition_updated', $3, now())
+        """,
+        [plan_id, phase_id, "lms-admin@example.com"]
+      )
+
+      assert Repo.query!(
+               "SELECT actor_email, actor_user_id FROM holistic_mentorship_phase_state_transitions WHERE phase_id = $1",
+               [phase_id]
+             ).rows == [["lms-admin@example.com", nil]]
+
+      assert Repo.query!(
+               "SELECT actor_email, actor_user_id FROM holistic_mentorship_phase_mutation_audits WHERE phase_id = $1",
+               [phase_id]
+             ).rows == [["lms-admin@example.com", nil]]
     end
 
     test "retains content-free mutation audit after a never-opened Phase is deleted" do
@@ -408,10 +450,10 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
       Repo.query!(
         """
         INSERT INTO holistic_mentorship_phase_mutation_audits
-          (phase_plan_id, phase_id, action, actor_user_id, occurred_at)
-        VALUES ($1, $2, 'created', $3, now())
+          (phase_plan_id, phase_id, action, actor_user_id, actor_email, occurred_at)
+        VALUES ($1, $2, 'created', $3, $4, now())
         """,
-        [plan_id, phase_id, actor.id]
+        [plan_id, phase_id, actor.id, actor.email]
       )
 
       Repo.transaction(fn ->
@@ -431,10 +473,10 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
         Repo.query(
           """
           INSERT INTO holistic_mentorship_phase_mutation_audits
-            (phase_plan_id, phase_id, action, actor_user_id, occurred_at)
-          VALUES ($1, 0, 'unknown', $2, now())
+            (phase_plan_id, phase_id, action, actor_user_id, actor_email, occurred_at)
+          VALUES ($1, 0, 'unknown', $2, $3, now())
           """,
-          [plan_id, actor.id]
+          [plan_id, actor.id, actor.email]
         )
       end)
     end

--- a/test/dbservice/holistic_mentorship_phase_schema_test.exs
+++ b/test/dbservice/holistic_mentorship_phase_schema_test.exs
@@ -30,6 +30,16 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
       "position",
       "text",
       "updated_at"
+    ],
+    "holistic_mentorship_phase_state_transitions" => [
+      "actor_user_id",
+      "from_state",
+      "id",
+      "inserted_at",
+      "occurred_at",
+      "phase_id",
+      "to_state",
+      "updated_at"
     ]
   }
 
@@ -62,6 +72,16 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
       "position" => "integer",
       "text" => "text",
       "updated_at" => "timestamp without time zone"
+    },
+    "holistic_mentorship_phase_state_transitions" => %{
+      "actor_user_id" => "bigint",
+      "from_state" => "character varying",
+      "id" => "bigint",
+      "inserted_at" => "timestamp without time zone",
+      "occurred_at" => "timestamp without time zone",
+      "phase_id" => "bigint",
+      "to_state" => "character varying",
+      "updated_at" => "timestamp without time zone"
     }
   }
 
@@ -72,7 +92,10 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
       "hm_phases_revision_check",
       "hm_phases_state_check"
     ],
-    "holistic_mentorship_phase_questions" => ["hm_phase_questions_position_check"]
+    "holistic_mentorship_phase_questions" => ["hm_phase_questions_position_check"],
+    "holistic_mentorship_phase_state_transitions" => [
+      "hm_phase_state_transitions_states_check"
+    ]
   }
 
   describe "Holistic Mentorship Phase Plan schema" do
@@ -111,6 +134,11 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
                {"phase_id", "holistic_mentorship_phases", "NO ACTION"}
              ]
 
+      assert foreign_keys("holistic_mentorship_phase_state_transitions") == [
+               {"actor_user_id", "user", "NO ACTION"},
+               {"phase_id", "holistic_mentorship_phases", "NO ACTION"}
+             ]
+
       for table <- Map.keys(@expected_columns) do
         assert_required(table, ["id", "inserted_at", "updated_at"])
       end
@@ -128,6 +156,14 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
       ])
 
       assert_required("holistic_mentorship_phase_questions", ["phase_id", "text", "position"])
+
+      assert_required("holistic_mentorship_phase_state_transitions", [
+        "phase_id",
+        "from_state",
+        "to_state",
+        "actor_user_id",
+        "occurred_at"
+      ])
 
       assert index_names("holistic_mentorship_phase_plans") == [
                "hm_phase_plan_scope_unique",
@@ -147,6 +183,12 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
                "hm_phase_questions_phase_idx",
                "hm_phase_questions_phase_position_unique",
                "holistic_mentorship_phase_questions_pkey"
+             ]
+
+      assert index_names("holistic_mentorship_phase_state_transitions") == [
+               "hm_phase_state_transitions_actor_idx",
+               "hm_phase_state_transitions_timeline_idx",
+               "holistic_mentorship_phase_state_transitions_pkey"
              ]
     end
 
@@ -244,6 +286,69 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
                """,
                [plan_id, grade_11_id]
              ).rows == [[active_phase_id]]
+    end
+
+    test "retains valid state transitions in timeline order" do
+      %{plan_id: plan_id, grade_11_id: grade_11_id} = insert_scope()
+      phase_id = insert_phase(plan_id, grade_11_id, 1, "locked")
+      actor = Dbservice.UsersFixtures.user_fixture(%{email: "hm-phase-actor@test.local"})
+
+      Repo.query!(
+        "INSERT INTO holistic_mentorship_phase_questions (phase_id, text, position) VALUES ($1, 'Question', 1)",
+        [phase_id]
+      )
+
+      times = [~U[2026-07-17 09:00:00Z], ~U[2026-07-17 10:00:00Z], ~U[2026-07-17 11:00:00Z]]
+
+      for {{from_state, to_state}, occurred_at} <-
+            Enum.zip([{"locked", "open"}, {"open", "locked"}, {"locked", "open"}], times) do
+        Repo.query!(
+          """
+          INSERT INTO holistic_mentorship_phase_state_transitions
+            (phase_id, from_state, to_state, actor_user_id, occurred_at)
+          VALUES ($1, $2, $3, $4, $5)
+          """,
+          [phase_id, from_state, to_state, actor.id, occurred_at]
+        )
+      end
+
+      assert Repo.query!(
+               """
+               SELECT from_state, to_state
+               FROM holistic_mentorship_phase_state_transitions
+               WHERE phase_id = $1
+               ORDER BY occurred_at, id
+               """,
+               [phase_id]
+             ).rows == [
+               ["locked", "open"],
+               ["open", "locked"],
+               ["locked", "open"]
+             ]
+
+      assert Repo.query!(
+               """
+               SELECT to_state
+               FROM holistic_mentorship_phase_state_transitions
+               WHERE phase_id = $1 AND occurred_at <= $2
+               ORDER BY occurred_at DESC, id DESC
+               LIMIT 1
+               """,
+               [phase_id, ~U[2026-07-17 10:30:00Z]]
+             ).rows == [["locked"]]
+
+      for {from_state, to_state} <- [{"open", "open"}, {"draft", "open"}] do
+        assert_constraint_violation(fn ->
+          Repo.query(
+            """
+            INSERT INTO holistic_mentorship_phase_state_transitions
+              (phase_id, from_state, to_state, actor_user_id, occurred_at)
+            VALUES ($1, $2, $3, $4, now())
+            """,
+            [phase_id, from_state, to_state, actor.id]
+          )
+        end)
+      end
     end
 
     test "defers Question cardinality until commit" do

--- a/test/dbservice/holistic_mentorship_privacy_schema_test.exs
+++ b/test/dbservice/holistic_mentorship_privacy_schema_test.exs
@@ -1,0 +1,148 @@
+defmodule Dbservice.HolisticMentorshipPrivacySchemaTest do
+  use Dbservice.DataCase, async: true
+
+  @table "holistic_mentorship_privacy_deletions"
+
+  import Dbservice.UsersFixtures
+
+  test "stores one durable content-free privacy tombstone per Student" do
+    assert Repo.query!(
+             """
+             SELECT column_name, data_type, is_nullable
+             FROM information_schema.columns
+             WHERE table_schema = 'public' AND table_name = $1
+             ORDER BY ordinal_position
+             """,
+             [@table]
+           ).rows == [
+             ["id", "bigint", "NO"],
+             ["student_id", "bigint", "NO"],
+             ["actor_user_id", "bigint", "NO"],
+             ["reason", "text", "NO"],
+             ["profile_summaries_erased", "integer", "NO"],
+             ["post_session_answers_erased", "integer", "NO"],
+             ["historical_answers_erased", "integer", "NO"],
+             ["occurred_at", "timestamp without time zone", "NO"],
+             ["inserted_at", "timestamp without time zone", "NO"],
+             ["updated_at", "timestamp without time zone", "NO"]
+           ]
+
+    assert Repo.query!(
+             """
+             SELECT a.attname, f.confdeltype
+             FROM pg_constraint f
+             JOIN pg_attribute a ON a.attrelid = f.conrelid AND a.attnum = ANY(f.conkey)
+             WHERE f.conrelid = to_regclass($1) AND f.contype = 'f'
+             ORDER BY a.attname
+             """,
+             [@table]
+           ).rows == [["actor_user_id", "a"], ["student_id", "a"]]
+
+    assert Repo.query!(
+             """
+             SELECT conname FROM pg_constraint
+             WHERE conrelid = to_regclass($1) AND contype = 'c'
+             """,
+             [@table]
+           ).rows == [["hm_privacy_deletions_content_check"]]
+
+    assert Repo.query!(
+             """
+             SELECT indexname FROM pg_indexes
+             WHERE schemaname = 'public' AND tablename = $1
+             ORDER BY indexname
+             """,
+             [@table]
+           ).rows == [
+             ["hm_privacy_deletions_student_uidx"],
+             ["holistic_mentorship_privacy_deletions_pkey"]
+           ]
+
+    assert Repo.query!(
+             """
+             SELECT indexdef FROM pg_indexes
+             WHERE schemaname = 'public' AND tablename = $1
+               AND indexname = 'hm_privacy_deletions_student_uidx'
+             """,
+             [@table]
+           ).rows == [
+             [
+               "CREATE UNIQUE INDEX hm_privacy_deletions_student_uidx ON public.holistic_mentorship_privacy_deletions USING btree (student_id)"
+             ]
+           ]
+
+    assert Repo.query!(
+             """
+             SELECT trigger_name FROM information_schema.triggers
+             WHERE event_object_schema = 'public'
+               AND trigger_name IN (
+                 'hm_privacy_deletions_immutable',
+                 'hm_profile_summaries_privacy_guard',
+                 'hm_post_session_answers_privacy_guard',
+                 'hm_historical_note_answers_privacy_guard'
+               )
+             GROUP BY trigger_name
+             ORDER BY trigger_name
+             """,
+             []
+           ).rows == [
+             ["hm_historical_note_answers_privacy_guard"],
+             ["hm_post_session_answers_privacy_guard"],
+             ["hm_privacy_deletions_immutable"],
+             ["hm_profile_summaries_privacy_guard"]
+           ]
+
+    assert Repo.query!(
+             """
+             SELECT pg_get_functiondef(
+               'holistic_mentorship_reject_erased_student_content()'::regprocedure
+             ) LIKE '%pg_advisory_xact_lock(target_student_id::integer, 0)%'
+             """,
+             []
+           ).rows == [[true]]
+  end
+
+  test "allows a zero-content tombstone once and protects it from mutation" do
+    {_student_user, student} = student_fixture()
+    actor = user_fixture()
+
+    assert Repo.query!(
+             """
+             INSERT INTO #{@table}
+               (student_id, actor_user_id, reason, profile_summaries_erased,
+                post_session_answers_erased, historical_answers_erased, occurred_at)
+             VALUES ($1, $2, 'approved-request', 0, 0, 0, now())
+             RETURNING student_id
+             """,
+             [student.id, actor.id]
+           ).rows == [[student.id]]
+
+    assert_postgres_error(:unique_violation, fn ->
+      Repo.query(
+        """
+        INSERT INTO #{@table}
+          (student_id, actor_user_id, reason, profile_summaries_erased,
+           post_session_answers_erased, historical_answers_erased, occurred_at)
+        VALUES ($1, $2, 'duplicate-request', 0, 0, 0, now())
+        """,
+        [student.id, actor.id]
+      )
+    end)
+
+    for operation <- [
+          fn ->
+            Repo.query("UPDATE #{@table} SET reason = 'changed' WHERE student_id = $1", [
+              student.id
+            ])
+          end,
+          fn -> Repo.query("DELETE FROM #{@table} WHERE student_id = $1", [student.id]) end
+        ] do
+      assert_postgres_error(:check_violation, operation)
+    end
+  end
+
+  defp assert_postgres_error(code, operation) do
+    assert {:error, {:error, %Postgrex.Error{postgres: %{code: ^code}}}} =
+             Repo.transaction(fn -> Repo.rollback(operation.()) end, mode: :savepoint)
+  end
+end

--- a/test/dbservice/holistic_mentorship_profile_schema_test.exs
+++ b/test/dbservice/holistic_mentorship_profile_schema_test.exs
@@ -1,0 +1,287 @@
+defmodule Dbservice.HolisticMentorshipProfileSchemaTest do
+  use Dbservice.DataCase, async: false
+
+  @journeys "holistic_mentorship_profile_journeys"
+  @profiles "holistic_mentorship_student_profiles"
+  @summaries "holistic_mentorship_student_profile_summaries"
+
+  test "defines the namespaced Student Profile storage contract without sensitive fields" do
+    assert column_types(@journeys) == %{
+             "af_session_id" => "character varying",
+             "entry_grade" => "integer",
+             "form_id" => "character varying",
+             "id" => "bigint",
+             "inserted_at" => "timestamp without time zone",
+             "student_id" => "bigint",
+             "updated_at" => "timestamp without time zone"
+           }
+
+    assert column_types(@profiles) == %{
+             "answer_fingerprint" => "character varying",
+             "generated_at" => "timestamp without time zone",
+             "id" => "bigint",
+             "inserted_at" => "timestamp without time zone",
+             "last_successful_etl_run_id" => "character varying",
+             "profile_journey_id" => "bigint",
+             "prompt_configuration_id" => "bigint",
+             "revision" => "integer",
+             "schema_fingerprint" => "character varying",
+             "updated_at" => "timestamp without time zone",
+             "warehouse_loaded_at" => "timestamp without time zone"
+           }
+
+    assert column_types(@summaries) == %{
+             "id" => "bigint",
+             "inserted_at" => "timestamp without time zone",
+             "position" => "integer",
+             "question_set_title" => "character varying",
+             "student_profile_id" => "bigint",
+             "summary" => "text",
+             "updated_at" => "timestamp without time zone"
+           }
+
+    assert nullable_columns(@journeys) == []
+    assert nullable_columns(@profiles) == []
+    assert nullable_columns(@summaries) == []
+
+    assert foreign_keys(@journeys) == [{"student_id", "student", "NO ACTION"}]
+
+    assert foreign_keys(@profiles) == [
+             {"profile_journey_id", @journeys, "NO ACTION"},
+             {"prompt_configuration_id", "holistic_mentorship_prompt_configurations", "NO ACTION"}
+           ]
+
+    assert foreign_keys(@summaries) == [
+             {"student_profile_id", @profiles, "CASCADE"}
+           ]
+  end
+
+  test "keeps one immutable approved Profile journey per canonical Student" do
+    student_id = insert_student!()
+    journey_id = insert_journey!(student_id, 11)
+
+    assert_constraint(:unique_violation, fn -> insert_journey(student_id, 11) end)
+
+    assert_constraint(:check_violation, fn ->
+      Repo.query("UPDATE #{@journeys} SET entry_grade = 12 WHERE id = $1", [journey_id])
+    end)
+
+    other_student_id = insert_student!()
+
+    assert_constraint(:check_violation, fn ->
+      Repo.query(
+        """
+        INSERT INTO #{@journeys} (student_id, form_id, af_session_id, entry_grade)
+        VALUES ($1, '6a44a83d1184e717b920c499',
+                'EnableStudents_6a44a83d1184e717b920c499', 12)
+        """,
+        [other_student_id]
+      )
+    end)
+  end
+
+  test "keys each positive-revision Profile by journey and Prompt Configuration" do
+    journey_id = insert_student!() |> insert_journey!(11)
+    first_configuration_id = insert_prompt_configuration!("openai/gpt-5-mini")
+    second_configuration_id = insert_prompt_configuration!("google/gemini-2.5-flash")
+
+    assert {:ok, _profile_id} = insert_profile(journey_id, first_configuration_id, 3)
+
+    assert_constraint(:unique_violation, fn ->
+      insert_profile(journey_id, first_configuration_id, 4)
+    end)
+
+    assert {:ok, _profile_id} = insert_profile(journey_id, second_configuration_id, 1)
+
+    assert_constraint(:check_violation, fn ->
+      insert_profile(journey_id, second_configuration_id, 0)
+    end)
+  end
+
+  test "commits exactly five ordered non-empty Question Set summaries" do
+    journey_id = insert_student!() |> insert_journey!(11)
+    configuration_id = insert_prompt_configuration!("openai/gpt-5-nano")
+
+    assert_constraint(:check_violation, fn ->
+      {:ok, profile_id} = insert_profile(journey_id, configuration_id, 1)
+
+      for position <- 1..4 do
+        insert_summary!(profile_id, position, "Summary #{position}")
+      end
+
+      Repo.query("SET CONSTRAINTS ALL IMMEDIATE")
+    end)
+
+    other_configuration_id = insert_prompt_configuration!("openai/gpt-5")
+    {:ok, profile_id} = insert_profile(journey_id, other_configuration_id, 1)
+
+    for {position, summary} <- [
+          {1, "First summary"},
+          {2, "Second summary"},
+          {3, "No response available"},
+          {4, "Fourth summary"},
+          {5, "Fifth summary"}
+        ] do
+      insert_summary!(profile_id, position, summary)
+    end
+
+    Repo.query!("SET CONSTRAINTS ALL IMMEDIATE")
+
+    assert Repo.query!(
+             "SELECT position, summary FROM #{@summaries} WHERE student_profile_id = $1 ORDER BY position",
+             [profile_id]
+           ).rows == [
+             [1, "First summary"],
+             [2, "Second summary"],
+             [3, "No response available"],
+             [4, "Fourth summary"],
+             [5, "Fifth summary"]
+           ]
+
+    assert_constraint(:check_violation, fn -> insert_summary(profile_id, 0, "Invalid") end)
+    assert_constraint(:check_violation, fn -> insert_summary(profile_id, 5, "") end)
+    assert_constraint(:unique_violation, fn -> insert_summary(profile_id, 5, "Duplicate") end)
+  end
+
+  defp column_types(table) do
+    Repo.query!(
+      """
+      SELECT column_name, data_type
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = $1
+      """,
+      [table]
+    ).rows
+    |> Map.new(fn [name, type] -> {name, type} end)
+  end
+
+  defp nullable_columns(table) do
+    Repo.query!(
+      """
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = $1 AND is_nullable = 'YES'
+      ORDER BY column_name
+      """,
+      [table]
+    ).rows
+    |> Enum.map(fn [name] -> name end)
+  end
+
+  defp foreign_keys(table) do
+    Repo.query!(
+      """
+      SELECT kcu.column_name, ccu.table_name, rc.delete_rule
+      FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+        ON kcu.constraint_name = tc.constraint_name AND kcu.table_schema = tc.table_schema
+      JOIN information_schema.constraint_column_usage ccu
+        ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema
+      JOIN information_schema.referential_constraints rc
+        ON rc.constraint_name = tc.constraint_name AND rc.constraint_schema = tc.table_schema
+      WHERE tc.constraint_type = 'FOREIGN KEY'
+        AND tc.table_schema = 'public'
+        AND tc.table_name = $1
+      ORDER BY kcu.column_name
+      """,
+      [table]
+    ).rows
+    |> Enum.map(fn [column, referenced_table, delete_rule] ->
+      {column, referenced_table, delete_rule}
+    end)
+  end
+
+  defp insert_student! do
+    [[user_id]] =
+      Repo.query!(
+        "INSERT INTO \"user\" (inserted_at, updated_at) VALUES (now(), now()) RETURNING id"
+      ).rows
+
+    [[student_id]] =
+      Repo.query!(
+        "INSERT INTO student (user_id, inserted_at, updated_at) VALUES ($1, now(), now()) RETURNING id",
+        [user_id]
+      ).rows
+
+    student_id
+  end
+
+  defp insert_journey!(student_id, entry_grade) do
+    {:ok, %{rows: [[id]]}} = insert_journey(student_id, entry_grade)
+    id
+  end
+
+  defp insert_journey(student_id, 11) do
+    Repo.query(
+      """
+      INSERT INTO #{@journeys} (student_id, form_id, af_session_id, entry_grade)
+      VALUES ($1, '6a44a83d1184e717b920c499',
+              'EnableStudents_6a44a83d1184e717b920c499', 11)
+      RETURNING id
+      """,
+      [student_id]
+    )
+  end
+
+  defp insert_prompt_configuration!(model_id) do
+    [[prompt_version_id]] =
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_prompt_versions (version, template_text, template_hash)
+        VALUES ($1, 'abc', 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
+        RETURNING id
+        """,
+        ["profile-schema-#{model_id}"]
+      ).rows
+
+    [[configuration_id]] =
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_prompt_configurations (prompt_version_id, model_id)
+        VALUES ($1, $2)
+        RETURNING id
+        """,
+        [prompt_version_id, model_id]
+      ).rows
+
+    configuration_id
+  end
+
+  defp insert_profile(journey_id, configuration_id, revision) do
+    case Repo.query(
+           """
+           INSERT INTO #{@profiles}
+             (profile_journey_id, prompt_configuration_id, schema_fingerprint,
+              answer_fingerprint, warehouse_loaded_at, generated_at, revision,
+              last_successful_etl_run_id)
+           VALUES ($1, $2, 'schema-v1', 'answers-v1', '2026-07-16 10:00:00',
+                   '2026-07-16 10:05:00', $3, 'etl-run-1')
+           RETURNING id
+           """,
+           [journey_id, configuration_id, revision]
+         ) do
+      {:ok, %{rows: [[profile_id]]}} -> {:ok, profile_id}
+      error -> error
+    end
+  end
+
+  defp insert_summary!(profile_id, position, summary) do
+    {:ok, result} = insert_summary(profile_id, position, summary)
+    result
+  end
+
+  defp insert_summary(profile_id, position, summary) do
+    Repo.query(
+      """
+      INSERT INTO #{@summaries} (student_profile_id, position, question_set_title, summary)
+      VALUES ($1, $2, $3, $4)
+      """,
+      [profile_id, position, "Question Set #{position}", summary]
+    )
+  end
+
+  defp assert_constraint(code, query) do
+    assert {:error, {:error, %Postgrex.Error{postgres: %{code: ^code}}}} =
+             Repo.transaction(fn -> Repo.rollback(query.()) end, mode: :savepoint)
+  end
+end

--- a/test/dbservice/services/student_eligibility_cleanup_test.exs
+++ b/test/dbservice/services/student_eligibility_cleanup_test.exs
@@ -56,7 +56,7 @@ defmodule Dbservice.Services.StudentEligibilityCleanupTest do
            ).rows == [[true, "db_service_student_eligibility", "student_grade_changed"]]
   end
 
-  test "a current School change ends the Student's active Holistic Mapping" do
+  test "a current School change leaves Mapping cleanup to AF LMS reconciliation" do
     %{mapping_id: mapping_id, student: student} = insert_mapping_scope()
     old_school_id = insert_school()
     new_school_id = insert_school()
@@ -87,16 +87,13 @@ defmodule Dbservice.Services.StudentEligibilityCleanupTest do
     assert Repo.get!(Dbservice.EnrollmentRecords.EnrollmentRecord, enrollment_id).group_id ==
              new_school_id
 
-    assert Repo.query!(
-             "SELECT end_source, end_reason FROM holistic_mentorship_mentor_mentee_mappings WHERE id = $1",
-             [mapping_id]
-           ).rows == [["db_service_student_eligibility", "student_school_changed"]]
+    assert mapping_active?(mapping_id)
 
     assert Repo.query!("SELECT count(*) FROM holistic_mentorship_mentor_mentee_mappings").rows ==
              [[1]]
   end
 
-  test "a current Program change takes precedence over a simultaneous School change" do
+  test "a current Program change leaves Mapping cleanup to AF LMS reconciliation" do
     %{mapping_id: mapping_id, student: student} = insert_mapping_scope()
     school_id = insert_school()
 
@@ -119,13 +116,10 @@ defmodule Dbservice.Services.StudentEligibilityCleanupTest do
                group_id: 1
              })
 
-    assert Repo.query!(
-             "SELECT end_reason FROM holistic_mentorship_mentor_mentee_mappings WHERE id = $1",
-             [mapping_id]
-           ).rows == [["student_program_changed"]]
+    assert mapping_active?(mapping_id)
   end
 
-  test "a batch enrollment failure rolls back School membership cleanup" do
+  test "a batch enrollment failure rolls back School membership" do
     %{mapping_id: mapping_id, student: student} = insert_mapping_scope()
 
     [[school_id]] =
@@ -281,17 +275,8 @@ defmodule Dbservice.Services.StudentEligibilityCleanupTest do
     assert mapping_active?(mapping_id)
   end
 
-  test "a School enrollment without an active Mapping skips the Student lock" do
-    [[user_id]] =
-      Repo.query!(
-        "INSERT INTO \"user\" (inserted_at, updated_at) VALUES (now(), now()) RETURNING id"
-      ).rows
-
-    Repo.query!(
-      "INSERT INTO student (user_id, status, inserted_at, updated_at) VALUES ($1, 'enrolled', now(), now())",
-      [user_id]
-    )
-
+  test "generic enrollment CRUD performs no Holistic query even with an active Mapping" do
+    %{mapping_id: mapping_id, student: student} = insert_mapping_scope()
     school_id = insert_school()
     handler_id = {__MODULE__, self()}
 
@@ -306,7 +291,7 @@ defmodule Dbservice.Services.StudentEligibilityCleanupTest do
 
     assert {:ok, _enrollment} =
              Dbservice.EnrollmentRecords.create_enrollment_record(%{
-               user_id: user_id,
+               user_id: student.user_id,
                group_id: school_id,
                group_type: "school",
                academic_year: "2026-27",
@@ -314,7 +299,26 @@ defmodule Dbservice.Services.StudentEligibilityCleanupTest do
                is_current: true
              })
 
-    refute Enum.any?(received_enrollment_queries(), &String.contains?(&1, "FOR UPDATE"))
+    {:ok, enrollment} =
+      Dbservice.EnrollmentRecords.create_enrollment_record(%{
+        user_id: student.user_id,
+        group_id: 1,
+        group_type: "program",
+        academic_year: "2026-27",
+        start_date: ~D[2026-04-01],
+        is_current: true
+      })
+
+    assert {:ok, enrollment} =
+             Dbservice.EnrollmentRecords.update_enrollment_record(enrollment, %{group_id: 2})
+
+    assert {:ok, _enrollment} = Dbservice.EnrollmentRecords.delete_enrollment_record(enrollment)
+    assert {:ok, 1} = Dbservice.EnrollmentRecords.delete_all_by_user_id(student.user_id)
+
+    queries = received_enrollment_queries()
+    refute Enum.any?(queries, &String.contains?(&1, "holistic_mentorship_"))
+    refute Enum.any?(queries, &String.contains?(&1, "FOR UPDATE"))
+    assert mapping_active?(mapping_id)
   end
 
   defp insert_mapping_scope do

--- a/test/dbservice/services/student_eligibility_cleanup_test.exs
+++ b/test/dbservice/services/student_eligibility_cleanup_test.exs
@@ -199,8 +199,8 @@ defmodule Dbservice.Services.StudentEligibilityCleanupTest do
 
   test "a cleanup failure rolls back the dropout status and enrollment changes" do
     %{mapping_id: mapping_id, student: student} = insert_mapping_scope()
-    {:ok, enrolled_status} = Dbservice.Statuses.create_status(%{"title" => "enrolled"})
-    {:ok, dropout_status} = Dbservice.Statuses.create_status(%{"title" => "dropout"})
+    enrolled_status = Dbservice.Statuses.get_status_by_title(:enrolled)
+    dropout_status = Dbservice.Statuses.get_status_by_title(:dropout)
 
     {:ok, current_enrollment} =
       Dbservice.EnrollmentRecords.create_enrollment_record(%{

--- a/test/dbservice/services/student_eligibility_cleanup_test.exs
+++ b/test/dbservice/services/student_eligibility_cleanup_test.exs
@@ -1,0 +1,239 @@
+defmodule Dbservice.Services.StudentEligibilityCleanupTest do
+  use Dbservice.DataCase, async: false
+
+  import Ecto.Query
+
+  alias Dbservice.Services.StudentUpdateService
+  alias Dbservice.Services.GroupUpdateService
+  alias Dbservice.Services.DropoutService
+
+  test "a dropout transition ends the Student's active Holistic Mapping" do
+    %{mapping_id: mapping_id, student: student} = insert_mapping_scope()
+
+    assert {:ok, updated_student} =
+             StudentUpdateService.update_student_with_user_data(student, %{"status" => "dropout"})
+
+    assert updated_student.status == "dropout"
+
+    assert Repo.query!(
+             """
+             SELECT ended_at IS NOT NULL, end_source, end_reason
+             FROM holistic_mentorship_mentor_mentee_mappings
+             WHERE id = $1
+             """,
+             [mapping_id]
+           ).rows == [[true, "db_service_student_eligibility", "student_dropout"]]
+
+    assert Repo.query!("SELECT count(*) FROM holistic_mentorship_mentor_mentee_mappings").rows ==
+             [
+               [1]
+             ]
+  end
+
+  test "a canonical Grade change ends the Student's active Holistic Mapping" do
+    %{mapping_id: mapping_id, student: student} = insert_mapping_scope()
+    old_grade_id = insert_grade(11)
+    new_grade_id = insert_grade(12)
+
+    Repo.query!("UPDATE student SET grade_id = $1 WHERE id = $2", [old_grade_id, student.id])
+    student = Dbservice.Users.get_student!(student.id)
+
+    assert {:ok, updated_student} =
+             StudentUpdateService.update_student_with_user_data(student, %{
+               "grade_id" => new_grade_id
+             })
+
+    assert updated_student.grade_id == new_grade_id
+
+    assert Repo.query!(
+             """
+             SELECT ended_at IS NOT NULL, end_source, end_reason
+             FROM holistic_mentorship_mentor_mentee_mappings
+             WHERE id = $1
+             """,
+             [mapping_id]
+           ).rows == [[true, "db_service_student_eligibility", "student_grade_changed"]]
+  end
+
+  test "a cleanup failure rolls back the Grade correction and its enrollment changes" do
+    %{mapping_id: mapping_id, student: student} = insert_mapping_scope()
+    old_grade_id = insert_grade(9)
+    new_grade_id = insert_grade(10)
+    {:ok, old_group} = Dbservice.Groups.create_group(%{type: "grade", child_id: old_grade_id})
+    {:ok, new_group} = Dbservice.Groups.create_group(%{type: "grade", child_id: new_grade_id})
+
+    Repo.query!("UPDATE student SET grade_id = $1 WHERE id = $2", [old_grade_id, student.id])
+
+    {:ok, group_user} =
+      Dbservice.GroupUsers.create_group_user(%{user_id: student.user_id, group_id: old_group.id})
+
+    {:ok, enrollment} =
+      Dbservice.EnrollmentRecords.create_enrollment_record(%{
+        user_id: student.user_id,
+        group_id: old_grade_id,
+        group_type: "grade",
+        academic_year: "2026-27",
+        start_date: ~D[2026-04-01],
+        is_current: true
+      })
+
+    install_failing_cleanup_trigger()
+
+    assert_raise Postgrex.Error, fn ->
+      GroupUpdateService.update_user_group_by_type(%{
+        "user_id" => student.user_id,
+        "group_id" => new_group.id,
+        "type" => "grade"
+      })
+    end
+
+    assert Repo.get!(Dbservice.Groups.GroupUser, group_user.id).group_id == old_group.id
+
+    assert Repo.get!(Dbservice.EnrollmentRecords.EnrollmentRecord, enrollment.id).group_id ==
+             old_grade_id
+
+    assert Dbservice.Users.get_student!(student.id).grade_id == old_grade_id
+    assert mapping_active?(mapping_id)
+  end
+
+  test "a cleanup failure rolls back the dropout status and enrollment changes" do
+    %{mapping_id: mapping_id, student: student} = insert_mapping_scope()
+    {:ok, enrolled_status} = Dbservice.Statuses.create_status(%{"title" => "enrolled"})
+    {:ok, dropout_status} = Dbservice.Statuses.create_status(%{"title" => "dropout"})
+
+    {:ok, current_enrollment} =
+      Dbservice.EnrollmentRecords.create_enrollment_record(%{
+        user_id: student.user_id,
+        group_id: enrolled_status.id,
+        group_type: "status",
+        academic_year: "2026-27",
+        start_date: ~D[2026-04-01],
+        is_current: true
+      })
+
+    install_failing_cleanup_trigger()
+
+    assert_raise Postgrex.Error, fn ->
+      DropoutService.process_dropout(student, ~D[2026-07-01], "2026-27")
+    end
+
+    assert Repo.get!(Dbservice.EnrollmentRecords.EnrollmentRecord, current_enrollment.id).is_current
+    assert Dbservice.Users.get_student!(student.id).status == "enrolled"
+    assert mapping_active?(mapping_id)
+
+    refute Repo.exists?(
+             from enrollment in Dbservice.EnrollmentRecords.EnrollmentRecord,
+               where:
+                 enrollment.user_id == ^student.user_id and
+                   enrollment.group_id == ^dropout_status.id and
+                   enrollment.group_type == "status"
+           )
+  end
+
+  test "dropout takes precedence when status and Grade change together" do
+    %{mapping_id: mapping_id, student: student} = insert_mapping_scope()
+    new_grade_id = insert_grade(12)
+
+    assert {:ok, _updated_student} =
+             StudentUpdateService.update_student_with_user_data(student, %{
+               "status" => "dropout",
+               "grade_id" => new_grade_id
+             })
+
+    assert Repo.query!(
+             "SELECT end_reason FROM holistic_mentorship_mentor_mentee_mappings WHERE id = $1",
+             [mapping_id]
+           ).rows == [["student_dropout"]]
+  end
+
+  test "unchanged eligibility leaves the active Mapping unchanged" do
+    %{mapping_id: mapping_id, student: student} = insert_mapping_scope()
+
+    assert {:ok, _updated_student} =
+             StudentUpdateService.update_student_with_user_data(student, %{
+               "status" => "enrolled",
+               "father_name" => "Updated"
+             })
+
+    assert Repo.query!(
+             "SELECT ended_at, end_source, end_reason FROM holistic_mentorship_mentor_mentee_mappings WHERE id = $1",
+             [mapping_id]
+           ).rows == [[nil, nil, nil]]
+  end
+
+  defp insert_mapping_scope do
+    [[student_user_id], [mentor_user_id]] =
+      Repo.query!(
+        "INSERT INTO \"user\" (inserted_at, updated_at) VALUES (now(), now()), (now(), now()) RETURNING id"
+      ).rows
+
+    [[student_id]] =
+      Repo.query!(
+        "INSERT INTO student (user_id, status, inserted_at, updated_at) VALUES ($1, 'enrolled', now(), now()) RETURNING id",
+        [student_user_id]
+      ).rows
+
+    [[school_id]] =
+      Repo.query!(
+        "INSERT INTO school (inserted_at, updated_at) VALUES (now(), now()) RETURNING id"
+      ).rows
+
+    [[product_id]] =
+      Repo.query!(
+        "INSERT INTO product (name, inserted_at, updated_at) VALUES ('Eligibility Cleanup', now(), now()) RETURNING id"
+      ).rows
+
+    [[program_id]] =
+      Repo.query!(
+        "INSERT INTO program (name, product_id, inserted_at, updated_at) VALUES ('Eligibility Cleanup', $1, now(), now()) RETURNING id",
+        [product_id]
+      ).rows
+
+    [[mapping_id]] =
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_mentor_mentee_mappings
+          (student_id, mentor_user_id, school_id, program_id, academic_year, started_at,
+           assignment_source)
+        VALUES ($1, $2, $3, $4, '2026-27', timezone('UTC', now()), 'af_lms')
+        RETURNING id
+        """,
+        [student_id, mentor_user_id, school_id, program_id]
+      ).rows
+
+    %{mapping_id: mapping_id, student: Dbservice.Users.get_student!(student_id)}
+  end
+
+  defp insert_grade(number) do
+    [[id]] =
+      Repo.query!(
+        "INSERT INTO grade (number, inserted_at, updated_at) VALUES ($1, now(), now()) RETURNING id",
+        [number]
+      ).rows
+
+    id
+  end
+
+  defp install_failing_cleanup_trigger do
+    Repo.query!("""
+    CREATE FUNCTION pg_temp.fail_holistic_mapping_cleanup() RETURNS trigger AS $$
+    BEGIN
+      RAISE EXCEPTION 'forced cleanup failure';
+    END;
+    $$ LANGUAGE plpgsql
+    """)
+
+    Repo.query!("""
+    CREATE TRIGGER fail_holistic_mapping_cleanup
+    BEFORE UPDATE ON holistic_mentorship_mentor_mentee_mappings
+    FOR EACH ROW EXECUTE FUNCTION pg_temp.fail_holistic_mapping_cleanup()
+    """)
+  end
+
+  defp mapping_active?(mapping_id) do
+    Repo.query!(
+      "SELECT ended_at IS NULL FROM holistic_mentorship_mentor_mentee_mappings WHERE id = $1",
+      [mapping_id]
+    ).rows == [[true]]
+  end
+end

--- a/test/dbservice/services/student_eligibility_cleanup_test.exs
+++ b/test/dbservice/services/student_eligibility_cleanup_test.exs
@@ -281,6 +281,42 @@ defmodule Dbservice.Services.StudentEligibilityCleanupTest do
     assert mapping_active?(mapping_id)
   end
 
+  test "a School enrollment without an active Mapping skips the Student lock" do
+    [[user_id]] =
+      Repo.query!(
+        "INSERT INTO \"user\" (inserted_at, updated_at) VALUES (now(), now()) RETURNING id"
+      ).rows
+
+    Repo.query!(
+      "INSERT INTO student (user_id, status, inserted_at, updated_at) VALUES ($1, 'enrolled', now(), now())",
+      [user_id]
+    )
+
+    school_id = insert_school()
+    handler_id = {__MODULE__, self()}
+
+    :telemetry.attach(
+      handler_id,
+      [:dbservice, :repo, :query],
+      fn _, _, metadata, pid -> send(pid, {:enrollment_query, metadata.query}) end,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    assert {:ok, _enrollment} =
+             Dbservice.EnrollmentRecords.create_enrollment_record(%{
+               user_id: user_id,
+               group_id: school_id,
+               group_type: "school",
+               academic_year: "2026-27",
+               start_date: ~D[2026-04-01],
+               is_current: true
+             })
+
+    refute Enum.any?(received_enrollment_queries(), &String.contains?(&1, "FOR UPDATE"))
+  end
+
   defp insert_mapping_scope do
     [[student_user_id], [mentor_user_id]] =
       Repo.query!(
@@ -380,5 +416,13 @@ defmodule Dbservice.Services.StudentEligibilityCleanupTest do
       "SELECT ended_at IS NULL FROM holistic_mentorship_mentor_mentee_mappings WHERE id = $1",
       [mapping_id]
     ).rows == [[true]]
+  end
+
+  defp received_enrollment_queries(queries \\ []) do
+    receive do
+      {:enrollment_query, query} -> received_enrollment_queries([query | queries])
+    after
+      0 -> queries
+    end
   end
 end

--- a/test/dbservice/services/student_eligibility_cleanup_test.exs
+++ b/test/dbservice/services/student_eligibility_cleanup_test.exs
@@ -6,6 +6,7 @@ defmodule Dbservice.Services.StudentEligibilityCleanupTest do
   alias Dbservice.Services.StudentUpdateService
   alias Dbservice.Services.GroupUpdateService
   alias Dbservice.Services.DropoutService
+  alias Dbservice.Services.EnrollmentService
 
   test "a dropout transition ends the Student's active Holistic Mapping" do
     %{mapping_id: mapping_id, student: student} = insert_mapping_scope()
@@ -53,6 +54,106 @@ defmodule Dbservice.Services.StudentEligibilityCleanupTest do
              """,
              [mapping_id]
            ).rows == [[true, "db_service_student_eligibility", "student_grade_changed"]]
+  end
+
+  test "a current School change ends the Student's active Holistic Mapping" do
+    %{mapping_id: mapping_id, student: student} = insert_mapping_scope()
+    old_school_id = insert_school()
+    new_school_id = insert_school()
+    {:ok, old_group} = Dbservice.Groups.create_group(%{type: "school", child_id: old_school_id})
+    {:ok, new_group} = Dbservice.Groups.create_group(%{type: "school", child_id: new_school_id})
+
+    {:ok, _group_user} =
+      Dbservice.GroupUsers.create_group_user(%{user_id: student.user_id, group_id: old_group.id})
+
+    [[enrollment_id]] =
+      Repo.query!(
+        """
+        INSERT INTO enrollment_record
+          (user_id, group_id, group_type, academic_year, start_date, is_current, inserted_at, updated_at)
+        VALUES ($1, $2, 'school', '2026-27', '2026-04-01', true, now(), now())
+        RETURNING id
+        """,
+        [student.user_id, old_school_id]
+      ).rows
+
+    assert {:ok, _group_user} =
+             GroupUpdateService.update_user_group_by_type(%{
+               "user_id" => student.user_id,
+               "group_id" => new_group.id,
+               "type" => "school"
+             })
+
+    assert Repo.get!(Dbservice.EnrollmentRecords.EnrollmentRecord, enrollment_id).group_id ==
+             new_school_id
+
+    assert Repo.query!(
+             "SELECT end_source, end_reason FROM holistic_mentorship_mentor_mentee_mappings WHERE id = $1",
+             [mapping_id]
+           ).rows == [["db_service_student_eligibility", "student_school_changed"]]
+
+    assert Repo.query!("SELECT count(*) FROM holistic_mentorship_mentor_mentee_mappings").rows ==
+             [[1]]
+  end
+
+  test "a current Program change takes precedence over a simultaneous School change" do
+    %{mapping_id: mapping_id, student: student} = insert_mapping_scope()
+    school_id = insert_school()
+
+    [[enrollment_id]] =
+      Repo.query!(
+        """
+        INSERT INTO enrollment_record
+          (user_id, group_id, group_type, academic_year, start_date, is_current, inserted_at, updated_at)
+        VALUES ($1, $2, 'school', '2026-27', '2026-04-01', true, now(), now())
+        RETURNING id
+        """,
+        [student.user_id, school_id]
+      ).rows
+
+    enrollment = Repo.get!(Dbservice.EnrollmentRecords.EnrollmentRecord, enrollment_id)
+
+    assert {:ok, _enrollment} =
+             Dbservice.EnrollmentRecords.update_enrollment_record(enrollment, %{
+               group_type: "program",
+               group_id: 1
+             })
+
+    assert Repo.query!(
+             "SELECT end_reason FROM holistic_mentorship_mentor_mentee_mappings WHERE id = $1",
+             [mapping_id]
+           ).rows == [["student_program_changed"]]
+  end
+
+  test "a batch enrollment failure rolls back School membership cleanup" do
+    %{mapping_id: mapping_id, student: student} = insert_mapping_scope()
+
+    [[school_id]] =
+      Repo.query!(
+        "INSERT INTO school (code, inserted_at, updated_at) VALUES ('BATCH-SCHOOL', now(), now()) RETURNING id"
+      ).rows
+
+    {:ok, _group} = Dbservice.Groups.create_group(%{type: "school", child_id: school_id})
+    install_failing_group_user_trigger()
+
+    assert_raise Postgrex.Error, fn ->
+      EnrollmentService.process_enrollment(%{
+        "user_id" => student.user_id,
+        "enrollment_type" => "school",
+        "school_code" => "BATCH-SCHOOL",
+        "academic_year" => "2026-27",
+        "start_date" => ~D[2026-04-01]
+      })
+    end
+
+    refute Repo.exists?(
+             from enrollment in Dbservice.EnrollmentRecords.EnrollmentRecord,
+               where:
+                 enrollment.user_id == ^student.user_id and
+                   enrollment.group_type == "school" and enrollment.is_current
+           )
+
+    assert mapping_active?(mapping_id)
   end
 
   test "a cleanup failure rolls back the Grade correction and its enrollment changes" do
@@ -161,6 +262,25 @@ defmodule Dbservice.Services.StudentEligibilityCleanupTest do
            ).rows == [[nil, nil, nil]]
   end
 
+  test "an unrelated enrollment mutation leaves the active Mapping unchanged" do
+    %{mapping_id: mapping_id, student: student} = insert_mapping_scope()
+
+    {:ok, enrollment} =
+      Dbservice.EnrollmentRecords.create_enrollment_record(%{
+        user_id: student.user_id,
+        group_id: 10,
+        group_type: "batch",
+        academic_year: "2026-27",
+        start_date: ~D[2026-04-01],
+        is_current: true
+      })
+
+    assert {:ok, _enrollment} =
+             Dbservice.EnrollmentRecords.update_enrollment_record(enrollment, %{group_id: 11})
+
+    assert mapping_active?(mapping_id)
+  end
+
   defp insert_mapping_scope do
     [[student_user_id], [mentor_user_id]] =
       Repo.query!(
@@ -214,6 +334,15 @@ defmodule Dbservice.Services.StudentEligibilityCleanupTest do
     id
   end
 
+  defp insert_school do
+    [[id]] =
+      Repo.query!(
+        "INSERT INTO school (inserted_at, updated_at) VALUES (now(), now()) RETURNING id"
+      ).rows
+
+    id
+  end
+
   defp install_failing_cleanup_trigger do
     Repo.query!("""
     CREATE FUNCTION pg_temp.fail_holistic_mapping_cleanup() RETURNS trigger AS $$
@@ -227,6 +356,22 @@ defmodule Dbservice.Services.StudentEligibilityCleanupTest do
     CREATE TRIGGER fail_holistic_mapping_cleanup
     BEFORE UPDATE ON holistic_mentorship_mentor_mentee_mappings
     FOR EACH ROW EXECUTE FUNCTION pg_temp.fail_holistic_mapping_cleanup()
+    """)
+  end
+
+  defp install_failing_group_user_trigger do
+    Repo.query!("""
+    CREATE FUNCTION pg_temp.fail_group_user_insert() RETURNS trigger AS $$
+    BEGIN
+      RAISE EXCEPTION 'forced group user failure';
+    END;
+    $$ LANGUAGE plpgsql
+    """)
+
+    Repo.query!("""
+    CREATE TRIGGER fail_group_user_insert
+    BEFORE INSERT ON group_user
+    FOR EACH ROW EXECUTE FUNCTION pg_temp.fail_group_user_insert()
     """)
   end
 

--- a/test/dbservice/utils/fetch_data_script_test.exs
+++ b/test/dbservice/utils/fetch_data_script_test.exs
@@ -1,0 +1,135 @@
+defmodule Dbservice.Utils.FetchDataScriptTest do
+  use ExUnit.Case, async: true
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "fetch-data-#{System.unique_integer([:positive])}")
+    bin = Path.join(root, "bin")
+    capture = Path.join(root, "capture")
+    File.mkdir_p!(bin)
+    File.mkdir_p!(capture)
+
+    script = Path.join(root, "fetch-data.sh")
+    File.cp!("utils/fetch-data.sh", script)
+    File.chmod!(script, 0o755)
+
+    File.write!(Path.join(root, ".env"), """
+    FETCH_ENVIRONMENT=production
+    TARGET_ENVIRONMENT=staging
+    PROD_DB_HOST=prod
+    PROD_DB_NAME=prod_db
+    PROD_DB_USER=prod_user
+    PROD_DB_PASSWORD=prod_password
+    PROD_DB_PORT=5432
+    STAGING_DB_HOST=staging
+    STAGING_DB_NAME=staging_db
+    STAGING_DB_USER=staging_user
+    STAGING_DB_PASSWORD=staging_password
+    STAGING_DB_PORT=5432
+    LOCAL_DB_HOST=local
+    LOCAL_DB_NAME=local_db
+    LOCAL_DB_USER=local_user
+    LOCAL_DB_PASSWORD=local_password
+    DUMP_FILE=test_dump.sql
+    """)
+
+    write_executable(Path.join(bin, "pg_dump"), """
+    #!/bin/bash
+    printf '%s\n' "$@" > "$CAPTURE_DIR/pg_dump.args"
+    for arg in "$@"; do
+      case "$arg" in --file=*) printf dump > "${arg#--file=}" ;; esac
+    done
+    """)
+
+    write_executable(Path.join(bin, "psql"), """
+    #!/bin/bash
+    printf '%s\n' "$@" >> "$CAPTURE_DIR/psql.args"
+    """)
+
+    on_exit(fn -> File.rm_rf!(root) end)
+
+    %{bin: bin, capture: capture, script: script}
+  end
+
+  test "production-to-staging excludes all Holistic Mentorship table data", context do
+    assert {_, 0} = run_script(context, "SYNC STAGING")
+
+    assert "--exclude-table-data=public.holistic_mentorship_*" in captured_args(
+             context,
+             "pg_dump.args"
+           )
+  end
+
+  test "production-to-local remains available without the Holistic exclusion", context do
+    set_environments(context, "production", "local")
+
+    assert {_, 0} = run_script(context, "y")
+
+    refute "--exclude-table-data=public.holistic_mentorship_*" in captured_args(
+             context,
+             "pg_dump.args"
+           )
+  end
+
+  test "invalid source is rejected before database commands run", context do
+    set_environments(context, "invalid", "local")
+
+    assert {output, status} = run_script(context, "y")
+    assert status != 0
+    assert output =~ "Invalid FETCH_ENVIRONMENT 'invalid'"
+    refute File.exists?(Path.join(context.capture, "pg_dump.args"))
+  end
+
+  test "invalid target is rejected before database commands run", context do
+    set_environments(context, "production", "invalid")
+
+    assert {output, status} = run_script(context, "y")
+    assert status != 0
+    assert output =~ "Invalid TARGET_ENVIRONMENT 'invalid'"
+    refute File.exists?(Path.join(context.capture, "pg_dump.args"))
+  end
+
+  test "production cannot be used as a sync target", context do
+    set_environments(context, "production", "production")
+
+    assert {output, status} = run_script(context, "y")
+    assert status != 0
+    assert output =~ "Production cannot be used as a sync target"
+    refute File.exists?(Path.join(context.capture, "pg_dump.args"))
+  end
+
+  defp run_script(context, confirmation) do
+    System.cmd(
+      "bash",
+      ["-c", "printf '%s\\n' \"$2\" | bash \"$1\"", "_", context.script, confirmation],
+      env: [
+        {"PATH", "#{context.bin}:#{System.fetch_env!("PATH")}"},
+        {"CAPTURE_DIR", context.capture}
+      ],
+      stderr_to_stdout: true
+    )
+  end
+
+  defp captured_args(context, file) do
+    context.capture
+    |> Path.join(file)
+    |> File.read!()
+    |> String.split("\n", trim: true)
+  end
+
+  defp set_environments(context, source, target) do
+    env_file = Path.join(Path.dirname(context.script), ".env")
+
+    contents =
+      env_file
+      |> File.read!()
+      |> String.replace("FETCH_ENVIRONMENT=production", "FETCH_ENVIRONMENT=#{source}")
+      |> String.replace("TARGET_ENVIRONMENT=staging", "TARGET_ENVIRONMENT=#{target}")
+
+    File.write!(env_file, contents)
+  end
+
+  defp write_executable(path, contents) do
+    File.write!(path, contents)
+    File.chmod!(path, 0o755)
+  end
+end

--- a/test/dbservice/utils/fetch_data_script_test.exs
+++ b/test/dbservice/utils/fetch_data_script_test.exs
@@ -76,7 +76,7 @@ defmodule Dbservice.Utils.FetchDataScriptTest do
     assert {output, status} = run_script(context, "y")
     assert status != 0
     assert output =~ "Invalid FETCH_ENVIRONMENT 'invalid'"
-    refute File.exists?(Path.join(context.capture, "pg_dump.args"))
+    refute_database_commands(context)
   end
 
   test "invalid target is rejected before database commands run", context do
@@ -85,7 +85,7 @@ defmodule Dbservice.Utils.FetchDataScriptTest do
     assert {output, status} = run_script(context, "y")
     assert status != 0
     assert output =~ "Invalid TARGET_ENVIRONMENT 'invalid'"
-    refute File.exists?(Path.join(context.capture, "pg_dump.args"))
+    refute_database_commands(context)
   end
 
   test "production cannot be used as a sync target", context do
@@ -94,7 +94,7 @@ defmodule Dbservice.Utils.FetchDataScriptTest do
     assert {output, status} = run_script(context, "y")
     assert status != 0
     assert output =~ "Production cannot be used as a sync target"
-    refute File.exists?(Path.join(context.capture, "pg_dump.args"))
+    refute_database_commands(context)
   end
 
   defp run_script(context, confirmation) do
@@ -114,6 +114,11 @@ defmodule Dbservice.Utils.FetchDataScriptTest do
     |> Path.join(file)
     |> File.read!()
     |> String.split("\n", trim: true)
+  end
+
+  defp refute_database_commands(context) do
+    refute File.exists?(Path.join(context.capture, "pg_dump.args"))
+    refute File.exists?(Path.join(context.capture, "psql.args"))
   end
 
   defp set_environments(context, source, target) do

--- a/test/dbservice/utils/group_update_processor_test.exs
+++ b/test/dbservice/utils/group_update_processor_test.exs
@@ -146,9 +146,9 @@ defmodule Dbservice.DataImport.GroupUpdateProcessorTest do
       assert {:ok, "School update processed successfully"} = result
 
       assert Repo.query!(
-               "SELECT end_reason FROM holistic_mentorship_mentor_mentee_mappings WHERE id = $1",
+               "SELECT ended_at IS NULL FROM holistic_mentorship_mentor_mentee_mappings WHERE id = $1",
                [mapping_id]
-             ).rows == [["student_school_changed"]]
+             ).rows == [[true]]
     end
 
     test "returns error when student is not found" do

--- a/test/dbservice/utils/group_update_processor_test.exs
+++ b/test/dbservice/utils/group_update_processor_test.exs
@@ -133,6 +133,8 @@ defmodule Dbservice.DataImport.GroupUpdateProcessorTest do
           academic_year: "2024-25"
         })
 
+      mapping_id = insert_active_mapping(student.id)
+
       record = %{
         "student_id" => student.student_id,
         "school_code" => school.code
@@ -141,6 +143,11 @@ defmodule Dbservice.DataImport.GroupUpdateProcessorTest do
       result = GroupUpdateProcessor.process_school_update(record)
 
       assert {:ok, "School update processed successfully"} = result
+
+      assert Repo.query!(
+               "SELECT end_reason FROM holistic_mentorship_mentor_mentee_mappings WHERE id = $1",
+               [mapping_id]
+             ).rows == [["student_school_changed"]]
     end
 
     test "returns error when student is not found" do

--- a/test/dbservice/utils/group_update_processor_test.exs
+++ b/test/dbservice/utils/group_update_processor_test.exs
@@ -186,6 +186,7 @@ defmodule Dbservice.DataImport.GroupUpdateProcessorTest do
     test "successfully processes grade update with valid data" do
       # Create fixtures
       {user, student} = student_fixture(%{student_id: "STUDENT001"})
+      mapping_id = insert_active_mapping(student.id)
       grade = grade_fixture(%{number: 9998})
 
       # Get existing group for the grade
@@ -217,6 +218,11 @@ defmodule Dbservice.DataImport.GroupUpdateProcessorTest do
       result = GroupUpdateProcessor.process_grade_update(record)
 
       assert {:ok, "Grade update processed successfully"} = result
+
+      assert Repo.query!(
+               "SELECT end_reason FROM holistic_mentorship_mentor_mentee_mappings WHERE id = $1",
+               [mapping_id]
+             ).rows == [["student_grade_changed"]]
     end
 
     test "returns error when student is not found" do
@@ -333,5 +339,35 @@ defmodule Dbservice.DataImport.GroupUpdateProcessorTest do
 
       assert {:error, "Group user or enrollment record not found"} = result
     end
+  end
+
+  defp insert_active_mapping(student_id) do
+    mentor = user_fixture()
+    school = school_fixture()
+
+    [[product_id]] =
+      Repo.query!(
+        "INSERT INTO product (name, inserted_at, updated_at) VALUES ('CSV Cleanup', now(), now()) RETURNING id"
+      ).rows
+
+    [[program_id]] =
+      Repo.query!(
+        "INSERT INTO program (name, product_id, inserted_at, updated_at) VALUES ('CSV Cleanup', $1, now(), now()) RETURNING id",
+        [product_id]
+      ).rows
+
+    [[mapping_id]] =
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_mentor_mentee_mappings
+          (student_id, mentor_user_id, school_id, program_id, academic_year, started_at,
+           assignment_source)
+        VALUES ($1, $2, $3, $4, '2026-27', timezone('UTC', now()), 'af_lms')
+        RETURNING id
+        """,
+        [student_id, mentor.id, school.id, program_id]
+      ).rows
+
+    mapping_id
   end
 end

--- a/test/dbservice_web/controllers/enrollment_record_controller_test.exs
+++ b/test/dbservice_web/controllers/enrollment_record_controller_test.exs
@@ -142,7 +142,7 @@ defmodule DbserviceWeb.EnrollmentRecordControllerTest do
       end
     end
 
-    test "ending current Program membership through the API ends the active Holistic Mapping", %{
+    test "ending current Program membership leaves Mapping cleanup to AF LMS", %{
       conn: conn
     } do
       %{enrollment_id: enrollment_id, mapping_id: mapping_id} = insert_program_mapping_scope()
@@ -152,9 +152,9 @@ defmodule DbserviceWeb.EnrollmentRecordControllerTest do
       assert response(conn, 204)
 
       assert Dbservice.Repo.query!(
-               "SELECT end_source, end_reason FROM holistic_mentorship_mentor_mentee_mappings WHERE id = $1",
+               "SELECT ended_at IS NULL FROM holistic_mentorship_mentor_mentee_mappings WHERE id = $1",
                [mapping_id]
-             ).rows == [["db_service_student_eligibility", "student_program_changed"]]
+             ).rows == [[true]]
     end
   end
 

--- a/test/dbservice_web/controllers/enrollment_record_controller_test.exs
+++ b/test/dbservice_web/controllers/enrollment_record_controller_test.exs
@@ -141,6 +141,21 @@ defmodule DbserviceWeb.EnrollmentRecordControllerTest do
         get(conn, ~p"/api/enrollment-record/#{enrollment_record}")
       end
     end
+
+    test "ending current Program membership through the API ends the active Holistic Mapping", %{
+      conn: conn
+    } do
+      %{enrollment_id: enrollment_id, mapping_id: mapping_id} = insert_program_mapping_scope()
+
+      conn = delete(conn, ~p"/api/enrollment-record/#{enrollment_id}")
+
+      assert response(conn, 204)
+
+      assert Dbservice.Repo.query!(
+               "SELECT end_source, end_reason FROM holistic_mentorship_mentor_mentee_mappings WHERE id = $1",
+               [mapping_id]
+             ).rows == [["db_service_student_eligibility", "student_program_changed"]]
+    end
   end
 
   defp create_enrollment_record(_) do
@@ -162,5 +177,59 @@ defmodule DbserviceWeb.EnrollmentRecordControllerTest do
     group_id = enrollment_record_fixture.group_id
     subject_id = enrollment_record_fixture.subject_id
     Map.merge(@update_attrs, %{user_id: user_id, group_id: group_id, subject_id: subject_id})
+  end
+
+  defp insert_program_mapping_scope do
+    [[student_user_id], [mentor_user_id]] =
+      Dbservice.Repo.query!(
+        "INSERT INTO \"user\" (inserted_at, updated_at) VALUES (now(), now()), (now(), now()) RETURNING id"
+      ).rows
+
+    [[student_id]] =
+      Dbservice.Repo.query!(
+        "INSERT INTO student (user_id, status, inserted_at, updated_at) VALUES ($1, 'enrolled', now(), now()) RETURNING id",
+        [student_user_id]
+      ).rows
+
+    [[school_id]] =
+      Dbservice.Repo.query!(
+        "INSERT INTO school (inserted_at, updated_at) VALUES (now(), now()) RETURNING id"
+      ).rows
+
+    [[product_id]] =
+      Dbservice.Repo.query!(
+        "INSERT INTO product (name, inserted_at, updated_at) VALUES ('Enrollment API Cleanup', now(), now()) RETURNING id"
+      ).rows
+
+    [[program_id]] =
+      Dbservice.Repo.query!(
+        "INSERT INTO program (name, product_id, inserted_at, updated_at) VALUES ('Enrollment API Cleanup', $1, now(), now()) RETURNING id",
+        [product_id]
+      ).rows
+
+    [[mapping_id]] =
+      Dbservice.Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_mentor_mentee_mappings
+          (student_id, mentor_user_id, school_id, program_id, academic_year, started_at,
+           assignment_source)
+        VALUES ($1, $2, $3, $4, '2026-27', timezone('UTC', now()), 'af_lms')
+        RETURNING id
+        """,
+        [student_id, mentor_user_id, school_id, program_id]
+      ).rows
+
+    [[enrollment_id]] =
+      Dbservice.Repo.query!(
+        """
+        INSERT INTO enrollment_record
+          (user_id, group_id, group_type, academic_year, start_date, is_current, inserted_at, updated_at)
+        VALUES ($1, $2, 'program', '2026-27', '2026-04-01', true, now(), now())
+        RETURNING id
+        """,
+        [student_user_id, program_id]
+      ).rows
+
+    %{enrollment_id: enrollment_id, mapping_id: mapping_id}
   end
 end

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_generation_status_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_generation_status_controller_test.exs
@@ -96,6 +96,58 @@ defmodule DbserviceWeb.HolisticMentorshipProfileGenerationStatusControllerTest d
            """).rows == [[1, "completed", "published"]]
   end
 
+  test "accepts concurrent retries of the initial queued state", %{conn: conn} do
+    authorization = conn |> get_req_header("authorization") |> List.first()
+
+    Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+      student_id = insert_student!()
+      configuration_id = insert_prompt_configuration!()
+      params = status_params(student_id, configuration_id)
+      parent = self()
+
+      try do
+        tasks =
+          for _ <- 1..2 do
+            Task.async(fn ->
+              Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+                send(parent, {:ready, self()})
+
+                receive do
+                  :go ->
+                    build_conn()
+                    |> put_req_header("authorization", authorization)
+                    |> post("/api/holistic-mentorship/profile-generation-statuses", params)
+                    |> json_response(200)
+                end
+              end)
+            end)
+          end
+
+        task_pids =
+          for _ <- tasks do
+            assert_receive {:ready, task_pid}
+            task_pid
+          end
+
+        Enum.each(task_pids, &send(&1, :go))
+        assert Enum.map(tasks, &Task.await/1) |> Enum.all?(&(&1["state"] == "queued"))
+
+        assert Repo.query!(
+                 "SELECT count(*) FROM holistic_mentorship_profile_generation_statuses WHERE etl_run_id = 'etl-run-623'"
+               ).rows == [[1]]
+      after
+        Repo.query!(
+          "TRUNCATE holistic_mentorship_profile_generation_statuses, holistic_mentorship_student_profile_summaries, holistic_mentorship_student_profiles, holistic_mentorship_prompt_configurations, holistic_mentorship_prompt_versions RESTART IDENTITY"
+        )
+
+        Repo.query!(
+          "WITH deleted AS (DELETE FROM student WHERE id = $1 RETURNING user_id) DELETE FROM \"user\" WHERE id IN (SELECT user_id FROM deleted)",
+          [student_id]
+        )
+      end
+    end)
+  end
+
   test "rejects invalid source, result, and unbounded error metadata with a stable safe error", %{
     conn: conn
   } do
@@ -211,6 +263,7 @@ defmodule DbserviceWeb.HolisticMentorshipProfileGenerationStatusControllerTest d
     configuration_id = insert_prompt_configuration!()
     profile_id = insert_successful_profile!(student_id, configuration_id)
     params = status_params(student_id, configuration_id)
+    error_message = String.duplicate("s", 500)
 
     post_status(conn, params)
     post_status(conn, Map.put(params, "state", "running"))
@@ -223,7 +276,7 @@ defmodule DbserviceWeb.HolisticMentorshipProfileGenerationStatusControllerTest d
           Map.merge(params, %{
             "answers" => "private answers 623",
             "error_code" => "upstream_timeout",
-            "error_message" => "Bounded safe failure",
+            "error_message" => error_message,
             "prompt" => "private prompt 623",
             "source_user_id" => "private-source-user-623",
             "state" => "failed",
@@ -235,7 +288,7 @@ defmodule DbserviceWeb.HolisticMentorshipProfileGenerationStatusControllerTest d
     assert json_response(failed_conn, 200) == %{
              "completed_outcome" => nil,
              "error_code" => "upstream_timeout",
-             "error_message" => "Bounded safe failure",
+             "error_message" => error_message,
              "state" => "failed"
            }
 

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_generation_status_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_generation_status_controller_test.exs
@@ -137,7 +137,7 @@ defmodule DbserviceWeb.HolisticMentorshipProfileGenerationStatusControllerTest d
                ).rows == [[1]]
       after
         Repo.query!(
-          "TRUNCATE holistic_mentorship_profile_generation_statuses, holistic_mentorship_student_profile_summaries, holistic_mentorship_student_profiles, holistic_mentorship_prompt_configurations, holistic_mentorship_prompt_versions RESTART IDENTITY"
+          "TRUNCATE holistic_mentorship_regeneration_requests, holistic_mentorship_profile_generation_statuses, holistic_mentorship_student_profile_summaries, holistic_mentorship_student_profiles, holistic_mentorship_prompt_configurations, holistic_mentorship_prompt_versions RESTART IDENTITY"
         )
 
         Repo.query!(

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_generation_status_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_generation_status_controller_test.exs
@@ -159,6 +159,7 @@ defmodule DbserviceWeb.HolisticMentorshipProfileGenerationStatusControllerTest d
       Map.merge(params, %{"state" => "completed"}),
       Map.merge(params, %{"completed_outcome" => "invented", "state" => "completed"}),
       Map.merge(params, %{"error_message" => String.duplicate("x", 501), "state" => "failed"}),
+      Map.put(params, "etl_run_id", String.duplicate("r", 256)),
       Map.put(params, "form_id", "unapproved-form")
     ]
 

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_generation_status_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_generation_status_controller_test.exs
@@ -1,0 +1,384 @@
+defmodule DbserviceWeb.HolisticMentorshipProfileGenerationStatusControllerTest do
+  use DbserviceWeb.ConnCase, async: false
+
+  alias Dbservice.Repo
+
+  import ExUnit.CaptureLog
+
+  test "records a queued Profile generation status at the authenticated HTTP boundary", %{
+    conn: conn
+  } do
+    student_id = insert_student!()
+    configuration_id = insert_prompt_configuration!()
+
+    response =
+      conn
+      |> post(
+        "/api/holistic-mentorship/profile-generation-statuses",
+        status_params(student_id, configuration_id)
+      )
+      |> json_response(200)
+
+    assert response == %{
+             "completed_outcome" => nil,
+             "error_code" => nil,
+             "error_message" => nil,
+             "state" => "queued"
+           }
+
+    assert Repo.query!("""
+           SELECT etl_run_id, student_id, form_id, af_session_id, entry_grade,
+                  prompt_configuration_id, state, completed_outcome, error_code,
+                  error_message, inserted_at IS NOT NULL, updated_at IS NOT NULL
+           FROM holistic_mentorship_profile_generation_statuses
+           """).rows == [
+             [
+               "etl-run-623",
+               student_id,
+               "6a44a83d1184e717b920c499",
+               "EnableStudents_6a44a83d1184e717b920c499",
+               11,
+               configuration_id,
+               "queued",
+               nil,
+               nil,
+               nil,
+               true,
+               true
+             ]
+           ]
+  end
+
+  test "advances valid transitions and retries each state without duplicate rows", %{conn: conn} do
+    student_id = insert_student!()
+    configuration_id = insert_prompt_configuration!()
+
+    queued = post_status(conn, status_params(student_id, configuration_id))
+    assert post_status(conn, status_params(student_id, configuration_id)) == queued
+
+    running =
+      post_status(conn, status_params(student_id, configuration_id, %{"state" => "running"}))
+
+    assert running["state"] == "running"
+
+    assert post_status(
+             conn,
+             status_params(student_id, configuration_id, %{"state" => "running"})
+           ) == running
+
+    completed =
+      post_status(
+        conn,
+        status_params(student_id, configuration_id, %{
+          "completed_outcome" => "published",
+          "state" => "completed"
+        })
+      )
+
+    assert completed == %{
+             "completed_outcome" => "published",
+             "error_code" => nil,
+             "error_message" => nil,
+             "state" => "completed"
+           }
+
+    assert post_status(
+             conn,
+             status_params(student_id, configuration_id, %{
+               "completed_outcome" => "published",
+               "state" => "completed"
+             })
+           ) == completed
+
+    assert Repo.query!("""
+           SELECT count(*), min(state), min(completed_outcome)
+           FROM holistic_mentorship_profile_generation_statuses
+           """).rows == [[1, "completed", "published"]]
+  end
+
+  test "rejects invalid source, result, and unbounded error metadata with a stable safe error", %{
+    conn: conn
+  } do
+    student_id = insert_student!()
+    configuration_id = insert_prompt_configuration!()
+    params = status_params(student_id, configuration_id)
+
+    invalid_requests = [
+      Map.merge(params, %{"state" => "completed"}),
+      Map.merge(params, %{"completed_outcome" => "invented", "state" => "completed"}),
+      Map.merge(params, %{"error_message" => String.duplicate("x", 501), "state" => "failed"}),
+      Map.put(params, "form_id", "unapproved-form")
+    ]
+
+    for invalid_params <- invalid_requests do
+      assert conn
+             |> post("/api/holistic-mentorship/profile-generation-statuses", invalid_params)
+             |> json_response(422) == %{
+               "error" => %{
+                 "code" => "invalid_request",
+                 "message" => "Profile generation status fields are missing or invalid"
+               }
+             }
+    end
+
+    assert Repo.query!("SELECT count(*) FROM holistic_mentorship_profile_generation_statuses").rows ==
+             [[0]]
+  end
+
+  test "rejects regressions and changes to terminal status with stable safe codes", %{conn: conn} do
+    student_id = insert_student!()
+    configuration_id = insert_prompt_configuration!()
+    params = status_params(student_id, configuration_id)
+
+    assert_error(
+      post(
+        conn,
+        "/api/holistic-mentorship/profile-generation-statuses",
+        Map.put(params, "state", "running")
+      ),
+      "invalid_status_transition",
+      "Profile generation status transition is invalid"
+    )
+
+    post_status(conn, params)
+    post_status(conn, Map.put(params, "state", "running"))
+
+    assert_error(
+      post(conn, "/api/holistic-mentorship/profile-generation-statuses", params),
+      "invalid_status_transition",
+      "Profile generation status transition is invalid"
+    )
+
+    post_status(
+      conn,
+      Map.merge(params, %{"state" => "failed", "error_code" => "upstream_timeout"})
+    )
+
+    assert_error(
+      post(
+        conn,
+        "/api/holistic-mentorship/profile-generation-statuses",
+        Map.merge(params, %{"state" => "failed", "error_code" => "different_error"})
+      ),
+      "terminal_status_conflict",
+      "Profile generation status is terminal"
+    )
+  end
+
+  test "rejects unknown canonical identities without exposing them in responses or logs", %{
+    conn: conn
+  } do
+    configuration_id = insert_prompt_configuration!()
+    unknown_student_id = 2_147_483_646
+
+    {conn, log} =
+      with_debug_log(fn ->
+        post(
+          conn,
+          "/api/holistic-mentorship/profile-generation-statuses",
+          status_params(unknown_student_id, configuration_id, %{
+            "answers" => "sensitive answers",
+            "prompt" => "sensitive prompt",
+            "source_user_id" => "sensitive-source-user",
+            "summaries" => ["sensitive summary"]
+          })
+        )
+      end)
+
+    assert json_response(conn, 422) == %{
+             "error" => %{
+               "code" => "invalid_request",
+               "message" => "Profile generation status fields are missing or invalid"
+             }
+           }
+
+    for sensitive <- [
+          Integer.to_string(unknown_student_id),
+          "sensitive answers",
+          "sensitive prompt",
+          "sensitive-source-user",
+          "sensitive summary"
+        ] do
+      refute conn.resp_body =~ sensitive
+      refute log =~ sensitive
+    end
+  end
+
+  test "failed and invalid updates preserve the successful Profile and redact sensitive input", %{
+    conn: conn
+  } do
+    student_id = insert_student!()
+    configuration_id = insert_prompt_configuration!()
+    profile_id = insert_successful_profile!(student_id, configuration_id)
+    params = status_params(student_id, configuration_id)
+
+    post_status(conn, params)
+    post_status(conn, Map.put(params, "state", "running"))
+
+    {failed_conn, log} =
+      with_debug_log(fn ->
+        post(
+          conn,
+          "/api/holistic-mentorship/profile-generation-statuses",
+          Map.merge(params, %{
+            "answers" => "private answers 623",
+            "error_code" => "upstream_timeout",
+            "error_message" => "Bounded safe failure",
+            "prompt" => "private prompt 623",
+            "source_user_id" => "private-source-user-623",
+            "state" => "failed",
+            "summaries" => ["private summary 623"]
+          })
+        )
+      end)
+
+    assert json_response(failed_conn, 200) == %{
+             "completed_outcome" => nil,
+             "error_code" => "upstream_timeout",
+             "error_message" => "Bounded safe failure",
+             "state" => "failed"
+           }
+
+    for sensitive <- [
+          "private answers 623",
+          "private prompt 623",
+          "private-source-user-623",
+          "private summary 623"
+        ] do
+      refute failed_conn.resp_body =~ sensitive
+      refute log =~ sensitive
+    end
+
+    assert Repo.query!(
+             """
+             SELECT profile.id, profile.answer_fingerprint, profile.revision, count(summary.id)
+             FROM holistic_mentorship_student_profiles AS profile
+             JOIN holistic_mentorship_student_profile_summaries AS summary
+               ON summary.student_profile_id = profile.id
+             WHERE profile.id = $1
+             GROUP BY profile.id
+             """,
+             [profile_id]
+           ).rows == [[profile_id, "answers-success", 2, 5]]
+  end
+
+  test "requires the existing Bearer token", %{conn: _conn} do
+    assert build_conn()
+           |> post("/api/holistic-mentorship/profile-generation-statuses", %{})
+           |> response(401) == "Not Authorized"
+  end
+
+  defp assert_error(conn, code, message) do
+    assert json_response(conn, 409) == %{"error" => %{"code" => code, "message" => message}}
+  end
+
+  defp with_debug_log(operation) do
+    previous_level = Logger.level()
+    Logger.configure(level: :debug)
+
+    try do
+      with_log([level: :debug], operation)
+    after
+      Logger.configure(level: previous_level)
+    end
+  end
+
+  defp post_status(conn, params) do
+    conn
+    |> post("/api/holistic-mentorship/profile-generation-statuses", params)
+    |> json_response(200)
+  end
+
+  defp status_params(student_id, configuration_id, overrides \\ %{}) do
+    Map.merge(
+      %{
+        "af_session_id" => "EnableStudents_6a44a83d1184e717b920c499",
+        "entry_grade" => 11,
+        "etl_run_id" => "etl-run-623",
+        "form_id" => "6a44a83d1184e717b920c499",
+        "prompt_configuration_id" => configuration_id,
+        "state" => "queued",
+        "student_id" => student_id
+      },
+      overrides
+    )
+  end
+
+  defp insert_student! do
+    [[user_id]] =
+      Repo.query!(
+        "INSERT INTO \"user\" (inserted_at, updated_at) VALUES (now(), now()) RETURNING id"
+      ).rows
+
+    [[student_id]] =
+      Repo.query!(
+        "INSERT INTO student (user_id, inserted_at, updated_at) VALUES ($1, now(), now()) RETURNING id",
+        [user_id]
+      ).rows
+
+    student_id
+  end
+
+  defp insert_prompt_configuration! do
+    [[prompt_version_id]] =
+      Repo.query!("""
+      INSERT INTO holistic_mentorship_prompt_versions (version, template_text, template_hash)
+      VALUES ('generation-status-v1', 'abc',
+              'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
+      RETURNING id
+      """).rows
+
+    [[configuration_id]] =
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_prompt_configurations (prompt_version_id, model_id)
+        VALUES ($1, 'openai/gpt-5-mini')
+        RETURNING id
+        """,
+        [prompt_version_id]
+      ).rows
+
+    configuration_id
+  end
+
+  defp insert_successful_profile!(student_id, configuration_id) do
+    [[journey_id]] =
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_profile_journeys
+          (student_id, form_id, af_session_id, entry_grade)
+        VALUES ($1, '6a44a83d1184e717b920c499',
+                'EnableStudents_6a44a83d1184e717b920c499', 11)
+        RETURNING id
+        """,
+        [student_id]
+      ).rows
+
+    [[profile_id]] =
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_student_profiles
+          (profile_journey_id, prompt_configuration_id, schema_fingerprint,
+           answer_fingerprint, warehouse_loaded_at, generated_at, revision,
+           last_successful_etl_run_id)
+        VALUES ($1, $2, 'schema-success', 'answers-success', '2026-07-16 10:00:00',
+                '2026-07-16 10:05:00', 2, 'etl-success')
+        RETURNING id
+        """,
+        [journey_id, configuration_id]
+      ).rows
+
+    for position <- 1..5 do
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_student_profile_summaries
+          (student_profile_id, position, question_set_title, summary)
+        VALUES ($1, $2, $3, $4)
+        """,
+        [profile_id, position, "Question Set #{position}", "Summary #{position}"]
+      )
+    end
+
+    profile_id
+  end
+end

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller_test.exs
@@ -88,7 +88,7 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
   end
 
   test "rejects an empty or missing records batch safely", %{conn: conn} do
-    for params <- [%{"records" => []}, %{}] do
+    for params <- [%{"records" => []}, %{"records" => ["not-a-record"]}, %{}] do
       assert conn
              |> post("/api/holistic-mentorship/profile-preflight", params)
              |> json_response(422) == %{

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller_test.exs
@@ -149,6 +149,20 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
            }
   end
 
+  test "rejects a privacy-deleted Student before Profile generation", %{conn: conn} do
+    prompt_configuration_id = prompt_configuration_id(conn)
+    {user, student} = eligible_student(11, "PRIVACY-DELETED")
+    insert_privacy_deletion!(student.id, user_fixture().id)
+
+    assert conn
+           |> post("/api/holistic-mentorship/profile-preflight", %{
+             "records" => [preflight_record("privacy-deleted", user.id, prompt_configuration_id)]
+           })
+           |> json_response(200) == %{
+             "results" => [rejected("privacy-deleted", "privacy_erased")]
+           }
+  end
+
   test "accepts 100 records and rejects 101 records wholly", %{conn: conn} do
     prompt_configuration_id = prompt_configuration_id(conn)
     {user, _student} = eligible_student(11, "BOUNDARY")
@@ -445,6 +459,18 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
 
   defp rejected(record_ref, reason_code) do
     %{"record_ref" => record_ref, "reason_code" => reason_code}
+  end
+
+  defp insert_privacy_deletion!(student_id, actor_user_id) do
+    Repo.query!(
+      """
+      INSERT INTO holistic_mentorship_privacy_deletions
+        (student_id, actor_user_id, reason, profile_summaries_erased,
+         post_session_answers_erased, historical_answers_erased, occurred_at)
+      VALUES ($1, $2, 'approved-request', 0, 0, 0, now())
+      """,
+      [student_id, actor_user_id]
+    )
   end
 
   defp insert_journey!(student_id, source) do

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller_test.exs
@@ -27,6 +27,9 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
     {grade_11_user, grade_11_student} = eligible_student(11, "BUSINESS-G11")
     {grade_12_user, grade_12_student} = eligible_student(12, "BUSINESS-G12")
 
+    assert Repo.query!("SELECT count(*) FROM enrollment_record WHERE group_type = 'program'").rows ==
+             [[0]]
+
     response =
       conn
       |> post("/api/holistic-mentorship/profile-preflight", %{
@@ -281,21 +284,14 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
 
   test "rejects out-of-scope, duplicate, and inconsistent current eligibility", %{conn: conn} do
     prompt_configuration_id = prompt_configuration_id(conn)
-    {program_user, _student} = eligible_student(11, "NO-PROGRAM")
     {school_program_user, _student} = eligible_student(11, "SCHOOL-NO-PROGRAM")
     {school_user, _student} = eligible_student(11, "NO-SCHOOL")
     {duplicate_school_user, _student} = eligible_student(11, "TWO-SCHOOLS")
-    {duplicate_program_user, _student} = eligible_student(11, "TWO-PROGRAMS")
     {grade_10_user, _student} = eligible_student(10, "GRADE-10")
     {missing_grade_user, _student} = eligible_student(11, "NO-GRADE")
     {duplicate_grade_user, duplicate_grade_student} = eligible_student(11, "TWO-GRADES")
     {mismatched_grade_user, _student} = eligible_student(11, "GRADE-MISMATCH")
     {dropout_user, _student} = eligible_student(11, "DROPOUT")
-
-    Repo.query!(
-      "UPDATE enrollment_record SET group_id = 2 WHERE user_id = $1 AND group_type = 'program'",
-      [program_user.id]
-    )
 
     Repo.query!(
       """
@@ -315,7 +311,6 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
 
     second_school = school_fixture(%{program_ids: [1], code: "second-school"})
     enroll(duplicate_school_user.id, "school", second_school.id)
-    enroll(duplicate_program_user.id, "program", 1)
 
     Repo.query!("DELETE FROM enrollment_record WHERE user_id = $1 AND group_type = 'grade'", [
       missing_grade_user.id
@@ -333,11 +328,9 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
     Repo.query!("UPDATE student SET status = 'dropout' WHERE user_id = $1", [dropout_user.id])
 
     records = [
-      preflight_record("program", program_user.id, prompt_configuration_id),
       preflight_record("school-program", school_program_user.id, prompt_configuration_id),
       preflight_record("school", school_user.id, prompt_configuration_id),
       preflight_record("two-schools", duplicate_school_user.id, prompt_configuration_id),
-      preflight_record("two-programs", duplicate_program_user.id, prompt_configuration_id),
       preflight_record("grade-10", grade_10_user.id, prompt_configuration_id),
       preflight_record("no-grade", missing_grade_user.id, prompt_configuration_id),
       preflight_record("two-grades", duplicate_grade_user.id, prompt_configuration_id),
@@ -349,11 +342,9 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
            |> post("/api/holistic-mentorship/profile-preflight", %{"records" => records})
            |> json_response(200) == %{
              "results" => [
-               rejected("program", "program_ineligible"),
                rejected("school-program", "program_ineligible"),
                rejected("school", "school_missing_or_ambiguous"),
                rejected("two-schools", "school_missing_or_ambiguous"),
-               rejected("two-programs", "eligibility_inconsistent"),
                rejected("grade-10", "grade_ineligible"),
                rejected("no-grade", "grade_ineligible"),
                rejected("two-grades", "eligibility_inconsistent"),
@@ -407,7 +398,6 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
     school = school_fixture(%{program_ids: [1], code: "school-#{user.id}"})
 
     enroll(user.id, "school", school.id)
-    enroll(user.id, "program", 1)
     enroll(user.id, "grade", grade.id)
 
     {user, student}

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller_test.exs
@@ -1,0 +1,350 @@
+defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
+  use DbserviceWeb.ConnCase, async: false
+
+  alias Dbservice.Repo
+
+  import Dbservice.GradesFixtures
+  import Dbservice.SchoolsFixtures
+  import Dbservice.UsersFixtures
+  import ExUnit.CaptureLog
+
+  @template_hash "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+  @grade_11_source %{
+    "af_session_id" => "EnableStudents_6a44a83d1184e717b920c499",
+    "entry_grade" => 11,
+    "form_id" => "6a44a83d1184e717b920c499"
+  }
+  @grade_12_source %{
+    "af_session_id" => "EnableStudents_6a4deca8e030ebe34669fb0f",
+    "entry_grade" => 12,
+    "form_id" => "6a4deca8e030ebe34669fb0f"
+  }
+
+  test "preflights both approved Profile sources in input order with canonical Student IDs", %{
+    conn: conn
+  } do
+    prompt_configuration_id = prompt_configuration_id(conn)
+    {grade_11_user, grade_11_student} = eligible_student(11, "BUSINESS-G11")
+    {grade_12_user, grade_12_student} = eligible_student(12, "BUSINESS-G12")
+
+    response =
+      conn
+      |> post("/api/holistic-mentorship/profile-preflight", %{
+        "records" => [
+          record("second", grade_12_user.id, prompt_configuration_id, @grade_12_source),
+          record("first", grade_11_user.id, prompt_configuration_id, @grade_11_source)
+        ]
+      })
+      |> json_response(200)
+
+    assert response == %{
+             "results" => [
+               %{
+                 "record_ref" => "second",
+                 "student_id" => grade_12_student.id,
+                 "prompt_configuration_id" => prompt_configuration_id,
+                 "profile_state" => "missing",
+                 "profile_revision" => nil
+               },
+               %{
+                 "record_ref" => "first",
+                 "student_id" => grade_11_student.id,
+                 "prompt_configuration_id" => prompt_configuration_id,
+                 "profile_state" => "missing",
+                 "profile_revision" => nil
+               }
+             ]
+           }
+
+    refute response |> inspect() =~ "BUSINESS-G"
+  end
+
+  test "accepts 100 records and rejects 101 records wholly", %{conn: conn} do
+    prompt_configuration_id = prompt_configuration_id(conn)
+    {user, _student} = eligible_student(11, "BOUNDARY")
+
+    records =
+      for index <- 1..100 do
+        record("record-#{index}", user.id, prompt_configuration_id, @grade_11_source)
+      end
+
+    assert %{"results" => results} =
+             conn
+             |> post("/api/holistic-mentorship/profile-preflight", %{"records" => records})
+             |> json_response(200)
+
+    assert length(results) == 100
+
+    assert conn
+           |> post("/api/holistic-mentorship/profile-preflight", %{
+             "records" => [hd(records) | records]
+           })
+           |> json_response(422) == %{
+             "error" => %{
+               "code" => "batch_too_large",
+               "message" => "Profile Preflight accepts at most 100 records"
+             }
+           }
+  end
+
+  test "rejects an empty or missing records batch safely", %{conn: conn} do
+    for params <- [%{"records" => []}, %{}] do
+      assert conn
+             |> post("/api/holistic-mentorship/profile-preflight", params)
+             |> json_response(422) == %{
+               "error" => %{
+                 "code" => "invalid_request",
+                 "message" => "Profile Preflight requires 1 through 100 records"
+               }
+             }
+    end
+  end
+
+  test "returns stable safe codes for source, identity, Form, and Prompt rejections", %{
+    conn: conn
+  } do
+    prompt_configuration_id = prompt_configuration_id(conn)
+    {eligible_user, _student} = eligible_student(11, "SAFE-CODES")
+    user_without_student = user_fixture()
+    {ambiguous_user, ambiguous_student} = eligible_student(11, "AMBIGUOUS")
+
+    {:ok, _duplicate_student} =
+      Dbservice.Users.create_student(%{
+        user_id: ambiguous_user.id,
+        grade_id: ambiguous_student.grade_id,
+        status: "active",
+        student_id: "AMBIGUOUS-SECOND"
+      })
+
+    baseline = record("baseline", eligible_user.id, prompt_configuration_id, @grade_11_source)
+
+    records = [
+      Map.merge(baseline, %{"record_ref" => "malformed", "source_user_id" => "not-an-id"}),
+      Map.merge(baseline, %{"record_ref" => "test", "source_record_type" => "test"}),
+      Map.merge(baseline, %{"record_ref" => "no-user", "source_user_id" => "2000000000"}),
+      Map.merge(baseline, %{
+        "record_ref" => "no-student",
+        "source_user_id" => Integer.to_string(user_without_student.id)
+      }),
+      Map.merge(baseline, %{
+        "record_ref" => "ambiguous",
+        "source_user_id" => Integer.to_string(ambiguous_user.id)
+      }),
+      Map.merge(baseline, %{"record_ref" => "bad-form", "form_id" => "unknown"}),
+      Map.merge(baseline, %{"record_ref" => "wrong-grade", "entry_grade" => 12}),
+      Map.merge(baseline, %{
+        "record_ref" => "no-prompt",
+        "prompt_configuration_id" => 2_000_000_000
+      }),
+      Map.merge(baseline, %{
+        "record_ref" => "bad-prompt-type",
+        "prompt_configuration_id" => "not-an-id"
+      })
+    ]
+
+    assert conn
+           |> post("/api/holistic-mentorship/profile-preflight", %{"records" => records})
+           |> json_response(200) == %{
+             "results" => [
+               rejected("malformed", "malformed_source_id"),
+               rejected("test", "test_record"),
+               rejected("no-user", "user_not_found"),
+               rejected("no-student", "student_not_found"),
+               rejected("ambiguous", "ambiguous_student"),
+               rejected("bad-form", "form_not_approved"),
+               rejected("wrong-grade", "form_grade_mismatch"),
+               rejected("no-prompt", "prompt_configuration_not_found"),
+               rejected("bad-prompt-type", "prompt_configuration_not_found")
+             ]
+           }
+  end
+
+  test "rejects out-of-scope, duplicate, and inconsistent current eligibility", %{conn: conn} do
+    prompt_configuration_id = prompt_configuration_id(conn)
+    {program_user, _student} = eligible_student(11, "NO-PROGRAM")
+    {school_program_user, _student} = eligible_student(11, "SCHOOL-NO-PROGRAM")
+    {school_user, _student} = eligible_student(11, "NO-SCHOOL")
+    {duplicate_school_user, _student} = eligible_student(11, "TWO-SCHOOLS")
+    {duplicate_program_user, _student} = eligible_student(11, "TWO-PROGRAMS")
+    {grade_10_user, _student} = eligible_student(10, "GRADE-10")
+    {missing_grade_user, _student} = eligible_student(11, "NO-GRADE")
+    {duplicate_grade_user, duplicate_grade_student} = eligible_student(11, "TWO-GRADES")
+    {mismatched_grade_user, _student} = eligible_student(11, "GRADE-MISMATCH")
+    {dropout_user, _student} = eligible_student(11, "DROPOUT")
+
+    Repo.query!(
+      "UPDATE enrollment_record SET group_id = 2 WHERE user_id = $1 AND group_type = 'program'",
+      [program_user.id]
+    )
+
+    Repo.query!(
+      """
+      UPDATE school SET program_ids = '{}'
+      FROM enrollment_record
+      WHERE enrollment_record.user_id = $1
+        AND enrollment_record.group_type = 'school'
+        AND school.id = enrollment_record.group_id
+      """,
+      [school_program_user.id]
+    )
+
+    Repo.query!(
+      "DELETE FROM enrollment_record WHERE user_id = $1 AND group_type = 'school'",
+      [school_user.id]
+    )
+
+    second_school = school_fixture(%{program_ids: [1], code: "second-school"})
+    enroll(duplicate_school_user.id, "school", second_school.id)
+    enroll(duplicate_program_user.id, "program", 1)
+
+    Repo.query!("DELETE FROM enrollment_record WHERE user_id = $1 AND group_type = 'grade'", [
+      missing_grade_user.id
+    ])
+
+    enroll(duplicate_grade_user.id, "grade", duplicate_grade_student.grade_id)
+
+    grade_12 = grade_fixture(%{number: 12})
+
+    Repo.query!(
+      "UPDATE enrollment_record SET group_id = $2 WHERE user_id = $1 AND group_type = 'grade'",
+      [mismatched_grade_user.id, grade_12.id]
+    )
+
+    Repo.query!("UPDATE student SET status = 'dropout' WHERE user_id = $1", [dropout_user.id])
+
+    records = [
+      preflight_record("program", program_user.id, prompt_configuration_id),
+      preflight_record("school-program", school_program_user.id, prompt_configuration_id),
+      preflight_record("school", school_user.id, prompt_configuration_id),
+      preflight_record("two-schools", duplicate_school_user.id, prompt_configuration_id),
+      preflight_record("two-programs", duplicate_program_user.id, prompt_configuration_id),
+      preflight_record("grade-10", grade_10_user.id, prompt_configuration_id),
+      preflight_record("no-grade", missing_grade_user.id, prompt_configuration_id),
+      preflight_record("two-grades", duplicate_grade_user.id, prompt_configuration_id),
+      preflight_record("grade-mismatch", mismatched_grade_user.id, prompt_configuration_id),
+      preflight_record("dropout", dropout_user.id, prompt_configuration_id)
+    ]
+
+    assert conn
+           |> post("/api/holistic-mentorship/profile-preflight", %{"records" => records})
+           |> json_response(200) == %{
+             "results" => [
+               rejected("program", "program_ineligible"),
+               rejected("school-program", "program_ineligible"),
+               rejected("school", "school_missing_or_ambiguous"),
+               rejected("two-schools", "school_missing_or_ambiguous"),
+               rejected("two-programs", "eligibility_inconsistent"),
+               rejected("grade-10", "grade_ineligible"),
+               rejected("no-grade", "grade_ineligible"),
+               rejected("two-grades", "eligibility_inconsistent"),
+               rejected("grade-mismatch", "eligibility_inconsistent"),
+               rejected("dropout", "dropout")
+             ]
+           }
+  end
+
+  test "does not expose source or canonical identifiers and Profile content in rejection logs", %{
+    conn: conn
+  } do
+    prompt_configuration_id = prompt_configuration_id(conn)
+    {user, student} = eligible_student(11, "SENSITIVE-BUSINESS-ID")
+    Repo.query!("UPDATE student SET status = 'dropout' WHERE id = $1", [student.id])
+
+    sensitive_answer = "sensitive-answer-fingerprint"
+
+    {conn, log} =
+      with_debug_log(fn ->
+        post(conn, "/api/holistic-mentorship/profile-preflight", %{
+          "records" => [
+            preflight_record("safe-ref", user.id, prompt_configuration_id)
+            |> Map.put("answer_fingerprint", sensitive_answer)
+          ]
+        })
+      end)
+
+    assert json_response(conn, 200) == %{
+             "results" => [rejected("safe-ref", "dropout")]
+           }
+
+    refute conn.resp_body =~ Integer.to_string(user.id)
+    refute conn.resp_body =~ Integer.to_string(student.id)
+    refute conn.resp_body =~ sensitive_answer
+    refute log =~ "\"source_user_id\" => \"#{user.id}\""
+    refute log =~ "\"student_id\" => #{student.id}"
+    refute log =~ sensitive_answer
+  end
+
+  defp eligible_student(grade_number, business_student_id) do
+    grade = grade_fixture(%{number: grade_number})
+
+    {user, student} =
+      student_fixture(%{
+        grade_id: grade.id,
+        status: "active",
+        student_id: business_student_id
+      })
+
+    school = school_fixture(%{program_ids: [1], code: "school-#{user.id}"})
+
+    enroll(user.id, "school", school.id)
+    enroll(user.id, "program", 1)
+    enroll(user.id, "grade", grade.id)
+
+    {user, student}
+  end
+
+  defp enroll(user_id, group_type, group_id) do
+    {:ok, _enrollment} =
+      Dbservice.EnrollmentRecords.create_enrollment_record(%{
+        user_id: user_id,
+        group_id: group_id,
+        group_type: group_type,
+        academic_year: "2026-27",
+        start_date: ~D[2026-06-01],
+        is_current: true
+      })
+  end
+
+  defp prompt_configuration_id(conn) do
+    response =
+      conn
+      |> post("/api/holistic-mentorship/prompt-configurations", %{
+        "prompt_version" => "profile-preflight-v1",
+        "template_text" => "abc",
+        "template_hash" => @template_hash,
+        "model_id" => "openai/gpt-5-mini"
+      })
+      |> json_response(200)
+
+    response["id"]
+  end
+
+  defp record(record_ref, user_id, prompt_configuration_id, source) do
+    Map.merge(source, %{
+      "answer_fingerprint" => "answer-fingerprint",
+      "prompt_configuration_id" => prompt_configuration_id,
+      "record_ref" => record_ref,
+      "source_record_type" => "production",
+      "source_user_id" => Integer.to_string(user_id)
+    })
+  end
+
+  defp preflight_record(record_ref, user_id, prompt_configuration_id) do
+    record(record_ref, user_id, prompt_configuration_id, @grade_11_source)
+  end
+
+  defp rejected(record_ref, reason_code) do
+    %{"record_ref" => record_ref, "reason_code" => reason_code}
+  end
+
+  defp with_debug_log(operation) do
+    previous_level = Logger.level()
+    Logger.configure(level: :debug)
+
+    try do
+      with_log([level: :debug], operation)
+    after
+      Logger.configure(level: previous_level)
+    end
+  end
+end

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller_test.exs
@@ -187,6 +187,39 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
     end
   end
 
+  test "rejects missing or oversized record references and answer fingerprints wholly", %{
+    conn: conn
+  } do
+    prompt_configuration_id = prompt_configuration_id(conn)
+    {user, _student} = eligible_student(11, "INVALID-ENVELOPE")
+
+    baseline = record("valid-ref", user.id, prompt_configuration_id, @grade_11_source)
+
+    invalid_records = [
+      Map.delete(baseline, "record_ref"),
+      Map.put(baseline, "record_ref", ""),
+      Map.put(baseline, "record_ref", 123),
+      Map.put(baseline, "record_ref", String.duplicate("r", 256)),
+      Map.delete(baseline, "answer_fingerprint"),
+      Map.put(baseline, "answer_fingerprint", ""),
+      Map.put(baseline, "answer_fingerprint", 123),
+      Map.put(baseline, "answer_fingerprint", String.duplicate("f", 256))
+    ]
+
+    for invalid_record <- invalid_records do
+      assert conn
+             |> post("/api/holistic-mentorship/profile-preflight", %{
+               "records" => [baseline, invalid_record]
+             })
+             |> json_response(422) == %{
+               "error" => %{
+                 "code" => "invalid_request",
+                 "message" => "Profile Preflight requires 1 through 100 records"
+               }
+             }
+    end
+  end
+
   test "returns stable safe codes for source, identity, Form, and Prompt rejections", %{
     conn: conn
   } do

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller_test.exs
@@ -59,6 +59,93 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
     refute response |> inspect() =~ "BUSINESS-G"
   end
 
+  test "keeps a Grade 11 journey after progression and rejects a conflicting Grade 12 source", %{
+    conn: conn
+  } do
+    prompt_configuration_id = prompt_configuration_id(conn)
+    {user, student} = eligible_student(11, "JOURNEY-G11")
+    insert_journey!(student.id, @grade_11_source)
+
+    grade_12 = grade_fixture(%{number: 12})
+    Repo.query!("UPDATE student SET grade_id = $2 WHERE id = $1", [student.id, grade_12.id])
+
+    Repo.query!(
+      "UPDATE enrollment_record SET group_id = $2 WHERE user_id = $1 AND group_type = 'grade'",
+      [user.id, grade_12.id]
+    )
+
+    response =
+      conn
+      |> post("/api/holistic-mentorship/profile-preflight", %{
+        "records" => [
+          record("original", user.id, prompt_configuration_id, @grade_11_source),
+          record("conflict", user.id, prompt_configuration_id, @grade_12_source)
+        ]
+      })
+      |> json_response(200)
+
+    assert response == %{
+             "results" => [
+               %{
+                 "record_ref" => "original",
+                 "student_id" => student.id,
+                 "prompt_configuration_id" => prompt_configuration_id,
+                 "profile_state" => "missing",
+                 "profile_revision" => nil
+               },
+               rejected("conflict", "journey_source_conflict")
+             ]
+           }
+  end
+
+  test "reports configuration-specific Profile state and revision from the answer fingerprint", %{
+    conn: conn
+  } do
+    first_configuration_id = prompt_configuration_id(conn)
+    second_configuration_id = prompt_configuration_id(conn, "google/gemini-2.5-flash")
+    {user, student} = eligible_student(11, "PROFILE-STATE")
+    journey_id = insert_journey!(student.id, @grade_11_source)
+    insert_profile!(journey_id, first_configuration_id, "answers-v1", 7)
+
+    baseline = record("unchanged", user.id, first_configuration_id, @grade_11_source)
+
+    records = [
+      Map.put(baseline, "answer_fingerprint", "answers-v1"),
+      baseline
+      |> Map.put("record_ref", "changed")
+      |> Map.put("answer_fingerprint", "answers-v2"),
+      record("other-configuration", user.id, second_configuration_id, @grade_11_source)
+    ]
+
+    assert conn
+           |> post("/api/holistic-mentorship/profile-preflight", %{"records" => records})
+           |> json_response(200) == %{
+             "results" => [
+               %{
+                 "record_ref" => "unchanged",
+                 "student_id" => student.id,
+                 "prompt_configuration_id" => first_configuration_id,
+                 "profile_state" => "unchanged",
+                 "profile_revision" => 7
+               },
+               %{
+                 "record_ref" => "changed",
+                 "student_id" => student.id,
+                 "prompt_configuration_id" => first_configuration_id,
+                 "profile_state" => "changed_answers",
+                 "profile_revision" => 7
+               },
+               %{
+                 "record_ref" => "other-configuration",
+                 "student_id" => student.id,
+                 "prompt_configuration_id" => second_configuration_id,
+                 "profile_state" => "missing",
+                 "profile_revision" => nil
+               }
+             ]
+           }
+  end
+
   test "accepts 100 records and rejects 101 records wholly", %{conn: conn} do
     prompt_configuration_id = prompt_configuration_id(conn)
     {user, _student} = eligible_student(11, "BOUNDARY")
@@ -305,14 +392,14 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
       })
   end
 
-  defp prompt_configuration_id(conn) do
+  defp prompt_configuration_id(conn, model_id \\ "openai/gpt-5-mini") do
     response =
       conn
       |> post("/api/holistic-mentorship/prompt-configurations", %{
         "prompt_version" => "profile-preflight-v1",
         "template_text" => "abc",
         "template_hash" => @template_hash,
-        "model_id" => "openai/gpt-5-mini"
+        "model_id" => model_id
       })
       |> json_response(200)
 
@@ -335,6 +422,48 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
 
   defp rejected(record_ref, reason_code) do
     %{"record_ref" => record_ref, "reason_code" => reason_code}
+  end
+
+  defp insert_journey!(student_id, source) do
+    [[journey_id]] =
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_profile_journeys
+          (student_id, form_id, af_session_id, entry_grade)
+        VALUES ($1, $2, $3, $4)
+        RETURNING id
+        """,
+        [student_id, source["form_id"], source["af_session_id"], source["entry_grade"]]
+      ).rows
+
+    journey_id
+  end
+
+  defp insert_profile!(journey_id, configuration_id, answer_fingerprint, revision) do
+    [[profile_id]] =
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_student_profiles
+          (profile_journey_id, prompt_configuration_id, schema_fingerprint,
+           answer_fingerprint, warehouse_loaded_at, generated_at, revision,
+           last_successful_etl_run_id)
+        VALUES ($1, $2, 'schema-v1', $3, '2026-07-16 10:00:00',
+                '2026-07-16 10:05:00', $4, 'etl-run-1')
+        RETURNING id
+        """,
+        [journey_id, configuration_id, answer_fingerprint, revision]
+      ).rows
+
+    for position <- 1..5 do
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_student_profile_summaries
+          (student_profile_id, position, question_set_title, summary)
+        VALUES ($1, $2, $3, $4)
+        """,
+        [profile_id, position, "Question Set #{position}", "Summary #{position}"]
+      )
+    end
   end
 
   defp with_debug_log(operation) do

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_publish_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_publish_controller_test.exs
@@ -199,6 +199,64 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePublishControllerTest do
            """).rows == [["rollback-child", "running"], ["rollback-stale", "running"]]
   end
 
+  test "concurrent workers allow one replacement and reject the stale writer", %{conn: conn} do
+    authorization = conn |> get_req_header("authorization") |> List.first()
+
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "concurrent-base")
+
+    publish(
+      build_conn(authorization),
+      publish_params(user.id, student.id, configuration_id, "concurrent-base")
+    )
+
+    for run_id <- ["concurrent-a", "concurrent-b"] do
+      insert_running_status!(student.id, configuration_id, run_id)
+    end
+
+    parent = self()
+
+    tasks =
+      for {run_id, fingerprint} <- [
+            {"concurrent-a", "answers-a"},
+            {"concurrent-b", "answers-b"}
+          ] do
+        Task.async(fn ->
+          send(parent, {:ready, self()})
+
+          receive do
+            :go ->
+              response =
+                build_conn(authorization)
+                |> post(
+                  "/api/holistic-mentorship/profiles/publish",
+                  publish_params(user.id, student.id, configuration_id, run_id, %{
+                    "answer_fingerprint" => fingerprint,
+                    "expected_profile_revision" => 1
+                  })
+                )
+
+              {response.status, Jason.decode!(response.resp_body)}
+          end
+        end)
+      end
+
+    task_pids =
+      for _ <- tasks do
+        assert_receive {:ready, task_pid}
+        task_pid
+      end
+
+    Enum.each(task_pids, &send(&1, :go))
+    results = Enum.map(tasks, &Task.await/1)
+
+    assert Enum.sort(Enum.map(results, &elem(&1, 0))) == [200, 409]
+    assert Enum.any?(results, fn {_, body} -> body["result"] == "replaced" end)
+
+    assert Repo.query!("SELECT revision FROM holistic_mentorship_student_profiles").rows == [[2]]
+  end
+
   test "revalidates eligibility at publication time", %{conn: conn} do
     {user, student} = eligible_student()
     configuration_id = insert_prompt_configuration!()
@@ -378,6 +436,11 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePublishControllerTest do
         "summary" => "#{prefix} #{position}"
       }
     end
+  end
+
+  defp build_conn(authorization) do
+    Phoenix.ConnTest.build_conn()
+    |> put_req_header("authorization", authorization)
   end
 
   defp with_debug_log(operation) do

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_publish_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_publish_controller_test.exs
@@ -909,7 +909,6 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePublishControllerTest do
     school = school_fixture(%{program_ids: [1], code: "publish-school-#{user.id}"})
 
     enroll(user.id, "school", school.id)
-    enroll(user.id, "program", 1)
     enroll(user.id, "grade", grade.id)
     {user, student}
   end

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_publish_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_publish_controller_test.exs
@@ -109,6 +109,34 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePublishControllerTest do
            """).rows == [[1, "unchanged-run-1", "Fixed summary 1", "unchanged"]]
   end
 
+  test "rejects normal publication for a privacy-deleted Student", %{conn: conn} do
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "privacy-normal-run")
+    insert_privacy_deletion!(student.id, user_fixture().id)
+
+    assert conn
+           |> post(
+             "/api/holistic-mentorship/profiles/publish",
+             publish_params(user.id, student.id, configuration_id, "privacy-normal-run")
+           )
+           |> json_response(422) == %{
+             "error" => %{
+               "code" => "privacy_erased",
+               "message" => "Profile publication is not eligible"
+             }
+           }
+
+    assert Repo.query!(
+             "SELECT count(*) FROM holistic_mentorship_profile_journeys WHERE student_id = $1",
+             [student.id]
+           ).rows == [[0]]
+
+    assert Repo.query!(
+             "SELECT state FROM holistic_mentorship_profile_generation_statuses WHERE etl_run_id = 'privacy-normal-run'"
+           ).rows == [["running"]]
+  end
+
   test "an authorized force request replaces unchanged answers and completes atomically", %{
     conn: conn
   } do
@@ -177,6 +205,43 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePublishControllerTest do
              """,
              [other_configuration_id]
            ).rows == [[1, "force-other-configuration"]]
+  end
+
+  test "rejects force publication without restoring erased summaries", %{conn: conn} do
+    {user, student} = eligible_student()
+    actor = user_fixture()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "privacy-force-base")
+    publish(conn, publish_params(user.id, student.id, configuration_id, "privacy-force-base"))
+
+    Repo.query!(
+      "UPDATE holistic_mentorship_student_profile_summaries SET summary = 'Content erased under approved privacy request'"
+    )
+
+    insert_privacy_deletion!(student.id, actor.id)
+    insert_running_status!(student.id, configuration_id, "privacy-force-run")
+    insert_regeneration_request!("privacy-force-request", actor.id, student.id, configuration_id)
+
+    params =
+      publish_params(user.id, student.id, configuration_id, "privacy-force-run", %{
+        "expected_profile_revision" => 1,
+        "force" => true,
+        "regeneration_request_key" => "privacy-force-request",
+        "summaries" => summaries("Must not return")
+      })
+
+    assert conn
+           |> post("/api/holistic-mentorship/profiles/publish", params)
+           |> json_response(422)
+           |> get_in(["error", "code"]) == "privacy_erased"
+
+    assert Repo.query!(
+             "SELECT DISTINCT summary FROM holistic_mentorship_student_profile_summaries"
+           ).rows == [["Content erased under approved privacy request"]]
+
+    assert Repo.query!(
+             "SELECT state FROM holistic_mentorship_regeneration_requests WHERE request_key = 'privacy-force-request'"
+           ).rows == [["queued"]]
   end
 
   test "a running request authorizes force publication for its ETL run", %{conn: conn} do
@@ -977,6 +1042,18 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePublishControllerTest do
       VALUES ($1, $2, $3, $4, $5, 'queued')
       """,
       [request_key, actor_id, student_id, configuration_id, force]
+    )
+  end
+
+  defp insert_privacy_deletion!(student_id, actor_user_id) do
+    Repo.query!(
+      """
+      INSERT INTO holistic_mentorship_privacy_deletions
+        (student_id, actor_user_id, reason, profile_summaries_erased,
+         post_session_answers_erased, historical_answers_erased, occurred_at)
+      VALUES ($1, $2, 'approved-request', 0, 0, 0, now())
+      """,
+      [student_id, actor_user_id]
     )
   end
 

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_publish_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_publish_controller_test.exs
@@ -126,7 +126,7 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePublishControllerTest do
       })
 
     assert publish(conn, new_params) == %{"result" => "replaced", "revision" => 2}
-    assert publish(conn, old_params) == %{"result" => "published", "revision" => 2}
+    assert publish(conn, old_params) == %{"result" => "published", "revision" => 1}
 
     assert Repo.query!("""
            SELECT profile.answer_fingerprint, profile.revision, min(summary.summary)
@@ -197,6 +197,31 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePublishControllerTest do
            SELECT etl_run_id, state FROM holistic_mentorship_profile_generation_statuses
            WHERE etl_run_id IN ('rollback-stale', 'rollback-child') ORDER BY etl_run_id
            """).rows == [["rollback-child", "running"], ["rollback-stale", "running"]]
+  end
+
+  test "rejects a malformed source User ID safely", %{conn: conn} do
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "malformed-source")
+
+    assert conn
+           |> post(
+             "/api/holistic-mentorship/profiles/publish",
+             publish_params(user.id, student.id, configuration_id, "malformed-source", %{
+               "source_user_id" => user.id
+             })
+           )
+           |> json_response(422) == %{
+             "error" => %{
+               "code" => "invalid_request",
+               "message" => "Profile publication request is invalid"
+             }
+           }
+
+    assert Repo.query!("""
+           SELECT state FROM holistic_mentorship_profile_generation_statuses
+           WHERE etl_run_id = 'malformed-source'
+           """).rows == [["running"]]
   end
 
   test "concurrent workers allow one replacement and reject the stale writer", %{conn: conn} do

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_publish_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_publish_controller_test.exs
@@ -708,6 +708,61 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePublishControllerTest do
            """).rows == [[1, "Fixed summary 1", "running", "queued"]]
   end
 
+  test "a transient database failure returns 503 and rolls back publication", %{conn: conn} do
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "transient-base")
+    publish(conn, publish_params(user.id, student.id, configuration_id, "transient-base"))
+
+    insert_running_status!(student.id, configuration_id, "transient-replacement")
+
+    Repo.query!("""
+    CREATE FUNCTION pg_temp.raise_test_serialization_failure() RETURNS trigger AS $$
+    BEGIN
+      IF NEW.summary = 'Transient 1' THEN
+        RAISE EXCEPTION 'forced serialization failure' USING ERRCODE = '40001';
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+    """)
+
+    Repo.query!("""
+    CREATE TRIGGER raise_test_serialization_failure
+    BEFORE INSERT ON holistic_mentorship_student_profile_summaries
+    FOR EACH ROW EXECUTE FUNCTION pg_temp.raise_test_serialization_failure()
+    """)
+
+    params =
+      publish_params(user.id, student.id, configuration_id, "transient-replacement", %{
+        "answer_fingerprint" => "transient-answers",
+        "expected_profile_revision" => 1,
+        "summaries" => summaries("Transient")
+      })
+
+    assert conn
+           |> post("/api/holistic-mentorship/profiles/publish", params)
+           |> json_response(503) == %{
+             "error" => %{
+               "code" => "database_temporarily_unavailable",
+               "message" => "Profile publication is temporarily unavailable"
+             }
+           }
+
+    assert Repo.query!("""
+           SELECT profile.revision, profile.answer_fingerprint, min(summary.summary)
+           FROM holistic_mentorship_student_profiles AS profile
+           JOIN holistic_mentorship_student_profile_summaries AS summary
+             ON summary.student_profile_id = profile.id
+           GROUP BY profile.id
+           """).rows == [[1, "answers-v1", "Fixed summary 1"]]
+
+    assert Repo.query!("""
+           SELECT state FROM holistic_mentorship_profile_generation_statuses
+           WHERE etl_run_id = 'transient-replacement'
+           """).rows == [["running"]]
+  end
+
   test "repeating a completed run cannot replay older output", %{conn: conn} do
     {user, student} = eligible_student()
     configuration_id = insert_prompt_configuration!()
@@ -826,59 +881,71 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePublishControllerTest do
   test "concurrent workers allow one replacement and reject the stale writer", %{conn: conn} do
     authorization = conn |> get_req_header("authorization") |> List.first()
 
-    {user, student} = eligible_student()
-    configuration_id = insert_prompt_configuration!()
-    insert_running_status!(student.id, configuration_id, "concurrent-base")
+    Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+      {user, student} = eligible_student()
+      school_id = current_school_id!(user.id)
+      configuration_id = insert_prompt_configuration!()
 
-    publish(
-      build_conn(authorization),
-      publish_params(user.id, student.id, configuration_id, "concurrent-base")
-    )
+      try do
+        insert_running_status!(student.id, configuration_id, "concurrent-base")
 
-    for run_id <- ["concurrent-a", "concurrent-b"] do
-      insert_running_status!(student.id, configuration_id, run_id)
-    end
+        publish(
+          build_conn(authorization),
+          publish_params(user.id, student.id, configuration_id, "concurrent-base")
+        )
 
-    parent = self()
+        for run_id <- ["concurrent-a", "concurrent-b"] do
+          insert_running_status!(student.id, configuration_id, run_id)
+        end
 
-    tasks =
-      for {run_id, fingerprint} <- [
-            {"concurrent-a", "answers-a"},
-            {"concurrent-b", "answers-b"}
-          ] do
-        Task.async(fn ->
-          send(parent, {:ready, self()})
+        parent = self()
 
-          receive do
-            :go ->
-              response =
-                build_conn(authorization)
-                |> post(
-                  "/api/holistic-mentorship/profiles/publish",
-                  publish_params(user.id, student.id, configuration_id, run_id, %{
-                    "answer_fingerprint" => fingerprint,
-                    "expected_profile_revision" => 1
-                  })
-                )
+        tasks =
+          for {run_id, fingerprint} <- [
+                {"concurrent-a", "answers-a"},
+                {"concurrent-b", "answers-b"}
+              ] do
+            Task.async(fn ->
+              Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+                send(parent, {:ready, self()})
 
-              {response.status, Jason.decode!(response.resp_body)}
+                receive do
+                  :go ->
+                    response =
+                      build_conn(authorization)
+                      |> post(
+                        "/api/holistic-mentorship/profiles/publish",
+                        publish_params(user.id, student.id, configuration_id, run_id, %{
+                          "answer_fingerprint" => fingerprint,
+                          "expected_profile_revision" => 1
+                        })
+                      )
+
+                    {response.status, Jason.decode!(response.resp_body)}
+                end
+              end)
+            end)
           end
-        end)
+
+        task_pids =
+          for _ <- tasks do
+            assert_receive {:ready, task_pid}
+            task_pid
+          end
+
+        Enum.each(task_pids, &send(&1, :go))
+        results = Enum.map(tasks, &Task.await/1)
+
+        assert Enum.sort(Enum.map(results, &elem(&1, 0))) == [200, 409]
+        assert Enum.any?(results, fn {_, body} -> body["result"] == "replaced" end)
+
+        assert Repo.query!("SELECT revision FROM holistic_mentorship_student_profiles").rows == [
+                 [2]
+               ]
+      after
+        cleanup_unboxed_profile_scope!(user.id, student.id, student.grade_id, school_id)
       end
-
-    task_pids =
-      for _ <- tasks do
-        assert_receive {:ready, task_pid}
-        task_pid
-      end
-
-    Enum.each(task_pids, &send(&1, :go))
-    results = Enum.map(tasks, &Task.await/1)
-
-    assert Enum.sort(Enum.map(results, &elem(&1, 0))) == [200, 409]
-    assert Enum.any?(results, fn {_, body} -> body["result"] == "replaced" end)
-
-    assert Repo.query!("SELECT revision FROM holistic_mentorship_student_profiles").rows == [[2]]
+    end)
   end
 
   test "revalidates eligibility at publication time", %{conn: conn} do
@@ -1093,6 +1160,41 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePublishControllerTest do
   defp build_conn(authorization) do
     Phoenix.ConnTest.build_conn()
     |> put_req_header("authorization", authorization)
+  end
+
+  defp current_school_id!(user_id) do
+    [[school_id]] =
+      Repo.query!(
+        "SELECT group_id FROM enrollment_record WHERE user_id = $1 AND group_type = 'school' AND is_current",
+        [user_id]
+      ).rows
+
+    school_id
+  end
+
+  defp cleanup_unboxed_profile_scope!(user_id, student_id, grade_id, school_id) do
+    Repo.query!("""
+    TRUNCATE holistic_mentorship_regeneration_requests,
+             holistic_mentorship_profile_generation_statuses,
+             holistic_mentorship_student_profile_summaries,
+             holistic_mentorship_student_profiles,
+             holistic_mentorship_profile_journeys,
+             holistic_mentorship_prompt_configurations,
+             holistic_mentorship_prompt_versions
+    RESTART IDENTITY
+    """)
+
+    Repo.query!("DELETE FROM enrollment_record WHERE user_id = $1", [user_id])
+    Repo.query!("DELETE FROM student WHERE id = $1", [student_id])
+
+    Repo.query!(
+      "DELETE FROM \"group\" WHERE (type = 'grade' AND child_id = $1) OR (type = 'school' AND child_id = $2)",
+      [grade_id, school_id]
+    )
+
+    Repo.query!("DELETE FROM grade WHERE id = $1", [grade_id])
+    Repo.query!("DELETE FROM school WHERE id = $1", [school_id])
+    Repo.query!("DELETE FROM \"user\" WHERE id = $1", [user_id])
   end
 
   defp with_debug_log(operation) do

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_publish_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_publish_controller_test.exs
@@ -109,6 +109,498 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePublishControllerTest do
            """).rows == [[1, "unchanged-run-1", "Fixed summary 1", "unchanged"]]
   end
 
+  test "an authorized force request replaces unchanged answers and completes atomically", %{
+    conn: conn
+  } do
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "force-base")
+    publish(conn, publish_params(user.id, student.id, configuration_id, "force-base"))
+
+    other_configuration_id = insert_prompt_configuration!("openai/gpt-5")
+    insert_running_status!(student.id, other_configuration_id, "force-other-configuration")
+
+    publish(
+      conn,
+      publish_params(user.id, student.id, other_configuration_id, "force-other-configuration")
+    )
+
+    insert_running_status!(student.id, configuration_id, "force-run")
+    insert_regeneration_request!("force-request", user.id, student.id, configuration_id)
+
+    params =
+      publish_params(user.id, student.id, configuration_id, "force-run", %{
+        "expected_profile_revision" => 1,
+        "force" => true,
+        "regeneration_request_key" => "force-request",
+        "summaries" => summaries("Forced")
+      })
+
+    assert publish(conn, params) == %{"result" => "replaced", "revision" => 2}
+
+    assert Repo.query!(
+             """
+             SELECT profile.revision, profile.answer_fingerprint, min(summary.summary),
+                    status.state, status.completed_outcome, request.state, request.etl_run_id,
+                    request.requested_by_user_id
+             FROM holistic_mentorship_student_profiles AS profile
+             JOIN holistic_mentorship_student_profile_summaries AS summary
+               ON summary.student_profile_id = profile.id
+             JOIN holistic_mentorship_profile_generation_statuses AS status
+               ON status.etl_run_id = 'force-run'
+             JOIN holistic_mentorship_regeneration_requests AS request
+               ON request.request_key = 'force-request'
+             WHERE profile.prompt_configuration_id = $1
+             GROUP BY profile.id, status.state, status.completed_outcome, request.state,
+                      request.etl_run_id, request.requested_by_user_id
+             """,
+             [configuration_id]
+           ).rows ==
+             [
+               [
+                 2,
+                 "answers-v1",
+                 "Forced 1",
+                 "completed",
+                 "replaced",
+                 "completed",
+                 "force-run",
+                 user.id
+               ]
+             ]
+
+    assert Repo.query!(
+             """
+             SELECT revision, last_successful_etl_run_id
+             FROM holistic_mentorship_student_profiles
+             WHERE prompt_configuration_id = $1
+             """,
+             [other_configuration_id]
+           ).rows == [[1, "force-other-configuration"]]
+  end
+
+  test "a running request authorizes force publication for its ETL run", %{conn: conn} do
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "running-force-base")
+    publish(conn, publish_params(user.id, student.id, configuration_id, "running-force-base"))
+
+    insert_running_status!(student.id, configuration_id, "running-force-run")
+    insert_regeneration_request!("running-force-request", user.id, student.id, configuration_id)
+
+    Repo.query!("""
+    UPDATE holistic_mentorship_regeneration_requests
+    SET state = 'running', etl_run_id = 'running-force-run'
+    WHERE request_key = 'running-force-request'
+    """)
+
+    params =
+      publish_params(user.id, student.id, configuration_id, "running-force-run", %{
+        "expected_profile_revision" => 1,
+        "force" => true,
+        "regeneration_request_key" => "running-force-request"
+      })
+
+    assert publish(conn, params) == %{"result" => "replaced", "revision" => 2}
+
+    assert Repo.query!("""
+           SELECT state, etl_run_id FROM holistic_mentorship_regeneration_requests
+           WHERE request_key = 'running-force-request'
+           """).rows == [["completed", "running-force-run"]]
+  end
+
+  test "repeating a completed force publication returns its prior result", %{conn: conn} do
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "force-repeat-base")
+
+    publish(
+      conn,
+      publish_params(user.id, student.id, configuration_id, "force-repeat-base")
+    )
+
+    insert_running_status!(student.id, configuration_id, "force-repeat")
+    insert_regeneration_request!("force-repeat-request", user.id, student.id, configuration_id)
+
+    params =
+      publish_params(user.id, student.id, configuration_id, "force-repeat", %{
+        "expected_profile_revision" => 1,
+        "force" => true,
+        "regeneration_request_key" => "force-repeat-request",
+        "summaries" => summaries("Repeated force")
+      })
+
+    assert publish(conn, params) == %{"result" => "replaced", "revision" => 2}
+    assert publish(conn, params) == %{"result" => "replaced", "revision" => 2}
+
+    assert Repo.query!("""
+           SELECT profile.revision, count(summary.id), request.state, request.etl_run_id
+           FROM holistic_mentorship_student_profiles AS profile
+           JOIN holistic_mentorship_student_profile_summaries AS summary
+             ON summary.student_profile_id = profile.id
+           JOIN holistic_mentorship_regeneration_requests AS request
+             ON request.request_key = 'force-repeat-request'
+           GROUP BY profile.id, request.state, request.etl_run_id
+           """).rows == [[2, 5, "completed", "force-repeat"]]
+  end
+
+  test "a terminal force request cannot authorize new publication work", %{conn: conn} do
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "terminal-force-base")
+
+    publish(
+      conn,
+      publish_params(user.id, student.id, configuration_id, "terminal-force-base")
+    )
+
+    insert_running_status!(student.id, configuration_id, "terminal-force-run")
+    insert_regeneration_request!("terminal-force-request", user.id, student.id, configuration_id)
+
+    Repo.query!("""
+    UPDATE holistic_mentorship_regeneration_requests
+    SET state = 'completed', etl_run_id = 'terminal-force-run'
+    WHERE request_key = 'terminal-force-request'
+    """)
+
+    params =
+      publish_params(user.id, student.id, configuration_id, "terminal-force-run", %{
+        "expected_profile_revision" => 1,
+        "force" => true,
+        "regeneration_request_key" => "terminal-force-request"
+      })
+
+    assert conn
+           |> post("/api/holistic-mentorship/profiles/publish", params)
+           |> json_response(422) == %{
+             "error" => %{
+               "code" => "invalid_request",
+               "message" => "Profile publication request is invalid"
+             }
+           }
+
+    assert Repo.query!("SELECT revision FROM holistic_mentorship_student_profiles").rows == [[1]]
+
+    assert Repo.query!("""
+           SELECT state FROM holistic_mentorship_profile_generation_statuses
+           WHERE etl_run_id = 'terminal-force-run'
+           """).rows == [["running"]]
+  end
+
+  test "force publication rejects missing, mismatched, non-force, and failed requests", %{
+    conn: conn
+  } do
+    {user, student} = eligible_student()
+    {_other_user, other_student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    other_configuration_id = insert_prompt_configuration!("openai/gpt-5")
+    insert_running_status!(student.id, configuration_id, "force-invalid-base")
+
+    publish(
+      conn,
+      publish_params(user.id, student.id, configuration_id, "force-invalid-base")
+    )
+
+    insert_regeneration_request!(
+      "force-wrong-student",
+      user.id,
+      other_student.id,
+      configuration_id
+    )
+
+    insert_regeneration_request!(
+      "force-wrong-configuration",
+      user.id,
+      student.id,
+      other_configuration_id
+    )
+
+    insert_regeneration_request!("force-disabled", user.id, student.id, configuration_id, false)
+    insert_regeneration_request!("force-failed", user.id, student.id, configuration_id)
+    insert_regeneration_request!("force-wrong-run", user.id, student.id, configuration_id)
+
+    Repo.query!("""
+    UPDATE holistic_mentorship_regeneration_requests
+    SET state = 'failed', etl_run_id = 'failed-run'
+    WHERE request_key = 'force-failed'
+    """)
+
+    Repo.query!("""
+    UPDATE holistic_mentorship_regeneration_requests
+    SET state = 'running', etl_run_id = 'different-run'
+    WHERE request_key = 'force-wrong-run'
+    """)
+
+    cases = [
+      {"force-missing", nil},
+      {"force-unknown", "unknown-request"},
+      {"force-student-mismatch", "force-wrong-student"},
+      {"force-configuration-mismatch", "force-wrong-configuration"},
+      {"force-disabled-run", "force-disabled"},
+      {"force-failed-run", "force-failed"},
+      {"force-etl-run-mismatch", "force-wrong-run"}
+    ]
+
+    for {run_id, request_key} <- cases do
+      insert_running_status!(student.id, configuration_id, run_id)
+
+      params =
+        publish_params(user.id, student.id, configuration_id, run_id, %{
+          "expected_profile_revision" => 1,
+          "force" => true
+        })
+        |> then(fn params ->
+          if request_key,
+            do: Map.put(params, "regeneration_request_key", request_key),
+            else: params
+        end)
+
+      assert conn
+             |> recycle()
+             |> post("/api/holistic-mentorship/profiles/publish", params)
+             |> json_response(422) == %{
+               "error" => %{
+                 "code" => "invalid_request",
+                 "message" => "Profile publication request is invalid"
+               }
+             }
+    end
+
+    assert Repo.query!("SELECT revision FROM holistic_mentorship_student_profiles").rows == [[1]]
+
+    assert Repo.query!("""
+           SELECT count(*) FROM holistic_mentorship_profile_generation_statuses
+           WHERE etl_run_id LIKE 'force-%' AND state = 'running'
+           """).rows == [[7]]
+  end
+
+  test "validation, stale, and child failures preserve Profile, status, and force request", %{
+    conn: conn
+  } do
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "force-rollback-base")
+
+    publish(
+      conn,
+      publish_params(user.id, student.id, configuration_id, "force-rollback-base")
+    )
+
+    for {run_id, request_key} <- [
+          {"force-rollback-validation", "force-validation-request"},
+          {"force-rollback-stale", "force-stale-request"},
+          {"force-rollback-child", "force-child-request"}
+        ] do
+      insert_running_status!(student.id, configuration_id, run_id)
+      insert_regeneration_request!(request_key, user.id, student.id, configuration_id)
+    end
+
+    validation =
+      publish_params(user.id, student.id, configuration_id, "force-rollback-validation", %{
+        "expected_profile_revision" => 1,
+        "force" => true,
+        "regeneration_request_key" => "force-validation-request"
+      })
+
+    Repo.query!("UPDATE student SET status = 'dropout' WHERE id = $1", [student.id])
+
+    assert conn
+           |> post("/api/holistic-mentorship/profiles/publish", validation)
+           |> json_response(422) == %{
+             "error" => %{
+               "code" => "dropout",
+               "message" => "Profile publication is not eligible"
+             }
+           }
+
+    Repo.query!("UPDATE student SET status = 'active' WHERE id = $1", [student.id])
+
+    stale =
+      publish_params(user.id, student.id, configuration_id, "force-rollback-stale", %{
+        "expected_profile_revision" => 2,
+        "force" => true,
+        "regeneration_request_key" => "force-stale-request"
+      })
+
+    assert conn
+           |> post("/api/holistic-mentorship/profiles/publish", stale)
+           |> json_response(409) == %{
+             "error" => %{
+               "code" => "stale_profile_revision",
+               "message" => "Profile revision is stale"
+             }
+           }
+
+    invalid_child =
+      publish_params(user.id, student.id, configuration_id, "force-rollback-child", %{
+        "expected_profile_revision" => 1,
+        "force" => true,
+        "regeneration_request_key" => "force-child-request",
+        "summaries" => [
+          %{
+            "position" => 1,
+            "question_set_title" => String.duplicate("x", 256),
+            "summary" => "invalid child"
+          }
+          | Enum.drop(summaries("Replacement"), 1)
+        ]
+      })
+
+    assert conn
+           |> recycle()
+           |> post("/api/holistic-mentorship/profiles/publish", invalid_child)
+           |> json_response(422) == %{
+             "error" => %{
+               "code" => "invalid_request",
+               "message" => "Profile publication request is invalid"
+             }
+           }
+
+    assert Repo.query!("""
+           SELECT profile.revision, min(summary.summary)
+           FROM holistic_mentorship_student_profiles AS profile
+           JOIN holistic_mentorship_student_profile_summaries AS summary
+             ON summary.student_profile_id = profile.id
+           GROUP BY profile.id
+           """).rows == [[1, "Fixed summary 1"]]
+
+    assert Repo.query!("""
+           SELECT state FROM holistic_mentorship_profile_generation_statuses
+           WHERE etl_run_id IN (
+             'force-rollback-validation', 'force-rollback-stale', 'force-rollback-child'
+           )
+           ORDER BY etl_run_id
+           """).rows == [["running"], ["running"], ["running"]]
+
+    assert Repo.query!("""
+           SELECT state FROM holistic_mentorship_regeneration_requests
+           WHERE request_key IN (
+             'force-validation-request', 'force-stale-request', 'force-child-request'
+           )
+           ORDER BY request_key
+           """).rows == [["queued"], ["queued"], ["queued"]]
+  end
+
+  test "a request transition failure preserves the prior successful Profile", %{conn: conn} do
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "transition-base")
+    publish(conn, publish_params(user.id, student.id, configuration_id, "transition-base"))
+
+    insert_running_status!(student.id, configuration_id, "transition-failure")
+
+    insert_regeneration_request!(
+      "failing-request-transition",
+      user.id,
+      student.id,
+      configuration_id
+    )
+
+    Repo.query!("""
+    CREATE FUNCTION reject_test_regeneration_completion() RETURNS trigger AS $$
+    BEGIN
+      IF OLD.request_key = 'failing-request-transition' AND NEW.state = 'completed' THEN
+        RETURN NULL;
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+    """)
+
+    Repo.query!("""
+    CREATE TRIGGER reject_test_regeneration_completion
+    BEFORE UPDATE ON holistic_mentorship_regeneration_requests
+    FOR EACH ROW EXECUTE FUNCTION reject_test_regeneration_completion()
+    """)
+
+    params =
+      publish_params(user.id, student.id, configuration_id, "transition-failure", %{
+        "expected_profile_revision" => 1,
+        "force" => true,
+        "regeneration_request_key" => "failing-request-transition",
+        "summaries" => summaries("Must roll back")
+      })
+
+    assert conn
+           |> post("/api/holistic-mentorship/profiles/publish", params)
+           |> json_response(422) == %{
+             "error" => %{
+               "code" => "invalid_request",
+               "message" => "Profile publication request is invalid"
+             }
+           }
+
+    assert Repo.query!("""
+           SELECT profile.revision, min(summary.summary), status.state, request.state
+           FROM holistic_mentorship_student_profiles AS profile
+           JOIN holistic_mentorship_student_profile_summaries AS summary
+             ON summary.student_profile_id = profile.id
+           JOIN holistic_mentorship_profile_generation_statuses AS status
+             ON status.etl_run_id = 'transition-failure'
+           JOIN holistic_mentorship_regeneration_requests AS request
+             ON request.request_key = 'failing-request-transition'
+           GROUP BY profile.id, status.state, request.state
+           """).rows == [[1, "Fixed summary 1", "running", "queued"]]
+  end
+
+  test "a generation status completion failure preserves the prior successful Profile", %{
+    conn: conn
+  } do
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "status-base")
+    publish(conn, publish_params(user.id, student.id, configuration_id, "status-base"))
+
+    insert_running_status!(student.id, configuration_id, "status-failure")
+    insert_regeneration_request!("status-failure-request", user.id, student.id, configuration_id)
+
+    Repo.query!("""
+    CREATE FUNCTION reject_test_status_completion() RETURNS trigger AS $$
+    BEGIN
+      IF OLD.etl_run_id = 'status-failure' AND NEW.state = 'completed' THEN
+        RETURN NULL;
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+    """)
+
+    Repo.query!("""
+    CREATE TRIGGER reject_test_status_completion
+    BEFORE UPDATE ON holistic_mentorship_profile_generation_statuses
+    FOR EACH ROW EXECUTE FUNCTION reject_test_status_completion()
+    """)
+
+    params =
+      publish_params(user.id, student.id, configuration_id, "status-failure", %{
+        "expected_profile_revision" => 1,
+        "force" => true,
+        "regeneration_request_key" => "status-failure-request",
+        "summaries" => summaries("Must roll back")
+      })
+
+    assert conn
+           |> post("/api/holistic-mentorship/profiles/publish", params)
+           |> json_response(422) == %{
+             "error" => %{
+               "code" => "invalid_request",
+               "message" => "Profile publication request is invalid"
+             }
+           }
+
+    assert Repo.query!("""
+           SELECT profile.revision, min(summary.summary), status.state, request.state
+           FROM holistic_mentorship_student_profiles AS profile
+           JOIN holistic_mentorship_student_profile_summaries AS summary
+             ON summary.student_profile_id = profile.id
+           JOIN holistic_mentorship_profile_generation_statuses AS status
+             ON status.etl_run_id = 'status-failure'
+           JOIN holistic_mentorship_regeneration_requests AS request
+             ON request.request_key = 'status-failure-request'
+           GROUP BY profile.id, status.state, request.state
+           """).rows == [[1, "Fixed summary 1", "running", "queued"]]
+  end
+
   test "repeating a completed run cannot replay older output", %{conn: conn} do
     {user, student} = eligible_student()
     configuration_id = insert_prompt_configuration!()
@@ -427,6 +919,23 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePublishControllerTest do
         @source["entry_grade"],
         configuration_id
       ]
+    )
+  end
+
+  defp insert_regeneration_request!(
+         request_key,
+         actor_id,
+         student_id,
+         configuration_id,
+         force \\ true
+       ) do
+    Repo.query!(
+      """
+      INSERT INTO holistic_mentorship_regeneration_requests
+        (request_key, requested_by_user_id, student_id, prompt_configuration_id, force, state)
+      VALUES ($1, $2, $3, $4, $5, 'queued')
+      """,
+      [request_key, actor_id, student_id, configuration_id, force]
     )
   end
 

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_publish_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_publish_controller_test.exs
@@ -109,54 +109,6 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePublishControllerTest do
            """).rows == [[1, "unchanged-run-1", "Fixed summary 1", "unchanged"]]
   end
 
-  test "force replaces unchanged answers only for the matching Regeneration Request", %{
-    conn: conn
-  } do
-    {user, student} = eligible_student()
-    configuration_id = insert_prompt_configuration!()
-    insert_running_status!(student.id, configuration_id, "force-run-1")
-    publish(conn, publish_params(user.id, student.id, configuration_id, "force-run-1"))
-    insert_running_status!(student.id, configuration_id, "force-run-2")
-
-    request_key =
-      insert_running_regeneration_request!(student.id, configuration_id, "force-run-2")
-
-    params =
-      publish_params(user.id, student.id, configuration_id, "force-run-2", %{
-        "expected_profile_revision" => 1,
-        "force" => true,
-        "regeneration_request_key" => request_key,
-        "summaries" => summaries("Forced")
-      })
-
-    assert publish(conn, params) == %{"result" => "replaced", "revision" => 2}
-
-    assert Repo.query!(
-             "SELECT state, etl_run_id FROM holistic_mentorship_regeneration_requests WHERE request_key = $1",
-             [request_key]
-           ).rows == [["completed", "force-run-2"]]
-  end
-
-  test "force accepts a matching queued Regeneration Request", %{conn: conn} do
-    {user, student} = eligible_student()
-    configuration_id = insert_prompt_configuration!()
-    insert_running_status!(student.id, configuration_id, "queued-force-run")
-    request_key = insert_queued_regeneration_request!(student.id, configuration_id)
-
-    params =
-      publish_params(user.id, student.id, configuration_id, "queued-force-run", %{
-        "force" => true,
-        "regeneration_request_key" => request_key
-      })
-
-    assert publish(conn, params) == %{"result" => "published", "revision" => 1}
-
-    assert Repo.query!(
-             "SELECT state, etl_run_id FROM holistic_mentorship_regeneration_requests WHERE request_key = $1",
-             [request_key]
-           ).rows == [["completed", "queued-force-run"]]
-  end
-
   test "repeating a completed run cannot replay older output", %{conn: conn} do
     {user, student} = eligible_student()
     configuration_id = insert_prompt_configuration!()
@@ -393,39 +345,6 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePublishControllerTest do
         configuration_id
       ]
     )
-  end
-
-  defp insert_running_regeneration_request!(student_id, configuration_id, run_id) do
-    requested_by_user = user_fixture()
-    request_key = "request-#{run_id}"
-
-    Repo.query!(
-      """
-      INSERT INTO holistic_mentorship_regeneration_requests
-        (request_key, requested_by_user_id, student_id, prompt_configuration_id,
-         force, state, etl_run_id)
-      VALUES ($1, $2, $3, $4, true, 'running', $5)
-      """,
-      [request_key, requested_by_user.id, student_id, configuration_id, run_id]
-    )
-
-    request_key
-  end
-
-  defp insert_queued_regeneration_request!(student_id, configuration_id) do
-    requested_by_user = user_fixture()
-    request_key = "queued-request-#{student_id}"
-
-    Repo.query!(
-      """
-      INSERT INTO holistic_mentorship_regeneration_requests
-        (request_key, requested_by_user_id, student_id, prompt_configuration_id, force)
-      VALUES ($1, $2, $3, $4, true)
-      """,
-      [request_key, requested_by_user.id, student_id, configuration_id]
-    )
-
-    request_key
   end
 
   defp publish(conn, params) do

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_publish_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_publish_controller_test.exs
@@ -1,0 +1,474 @@
+defmodule DbserviceWeb.HolisticMentorshipProfilePublishControllerTest do
+  use DbserviceWeb.ConnCase, async: false
+
+  alias Dbservice.Repo
+
+  import Dbservice.GradesFixtures
+  import Dbservice.SchoolsFixtures
+  import Dbservice.UsersFixtures
+  import ExUnit.CaptureLog
+
+  @source %{
+    "af_session_id" => "EnableStudents_6a44a83d1184e717b920c499",
+    "entry_grade" => 11,
+    "form_id" => "6a44a83d1184e717b920c499"
+  }
+
+  test "publishes one complete Student Profile and completes its generation status", %{conn: conn} do
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "publish-run-1")
+
+    response =
+      conn
+      |> post(
+        "/api/holistic-mentorship/profiles/publish",
+        publish_params(user.id, student.id, configuration_id, "publish-run-1")
+      )
+      |> json_response(200)
+
+    assert response == %{"result" => "published", "revision" => 1}
+
+    assert Repo.query!("""
+           SELECT profile.revision, profile.answer_fingerprint, status.state,
+                  status.completed_outcome, summary.position, summary.question_set_title,
+                  summary.summary
+           FROM holistic_mentorship_student_profiles AS profile
+           JOIN holistic_mentorship_student_profile_summaries AS summary
+             ON summary.student_profile_id = profile.id
+           JOIN holistic_mentorship_profile_generation_statuses AS status
+             ON status.etl_run_id = profile.last_successful_etl_run_id
+           ORDER BY summary.position
+           """).rows ==
+             (for position <- 1..5 do
+                [
+                  1,
+                  "answers-v1",
+                  "completed",
+                  "published",
+                  position,
+                  "Question Set #{position}",
+                  "Fixed summary #{position}"
+                ]
+              end)
+  end
+
+  test "replaces changed answers for the same configuration", %{conn: conn} do
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "replace-run-1")
+
+    assert publish(conn, publish_params(user.id, student.id, configuration_id, "replace-run-1")) ==
+             %{"result" => "published", "revision" => 1}
+
+    insert_running_status!(student.id, configuration_id, "replace-run-2")
+
+    params =
+      publish_params(user.id, student.id, configuration_id, "replace-run-2", %{
+        "answer_fingerprint" => "answers-v2",
+        "expected_profile_revision" => 1,
+        "summaries" => summaries("Replacement")
+      })
+
+    assert publish(conn, params) == %{"result" => "replaced", "revision" => 2}
+
+    assert Repo.query!("""
+           SELECT profile.revision, profile.answer_fingerprint, profile.last_successful_etl_run_id,
+                  count(summary.id), min(summary.summary), max(summary.summary)
+           FROM holistic_mentorship_student_profiles AS profile
+           JOIN holistic_mentorship_student_profile_summaries AS summary
+             ON summary.student_profile_id = profile.id
+           GROUP BY profile.id
+           """).rows == [[2, "answers-v2", "replace-run-2", 5, "Replacement 1", "Replacement 5"]]
+  end
+
+  test "returns unchanged without replacing a matching answer fingerprint", %{conn: conn} do
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "unchanged-run-1")
+    publish(conn, publish_params(user.id, student.id, configuration_id, "unchanged-run-1"))
+    insert_running_status!(student.id, configuration_id, "unchanged-run-2")
+
+    params =
+      publish_params(user.id, student.id, configuration_id, "unchanged-run-2", %{
+        "expected_profile_revision" => 1,
+        "summaries" => summaries("Should not persist")
+      })
+
+    assert publish(conn, params) == %{"result" => "unchanged", "revision" => 1}
+
+    assert Repo.query!("""
+           SELECT profile.revision, profile.last_successful_etl_run_id,
+                  min(summary.summary), status.completed_outcome
+           FROM holistic_mentorship_student_profiles AS profile
+           JOIN holistic_mentorship_student_profile_summaries AS summary
+             ON summary.student_profile_id = profile.id
+           JOIN holistic_mentorship_profile_generation_statuses AS status
+             ON status.etl_run_id = 'unchanged-run-2'
+           GROUP BY profile.id, status.completed_outcome
+           """).rows == [[1, "unchanged-run-1", "Fixed summary 1", "unchanged"]]
+  end
+
+  test "force replaces unchanged answers only for the matching Regeneration Request", %{
+    conn: conn
+  } do
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "force-run-1")
+    publish(conn, publish_params(user.id, student.id, configuration_id, "force-run-1"))
+    insert_running_status!(student.id, configuration_id, "force-run-2")
+
+    request_key =
+      insert_running_regeneration_request!(student.id, configuration_id, "force-run-2")
+
+    params =
+      publish_params(user.id, student.id, configuration_id, "force-run-2", %{
+        "expected_profile_revision" => 1,
+        "force" => true,
+        "regeneration_request_key" => request_key,
+        "summaries" => summaries("Forced")
+      })
+
+    assert publish(conn, params) == %{"result" => "replaced", "revision" => 2}
+
+    assert Repo.query!(
+             "SELECT state, etl_run_id FROM holistic_mentorship_regeneration_requests WHERE request_key = $1",
+             [request_key]
+           ).rows == [["completed", "force-run-2"]]
+  end
+
+  test "force accepts a matching queued Regeneration Request", %{conn: conn} do
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "queued-force-run")
+    request_key = insert_queued_regeneration_request!(student.id, configuration_id)
+
+    params =
+      publish_params(user.id, student.id, configuration_id, "queued-force-run", %{
+        "force" => true,
+        "regeneration_request_key" => request_key
+      })
+
+    assert publish(conn, params) == %{"result" => "published", "revision" => 1}
+
+    assert Repo.query!(
+             "SELECT state, etl_run_id FROM holistic_mentorship_regeneration_requests WHERE request_key = $1",
+             [request_key]
+           ).rows == [["completed", "queued-force-run"]]
+  end
+
+  test "repeating a completed run cannot replay older output", %{conn: conn} do
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "repeat-old")
+    old_params = publish_params(user.id, student.id, configuration_id, "repeat-old")
+    assert publish(conn, old_params) == %{"result" => "published", "revision" => 1}
+
+    insert_running_status!(student.id, configuration_id, "repeat-new")
+
+    new_params =
+      publish_params(user.id, student.id, configuration_id, "repeat-new", %{
+        "answer_fingerprint" => "answers-new",
+        "expected_profile_revision" => 1,
+        "summaries" => summaries("Newest")
+      })
+
+    assert publish(conn, new_params) == %{"result" => "replaced", "revision" => 2}
+    assert publish(conn, old_params) == %{"result" => "published", "revision" => 2}
+
+    assert Repo.query!("""
+           SELECT profile.answer_fingerprint, profile.revision, min(summary.summary)
+           FROM holistic_mentorship_student_profiles AS profile
+           JOIN holistic_mentorship_student_profile_summaries AS summary
+             ON summary.student_profile_id = profile.id
+           GROUP BY profile.id
+           """).rows == [["answers-new", 2, "Newest 1"]]
+  end
+
+  test "stale revisions and child-write failures roll back the whole publication", %{conn: conn} do
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "rollback-base")
+    publish(conn, publish_params(user.id, student.id, configuration_id, "rollback-base"))
+
+    insert_running_status!(student.id, configuration_id, "rollback-stale")
+
+    stale =
+      publish_params(user.id, student.id, configuration_id, "rollback-stale", %{
+        "answer_fingerprint" => "stale-answers",
+        "expected_profile_revision" => 2
+      })
+
+    assert conn
+           |> post("/api/holistic-mentorship/profiles/publish", stale)
+           |> json_response(409) == %{
+             "error" => %{
+               "code" => "stale_profile_revision",
+               "message" => "Profile revision is stale"
+             }
+           }
+
+    insert_running_status!(student.id, configuration_id, "rollback-child")
+
+    invalid_child =
+      publish_params(user.id, student.id, configuration_id, "rollback-child", %{
+        "answer_fingerprint" => "child-answers",
+        "expected_profile_revision" => 1,
+        "summaries" => [
+          %{
+            "position" => 1,
+            "question_set_title" => String.duplicate("x", 256),
+            "summary" => "invalid child"
+          }
+          | Enum.drop(summaries("Replacement"), 1)
+        ]
+      })
+
+    assert conn
+           |> post("/api/holistic-mentorship/profiles/publish", invalid_child)
+           |> json_response(422) == %{
+             "error" => %{
+               "code" => "invalid_request",
+               "message" => "Profile publication request is invalid"
+             }
+           }
+
+    assert Repo.query!("""
+           SELECT profile.revision, profile.answer_fingerprint, min(summary.summary)
+           FROM holistic_mentorship_student_profiles AS profile
+           JOIN holistic_mentorship_student_profile_summaries AS summary
+             ON summary.student_profile_id = profile.id
+           GROUP BY profile.id
+           """).rows == [[1, "answers-v1", "Fixed summary 1"]]
+
+    assert Repo.query!("""
+           SELECT etl_run_id, state FROM holistic_mentorship_profile_generation_statuses
+           WHERE etl_run_id IN ('rollback-stale', 'rollback-child') ORDER BY etl_run_id
+           """).rows == [["rollback-child", "running"], ["rollback-stale", "running"]]
+  end
+
+  test "revalidates eligibility at publication time", %{conn: conn} do
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "ineligible-run")
+    Repo.query!("UPDATE student SET status = 'dropout' WHERE id = $1", [student.id])
+
+    response =
+      conn
+      |> post(
+        "/api/holistic-mentorship/profiles/publish",
+        publish_params(user.id, student.id, configuration_id, "ineligible-run")
+      )
+      |> json_response(422)
+
+    assert response == %{
+             "error" => %{
+               "code" => "dropout",
+               "message" => "Profile publication is not eligible"
+             }
+           }
+
+    assert Repo.query!("SELECT count(*) FROM holistic_mentorship_profile_journeys").rows == [[0]]
+    refute inspect(response) =~ Integer.to_string(student.id)
+    refute inspect(response) =~ Integer.to_string(user.id)
+  end
+
+  test "retains a Profile published for another Prompt Configuration", %{conn: conn} do
+    {user, student} = eligible_student()
+    first_configuration = insert_prompt_configuration!()
+    second_configuration = insert_prompt_configuration!("openai/gpt-5")
+    insert_running_status!(student.id, first_configuration, "configuration-first")
+
+    publish(
+      conn,
+      publish_params(user.id, student.id, first_configuration, "configuration-first")
+    )
+
+    insert_running_status!(student.id, second_configuration, "configuration-second")
+
+    assert publish(
+             conn,
+             publish_params(user.id, student.id, second_configuration, "configuration-second")
+           ) == %{"result" => "published", "revision" => 1}
+
+    assert Repo.query!("""
+           SELECT prompt_configuration_id, revision
+           FROM holistic_mentorship_student_profiles
+           ORDER BY prompt_configuration_id
+           """).rows == [[first_configuration, 1], [second_configuration, 1]]
+  end
+
+  test "requires authentication and redacts publication content from errors and logs", %{
+    conn: conn
+  } do
+    assert build_conn()
+           |> post("/api/holistic-mentorship/profiles/publish", %{})
+           |> response(401) == "Not Authorized"
+
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "redacted-run")
+    Repo.query!("UPDATE student SET status = 'dropout' WHERE id = $1", [student.id])
+
+    params =
+      publish_params(user.id, student.id, configuration_id, "redacted-run", %{
+        "answer_fingerprint" => "private-answer-fingerprint",
+        "summaries" => summaries("private-summary")
+      })
+
+    {response, log} =
+      with_debug_log(fn ->
+        conn
+        |> post("/api/holistic-mentorship/profiles/publish", params)
+        |> json_response(422)
+      end)
+
+    for sensitive <- [
+          Integer.to_string(user.id),
+          Integer.to_string(student.id),
+          "private-answer-fingerprint",
+          "private-summary"
+        ] do
+      refute inspect(response) =~ sensitive
+      refute log =~ sensitive
+    end
+  end
+
+  defp eligible_student do
+    grade = grade_fixture(%{number: 11})
+    {user, student} = student_fixture(%{grade_id: grade.id, status: "active"})
+    school = school_fixture(%{program_ids: [1], code: "publish-school-#{user.id}"})
+
+    enroll(user.id, "school", school.id)
+    enroll(user.id, "program", 1)
+    enroll(user.id, "grade", grade.id)
+    {user, student}
+  end
+
+  defp enroll(user_id, group_type, group_id) do
+    {:ok, _} =
+      Dbservice.EnrollmentRecords.create_enrollment_record(%{
+        user_id: user_id,
+        group_id: group_id,
+        group_type: group_type,
+        academic_year: "2026-27",
+        start_date: ~D[2026-06-01],
+        is_current: true
+      })
+  end
+
+  defp insert_prompt_configuration!(model_id \\ "openai/gpt-5-mini") do
+    [[version_id]] =
+      Repo.query!("""
+      INSERT INTO holistic_mentorship_prompt_versions (version, template_text, template_hash)
+      VALUES ('publish-v1', 'abc',
+              'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
+      ON CONFLICT (version) DO UPDATE SET version = EXCLUDED.version
+      RETURNING id
+      """).rows
+
+    [[configuration_id]] =
+      Repo.query!(
+        "INSERT INTO holistic_mentorship_prompt_configurations (prompt_version_id, model_id) VALUES ($1, $2) RETURNING id",
+        [version_id, model_id]
+      ).rows
+
+    configuration_id
+  end
+
+  defp insert_running_status!(student_id, configuration_id, run_id) do
+    Repo.query!(
+      """
+      INSERT INTO holistic_mentorship_profile_generation_statuses
+        (etl_run_id, student_id, form_id, af_session_id, entry_grade,
+         prompt_configuration_id, state)
+      VALUES ($1, $2, $3, $4, $5, $6, 'running')
+      """,
+      [
+        run_id,
+        student_id,
+        @source["form_id"],
+        @source["af_session_id"],
+        @source["entry_grade"],
+        configuration_id
+      ]
+    )
+  end
+
+  defp insert_running_regeneration_request!(student_id, configuration_id, run_id) do
+    requested_by_user = user_fixture()
+    request_key = "request-#{run_id}"
+
+    Repo.query!(
+      """
+      INSERT INTO holistic_mentorship_regeneration_requests
+        (request_key, requested_by_user_id, student_id, prompt_configuration_id,
+         force, state, etl_run_id)
+      VALUES ($1, $2, $3, $4, true, 'running', $5)
+      """,
+      [request_key, requested_by_user.id, student_id, configuration_id, run_id]
+    )
+
+    request_key
+  end
+
+  defp insert_queued_regeneration_request!(student_id, configuration_id) do
+    requested_by_user = user_fixture()
+    request_key = "queued-request-#{student_id}"
+
+    Repo.query!(
+      """
+      INSERT INTO holistic_mentorship_regeneration_requests
+        (request_key, requested_by_user_id, student_id, prompt_configuration_id, force)
+      VALUES ($1, $2, $3, $4, true)
+      """,
+      [request_key, requested_by_user.id, student_id, configuration_id]
+    )
+
+    request_key
+  end
+
+  defp publish(conn, params) do
+    conn
+    |> post("/api/holistic-mentorship/profiles/publish", params)
+    |> json_response(200)
+  end
+
+  defp publish_params(user_id, student_id, configuration_id, run_id, overrides \\ %{}) do
+    Map.merge(@source, %{
+      "answer_fingerprint" => "answers-v1",
+      "etl_run_id" => run_id,
+      "expected_profile_revision" => nil,
+      "force" => false,
+      "generated_at" => "2026-07-16T10:05:00Z",
+      "prompt_configuration_id" => configuration_id,
+      "schema_fingerprint" => "schema-v1",
+      "source_user_id" => Integer.to_string(user_id),
+      "student_id" => student_id,
+      "summaries" => summaries("Fixed summary"),
+      "warehouse_loaded_at" => "2026-07-16T10:00:00Z"
+    })
+    |> Map.merge(overrides)
+  end
+
+  defp summaries(prefix) do
+    for position <- 1..5 do
+      %{
+        "position" => position,
+        "question_set_title" => "Question Set #{position}",
+        "summary" => "#{prefix} #{position}"
+      }
+    end
+  end
+
+  defp with_debug_log(operation) do
+    previous_level = Logger.level()
+    Logger.configure(level: :debug)
+
+    try do
+      with_log([level: :debug], operation)
+    after
+      Logger.configure(level: previous_level)
+    end
+  end
+end

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_publish_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_publish_controller_test.exs
@@ -209,6 +209,48 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePublishControllerTest do
            """).rows == [["completed", "running-force-run"]]
   end
 
+  test "a queued force request follows the request state machine", %{conn: conn} do
+    {user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_running_status!(student.id, configuration_id, "queued-force-base")
+    publish(conn, publish_params(user.id, student.id, configuration_id, "queued-force-base"))
+
+    insert_running_status!(student.id, configuration_id, "queued-force-run")
+    insert_regeneration_request!("queued-force-request", user.id, student.id, configuration_id)
+
+    Repo.query!("""
+    CREATE FUNCTION reject_queued_to_completed() RETURNS trigger AS $$
+    BEGIN
+      IF OLD.request_key = 'queued-force-request'
+         AND OLD.state = 'queued' AND NEW.state = 'completed' THEN
+        RAISE EXCEPTION 'invalid regeneration transition';
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+    """)
+
+    Repo.query!("""
+    CREATE TRIGGER reject_queued_to_completed
+    BEFORE UPDATE ON holistic_mentorship_regeneration_requests
+    FOR EACH ROW EXECUTE FUNCTION reject_queued_to_completed()
+    """)
+
+    params =
+      publish_params(user.id, student.id, configuration_id, "queued-force-run", %{
+        "expected_profile_revision" => 1,
+        "force" => true,
+        "regeneration_request_key" => "queued-force-request"
+      })
+
+    assert publish(conn, params) == %{"result" => "replaced", "revision" => 2}
+
+    assert Repo.query!("""
+           SELECT state, etl_run_id FROM holistic_mentorship_regeneration_requests
+           WHERE request_key = 'queued-force-request'
+           """).rows == [["completed", "queued-force-run"]]
+  end
+
   test "repeating a completed force publication returns its prior result", %{conn: conn} do
     {user, student} = eligible_student()
     configuration_id = insert_prompt_configuration!()

--- a/test/dbservice_web/controllers/holistic_mentorship_prompt_configuration_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_prompt_configuration_controller_test.exs
@@ -223,7 +223,7 @@ defmodule DbserviceWeb.HolisticMentorshipPromptConfigurationControllerTest do
                ).rows == [[1]]
       after
         Repo.query!(
-          "TRUNCATE holistic_mentorship_prompt_configurations, holistic_mentorship_prompt_versions RESTART IDENTITY"
+          "TRUNCATE holistic_mentorship_student_profile_summaries, holistic_mentorship_student_profiles, holistic_mentorship_prompt_configurations, holistic_mentorship_prompt_versions RESTART IDENTITY"
         )
       end
     end)

--- a/test/dbservice_web/controllers/holistic_mentorship_prompt_configuration_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_prompt_configuration_controller_test.exs
@@ -223,7 +223,7 @@ defmodule DbserviceWeb.HolisticMentorshipPromptConfigurationControllerTest do
                ).rows == [[1]]
       after
         Repo.query!(
-          "TRUNCATE holistic_mentorship_student_profile_summaries, holistic_mentorship_student_profiles, holistic_mentorship_prompt_configurations, holistic_mentorship_prompt_versions RESTART IDENTITY"
+          "TRUNCATE holistic_mentorship_profile_generation_statuses, holistic_mentorship_student_profile_summaries, holistic_mentorship_student_profiles, holistic_mentorship_prompt_configurations, holistic_mentorship_prompt_versions RESTART IDENTITY"
         )
       end
     end)

--- a/test/dbservice_web/controllers/holistic_mentorship_prompt_configuration_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_prompt_configuration_controller_test.exs
@@ -150,6 +150,28 @@ defmodule DbserviceWeb.HolisticMentorshipPromptConfigurationControllerTest do
            }
   end
 
+  test "rejects oversized prompt configuration strings with a safe machine error", %{conn: conn} do
+    for overrides <- [
+          %{"prompt_version" => String.duplicate("v", 256)},
+          %{"template_hash" => String.duplicate("h", 256)},
+          %{"model_id" => String.duplicate("m", 256)}
+        ] do
+      assert conn
+             |> register(overrides)
+             |> json_response(422) == %{
+               "error" => %{
+                 "code" => "invalid_request",
+                 "message" => "Required prompt configuration fields are missing or invalid"
+               }
+             }
+    end
+
+    assert Repo.query!("SELECT count(*) FROM holistic_mentorship_prompt_versions").rows == [[0]]
+
+    assert Repo.query!("SELECT count(*) FROM holistic_mentorship_prompt_configurations").rows ==
+             [[0]]
+  end
+
   test "rejects unknown activation targets with a stable safe error", %{conn: conn} do
     conn = post(conn, "/api/holistic-mentorship/prompt-configurations/999999/activate", %{})
 

--- a/test/dbservice_web/controllers/holistic_mentorship_prompt_configuration_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_prompt_configuration_controller_test.exs
@@ -42,7 +42,7 @@ defmodule DbserviceWeb.HolisticMentorshipPromptConfigurationControllerTest do
     template_text = "sensitive template text"
 
     {conn, log} =
-      with_log(fn ->
+      with_debug_log(fn ->
         post(conn, "/api/holistic-mentorship/prompt-configurations", %{
           "prompt_version" => "profile-v1",
           "template_text" => template_text,
@@ -69,7 +69,7 @@ defmodule DbserviceWeb.HolisticMentorshipPromptConfigurationControllerTest do
     conflicting_text = "abcd"
 
     {conn, log} =
-      with_log(fn ->
+      with_debug_log(fn ->
         post(conn, "/api/holistic-mentorship/prompt-configurations", %{
           "prompt_version" => "profile-v1",
           "template_text" => conflicting_text,
@@ -271,6 +271,17 @@ defmodule DbserviceWeb.HolisticMentorshipPromptConfigurationControllerTest do
 
   defp build_conn(authorization) do
     build_conn() |> put_req_header("authorization", authorization)
+  end
+
+  defp with_debug_log(operation) do
+    previous_level = Logger.level()
+    Logger.configure(level: :debug)
+
+    try do
+      with_log([level: :debug], operation)
+    after
+      Logger.configure(level: previous_level)
+    end
   end
 
   defp assert_check_violation(operation) do

--- a/test/dbservice_web/controllers/holistic_mentorship_prompt_configuration_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_prompt_configuration_controller_test.exs
@@ -223,7 +223,7 @@ defmodule DbserviceWeb.HolisticMentorshipPromptConfigurationControllerTest do
                ).rows == [[1]]
       after
         Repo.query!(
-          "TRUNCATE holistic_mentorship_profile_generation_statuses, holistic_mentorship_student_profile_summaries, holistic_mentorship_student_profiles, holistic_mentorship_prompt_configurations, holistic_mentorship_prompt_versions RESTART IDENTITY"
+          "TRUNCATE holistic_mentorship_regeneration_requests, holistic_mentorship_profile_generation_statuses, holistic_mentorship_student_profile_summaries, holistic_mentorship_student_profiles, holistic_mentorship_prompt_configurations, holistic_mentorship_prompt_versions RESTART IDENTITY"
         )
       end
     end)

--- a/test/dbservice_web/controllers/holistic_mentorship_prompt_configuration_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_prompt_configuration_controller_test.exs
@@ -1,0 +1,280 @@
+defmodule DbserviceWeb.HolisticMentorshipPromptConfigurationControllerTest do
+  use DbserviceWeb.ConnCase, async: false
+
+  alias Dbservice.Repo
+
+  import ExUnit.CaptureLog
+
+  @template_hash "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+
+  test "registers an inactive Prompt Configuration after verifying its template hash", %{
+    conn: conn
+  } do
+    response =
+      conn
+      |> post("/api/holistic-mentorship/prompt-configurations", %{
+        "prompt_version" => "profile-v1",
+        "template_text" => "abc",
+        "template_hash" => @template_hash,
+        "model_id" => "openai/gpt-5-mini"
+      })
+      |> json_response(200)
+
+    assert response == %{
+             "id" => response["id"],
+             "model_id" => "openai/gpt-5-mini",
+             "prompt_version" => "profile-v1",
+             "state" => "inactive",
+             "template_hash" => @template_hash
+           }
+
+    assert Repo.query!("""
+           SELECT version, template_text, template_hash, model_id, state
+           FROM holistic_mentorship_prompt_versions AS version
+           JOIN holistic_mentorship_prompt_configurations AS configuration
+             ON configuration.prompt_version_id = version.id
+           """).rows == [
+             ["profile-v1", "abc", @template_hash, "openai/gpt-5-mini", "inactive"]
+           ]
+  end
+
+  test "rejects a mismatched template hash without exposing the template", %{conn: conn} do
+    template_text = "sensitive template text"
+
+    {conn, log} =
+      with_log(fn ->
+        post(conn, "/api/holistic-mentorship/prompt-configurations", %{
+          "prompt_version" => "profile-v1",
+          "template_text" => template_text,
+          "template_hash" => String.duplicate("0", 64),
+          "model_id" => "openai/gpt-5-mini"
+        })
+      end)
+
+    assert json_response(conn, 422) == %{
+             "error" => %{
+               "code" => "template_hash_mismatch",
+               "message" => "Template hash does not match template text"
+             }
+           }
+
+    refute conn.resp_body =~ template_text
+    refute log =~ template_text
+  end
+
+  test "rejects different content for an existing Prompt Version without exposing it", %{
+    conn: conn
+  } do
+    register(conn)
+    conflicting_text = "abcd"
+
+    {conn, log} =
+      with_log(fn ->
+        post(conn, "/api/holistic-mentorship/prompt-configurations", %{
+          "prompt_version" => "profile-v1",
+          "template_text" => conflicting_text,
+          "template_hash" => "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589",
+          "model_id" => "anthropic/claude-sonnet"
+        })
+      end)
+
+    assert json_response(conn, 409) == %{
+             "error" => %{
+               "code" => "prompt_version_conflict",
+               "message" => "Prompt Version already exists with different content"
+             }
+           }
+
+    refute conn.resp_body =~ conflicting_text
+    refute log =~ conflicting_text
+
+    assert Repo.query!(
+             "SELECT template_text, template_hash FROM holistic_mentorship_prompt_versions"
+           ).rows == [["abc", @template_hash]]
+  end
+
+  test "retries idempotently and registers distinct inactive model configurations", %{conn: conn} do
+    first = register(conn) |> json_response(200)
+    retry = register(conn) |> json_response(200)
+
+    second =
+      register(conn, %{"model_id" => "anthropic/claude-sonnet"})
+      |> json_response(200)
+
+    assert retry == first
+    refute second["id"] == first["id"]
+
+    assert Repo.query!("""
+           SELECT version, model_id, state
+           FROM holistic_mentorship_prompt_versions AS version
+           JOIN holistic_mentorship_prompt_configurations AS configuration
+             ON configuration.prompt_version_id = version.id
+           ORDER BY model_id
+           """).rows == [
+             ["profile-v1", "anthropic/claude-sonnet", "inactive"],
+             ["profile-v1", "openai/gpt-5-mini", "inactive"]
+           ]
+  end
+
+  test "explicit activation switches the single Active configuration idempotently", %{conn: conn} do
+    first = register(conn) |> json_response(200)
+
+    second =
+      register(conn, %{"model_id" => "anthropic/claude-sonnet"})
+      |> json_response(200)
+
+    assert activate(conn, first["id"])["state"] == "active"
+    assert activate(conn, second["id"]) == activate(conn, second["id"])
+
+    assert Repo.query!(
+             "SELECT id, state FROM holistic_mentorship_prompt_configurations ORDER BY id"
+           ).rows == [
+             [first["id"], "inactive"],
+             [second["id"], "active"]
+           ]
+  end
+
+  test "rejects malformed registration with a safe machine error", %{conn: conn} do
+    conn =
+      post(conn, "/api/holistic-mentorship/prompt-configurations", %{
+        "prompt_version" => "profile-v1",
+        "template_hash" => @template_hash,
+        "model_id" => "openai/gpt-5-mini"
+      })
+
+    assert json_response(conn, 422) == %{
+             "error" => %{
+               "code" => "invalid_request",
+               "message" => "Required prompt configuration fields are missing or invalid"
+             }
+           }
+  end
+
+  test "rejects unknown activation targets with a stable safe error", %{conn: conn} do
+    conn = post(conn, "/api/holistic-mentorship/prompt-configurations/999999/activate", %{})
+
+    assert json_response(conn, 404) == %{
+             "error" => %{
+               "code" => "prompt_configuration_not_found",
+               "message" => "Prompt Configuration not found"
+             }
+           }
+  end
+
+  test "requires the existing Bearer token while health remains public" do
+    for authorization <- [
+          nil,
+          "Token malformed",
+          "Bearer wrong-token",
+          "Bearer production-test-token"
+        ] do
+      request_conn = build_conn()
+
+      request_conn =
+        if authorization,
+          do: put_req_header(request_conn, "authorization", authorization),
+          else: request_conn
+
+      assert request_conn
+             |> post("/api/holistic-mentorship/prompt-configurations", %{})
+             |> response(401) == "Not Authorized"
+    end
+
+    assert build_conn() |> get("/api/health") |> json_response(200) == %{"status" => "ok"}
+    assert build_conn() |> get("/api/health/ready") |> json_response(200) == %{"status" => "ok"}
+  end
+
+  test "serializes concurrent activation and leaves exactly one configuration Active", %{
+    conn: conn
+  } do
+    authorization = conn |> get_req_header("authorization") |> List.first()
+
+    Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+      first = register(build_conn(authorization)) |> json_response(200)
+
+      second =
+        register(build_conn(authorization), %{"model_id" => "anthropic/claude-sonnet"})
+        |> json_response(200)
+
+      try do
+        parent = self()
+
+        tasks =
+          for id <- [first["id"], second["id"]] do
+            Task.async(fn ->
+              Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+                send(parent, {:ready, self()})
+                receive do: (:go -> activate(build_conn(authorization), id))
+              end)
+            end)
+          end
+
+        task_pids =
+          for _ <- tasks do
+            assert_receive {:ready, task_pid}
+            task_pid
+          end
+
+        Enum.each(task_pids, &send(&1, :go))
+        assert Enum.map(tasks, &Task.await/1) |> Enum.all?(&(&1["state"] == "active"))
+
+        assert Repo.query!(
+                 "SELECT count(*) FROM holistic_mentorship_prompt_configurations WHERE state = 'active'"
+               ).rows == [[1]]
+      after
+        Repo.query!(
+          "TRUNCATE holistic_mentorship_prompt_configurations, holistic_mentorship_prompt_versions RESTART IDENTITY"
+        )
+      end
+    end)
+  end
+
+  test "database rows keep Prompt Version and model configuration content immutable", %{
+    conn: conn
+  } do
+    configuration = register(conn) |> json_response(200)
+
+    assert_check_violation(fn ->
+      Repo.query(
+        "UPDATE holistic_mentorship_prompt_versions SET template_text = 'changed' WHERE version = 'profile-v1'"
+      )
+    end)
+
+    assert_check_violation(fn ->
+      Repo.query(
+        "UPDATE holistic_mentorship_prompt_configurations SET model_id = 'changed' WHERE id = $1",
+        [configuration["id"]]
+      )
+    end)
+  end
+
+  defp register(conn, overrides \\ %{}) do
+    params =
+      Map.merge(
+        %{
+          "prompt_version" => "profile-v1",
+          "template_text" => "abc",
+          "template_hash" => @template_hash,
+          "model_id" => "openai/gpt-5-mini"
+        },
+        overrides
+      )
+
+    post(conn, "/api/holistic-mentorship/prompt-configurations", params)
+  end
+
+  defp activate(conn, id) do
+    conn
+    |> post("/api/holistic-mentorship/prompt-configurations/#{id}/activate", %{})
+    |> json_response(200)
+  end
+
+  defp build_conn(authorization) do
+    build_conn() |> put_req_header("authorization", authorization)
+  end
+
+  defp assert_check_violation(operation) do
+    assert {:error, {:error, %Postgrex.Error{postgres: %{code: :check_violation}}}} =
+             Repo.transaction(fn -> Repo.rollback(operation.()) end, mode: :savepoint)
+  end
+end

--- a/test/dbservice_web/controllers/holistic_mentorship_regeneration_request_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_regeneration_request_controller_test.exs
@@ -209,6 +209,7 @@ defmodule DbserviceWeb.HolisticMentorshipRegenerationRequestControllerTest do
 
     for params <- [
           %{"etl_run_id" => "etl-invalid", "state" => "queued"},
+          %{"etl_run_id" => String.duplicate("x", 256), "state" => "running"},
           %{
             "error_message" => String.duplicate("x", 501),
             "etl_run_id" => "etl-invalid",

--- a/test/dbservice_web/controllers/holistic_mentorship_regeneration_request_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_regeneration_request_controller_test.exs
@@ -39,6 +39,32 @@ defmodule DbserviceWeb.HolisticMentorshipRegenerationRequestControllerTest do
     refute student_user.id == admin.id
   end
 
+  test "rejects a queued request for a privacy-deleted Student", %{conn: conn} do
+    {_student_user, student} = eligible_student()
+    admin = user_fixture()
+    configuration_id = insert_prompt_configuration!()
+    insert_request!(admin.id, student.id, configuration_id, "privacy-deleted-request")
+
+    Repo.query!(
+      """
+      INSERT INTO holistic_mentorship_privacy_deletions
+        (student_id, actor_user_id, reason, profile_summaries_erased,
+         post_session_answers_erased, historical_answers_erased, occurred_at)
+      VALUES ($1, $2, 'approved-request', 0, 0, 0, now())
+      """,
+      [student.id, admin.id]
+    )
+
+    assert conn
+           |> get("/api/holistic-mentorship/regeneration-requests/privacy-deleted-request")
+           |> json_response(422) == %{
+             "error" => %{
+               "code" => "privacy_erased",
+               "message" => "Student is not eligible"
+             }
+           }
+  end
+
   test "keeps the human actor and request identity immutable" do
     {_student_user, student} = eligible_student()
     admin = user_fixture()

--- a/test/dbservice_web/controllers/holistic_mentorship_regeneration_request_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_regeneration_request_controller_test.exs
@@ -27,9 +27,13 @@ defmodule DbserviceWeb.HolisticMentorshipRegenerationRequestControllerTest do
            |> json_response(200) == %{
              "etl_run_id" => nil,
              "force" => true,
+             "model_id" => "openai/gpt-5-mini",
              "prompt_configuration_id" => configuration_id,
+             "prompt_version" => "regeneration-v1",
+             "request_key" => "request-624",
              "state" => "queued",
-             "student_id" => student.id
+             "student_id" => student.id,
+             "template_hash" => "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
            }
 
     refute student_user.id == admin.id
@@ -122,6 +126,43 @@ defmodule DbserviceWeb.HolisticMentorshipRegenerationRequestControllerTest do
            ]
   end
 
+  test "binds one ETL run while the request remains queued", %{conn: conn} do
+    {_student_user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_request!(user_fixture().id, student.id, configuration_id, "bound-request")
+
+    bound_params = %{"etl_run_id" => "bound-run", "state" => "queued"}
+
+    assert post_status(conn, "bound-request", bound_params) == %{
+             "error_code" => nil,
+             "error_message" => nil,
+             "etl_run_id" => "bound-run",
+             "state" => "queued"
+           }
+
+    assert post_status(conn, "bound-request", bound_params)["etl_run_id"] == "bound-run"
+
+    assert_status_error(
+      conn,
+      "bound-request",
+      %{"etl_run_id" => "losing-run", "state" => "queued"},
+      "etl_run_conflict"
+    )
+
+    assert_check_violation(fn ->
+      Repo.query("""
+      UPDATE holistic_mentorship_regeneration_requests
+      SET etl_run_id = 'bypassing-run'
+      WHERE request_key = 'bound-request'
+      """)
+    end)
+
+    assert post_status(conn, "bound-request", %{
+             "etl_run_id" => "bound-run",
+             "state" => "running"
+           })["state"] == "running"
+  end
+
   test "supports failed completion and rejects regressions or ETL run conflicts", %{conn: conn} do
     {_student_user, student} = eligible_student()
     configuration_id = insert_prompt_configuration!()
@@ -162,6 +203,39 @@ defmodule DbserviceWeb.HolisticMentorshipRegenerationRequestControllerTest do
       "queued-request",
       %{"etl_run_id" => "etl-queued", "state" => "completed"},
       "invalid_status_transition"
+    )
+  end
+
+  test "a bound request can fail before its worker reaches running", %{conn: conn} do
+    {_student_user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_request!(user_fixture().id, student.id, configuration_id, "pre-running-failure")
+
+    post_status(conn, "pre-running-failure", %{
+      "etl_run_id" => "pre-running-run",
+      "state" => "queued"
+    })
+
+    failed_params = %{
+      "error_code" => "worker_start_failed",
+      "etl_run_id" => "pre-running-run",
+      "state" => "failed"
+    }
+
+    assert post_status(conn, "pre-running-failure", failed_params) == %{
+             "error_code" => "worker_start_failed",
+             "error_message" => nil,
+             "etl_run_id" => "pre-running-run",
+             "state" => "failed"
+           }
+
+    assert post_status(conn, "pre-running-failure", failed_params)["state"] == "failed"
+
+    assert_status_error(
+      conn,
+      "pre-running-failure",
+      %{"etl_run_id" => "other-run", "state" => "failed"},
+      "etl_run_conflict"
     )
   end
 
@@ -208,7 +282,11 @@ defmodule DbserviceWeb.HolisticMentorshipRegenerationRequestControllerTest do
     insert_request!(user_fixture().id, student.id, configuration_id, "invalid-request")
 
     for params <- [
-          %{"etl_run_id" => "etl-invalid", "state" => "queued"},
+          %{
+            "error_code" => "not-allowed-while-queued",
+            "etl_run_id" => "etl-invalid",
+            "state" => "queued"
+          },
           %{"etl_run_id" => String.duplicate("x", 256), "state" => "running"},
           %{
             "error_message" => String.duplicate("x", 501),
@@ -231,13 +309,25 @@ defmodule DbserviceWeb.HolisticMentorshipRegenerationRequestControllerTest do
   end
 
   test "requires the existing Bearer token for both Regeneration Request routes" do
-    assert build_conn()
-           |> get("/api/holistic-mentorship/regeneration-requests/request-624")
-           |> response(401) == "Not Authorized"
+    for authorization <- [nil, "Token malformed", "Bearer wrong-environment-secret"] do
+      conn =
+        if authorization,
+          do: put_req_header(build_conn(), "authorization", authorization),
+          else: build_conn()
 
-    assert build_conn()
-           |> post("/api/holistic-mentorship/regeneration-requests/request-624/status", %{})
-           |> response(401) == "Not Authorized"
+      assert conn
+             |> get("/api/holistic-mentorship/regeneration-requests/request-624")
+             |> response(401) == "Not Authorized"
+
+      conn =
+        if authorization,
+          do: put_req_header(build_conn(), "authorization", authorization),
+          else: build_conn()
+
+      assert conn
+             |> post("/api/holistic-mentorship/regeneration-requests/request-624/status", %{})
+             |> response(401) == "Not Authorized"
+    end
   end
 
   defp eligible_student do

--- a/test/dbservice_web/controllers/holistic_mentorship_regeneration_request_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_regeneration_request_controller_test.exs
@@ -1,0 +1,332 @@
+defmodule DbserviceWeb.HolisticMentorshipRegenerationRequestControllerTest do
+  use DbserviceWeb.ConnCase, async: false
+
+  alias Dbservice.Repo
+
+  import Dbservice.GradesFixtures
+  import Dbservice.SchoolsFixtures
+  import Dbservice.UsersFixtures
+  import ExUnit.CaptureLog
+
+  test "returns an eligible queued Regeneration Request created by af_lms", %{conn: conn} do
+    {student_user, student} = eligible_student()
+    admin = user_fixture()
+    configuration_id = insert_prompt_configuration!()
+
+    Repo.query!(
+      """
+      INSERT INTO holistic_mentorship_regeneration_requests
+        (request_key, requested_by_user_id, student_id, prompt_configuration_id, force, state)
+      VALUES ('request-624', $1, $2, $3, true, 'queued')
+      """,
+      [admin.id, student.id, configuration_id]
+    )
+
+    assert conn
+           |> get("/api/holistic-mentorship/regeneration-requests/request-624")
+           |> json_response(200) == %{
+             "etl_run_id" => nil,
+             "force" => true,
+             "prompt_configuration_id" => configuration_id,
+             "state" => "queued",
+             "student_id" => student.id
+           }
+
+    refute student_user.id == admin.id
+  end
+
+  test "keeps the human actor and request identity immutable" do
+    {_student_user, student} = eligible_student()
+    admin = user_fixture()
+    replacement_admin = user_fixture()
+    configuration_id = insert_prompt_configuration!()
+
+    [[request_id, true, true]] =
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_regeneration_requests
+          (request_key, requested_by_user_id, student_id, prompt_configuration_id, force, state)
+        VALUES ('immutable-request', $1, $2, $3, true, 'queued')
+        RETURNING id, inserted_at IS NOT NULL, updated_at IS NOT NULL
+        """,
+        [admin.id, student.id, configuration_id]
+      ).rows
+
+    assert_unique_violation(fn ->
+      Repo.query(
+        """
+        INSERT INTO holistic_mentorship_regeneration_requests
+          (request_key, requested_by_user_id, student_id, prompt_configuration_id, force, state)
+        VALUES ('immutable-request', $1, $2, $3, true, 'queued')
+        """,
+        [admin.id, student.id, configuration_id]
+      )
+    end)
+
+    assert_check_violation(fn ->
+      Repo.query(
+        """
+        UPDATE holistic_mentorship_regeneration_requests
+        SET request_key = 'changed', requested_by_user_id = $2, force = false
+        WHERE id = $1
+        """,
+        [request_id, replacement_admin.id]
+      )
+    end)
+  end
+
+  test "advances queued requests through running to completed idempotently", %{conn: conn} do
+    {_student_user, student} = eligible_student()
+    admin = user_fixture()
+    configuration_id = insert_prompt_configuration!()
+    insert_request!(admin.id, student.id, configuration_id, "completed-request")
+
+    running_params = %{"etl_run_id" => "etl-run-624", "state" => "running"}
+    running = post_status(conn, "completed-request", running_params)
+
+    assert running == %{
+             "error_code" => nil,
+             "error_message" => nil,
+             "etl_run_id" => "etl-run-624",
+             "state" => "running"
+           }
+
+    assert post_status(conn, "completed-request", running_params) == running
+
+    completed =
+      post_status(conn, "completed-request", %{
+        "etl_run_id" => "etl-run-624",
+        "state" => "completed"
+      })
+
+    assert completed["state"] == "completed"
+
+    assert post_status(conn, "completed-request", Map.put(running_params, "state", "completed")) ==
+             completed
+
+    assert Repo.query!("""
+           SELECT requested_by_user_id, student_id, prompt_configuration_id, request_key, force,
+                  state, etl_run_id
+           FROM holistic_mentorship_regeneration_requests
+           WHERE request_key = 'completed-request'
+           """).rows == [
+             [
+               admin.id,
+               student.id,
+               configuration_id,
+               "completed-request",
+               true,
+               "completed",
+               "etl-run-624"
+             ]
+           ]
+  end
+
+  test "supports failed completion and rejects regressions or ETL run conflicts", %{conn: conn} do
+    {_student_user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    admin_id = user_fixture().id
+
+    insert_request!(admin_id, student.id, configuration_id, "failed-request")
+    insert_request!(admin_id, student.id, configuration_id, "queued-request")
+
+    post_status(conn, "failed-request", %{"etl_run_id" => "etl-failed", "state" => "running"})
+
+    assert_status_error(
+      conn,
+      "failed-request",
+      %{"etl_run_id" => "other-run", "state" => "running"},
+      "etl_run_conflict"
+    )
+
+    failed_params = %{
+      "error_code" => "upstream_timeout",
+      "error_message" => "Upstream generation timed out",
+      "etl_run_id" => "etl-failed",
+      "state" => "failed"
+    }
+
+    failed = post_status(conn, "failed-request", failed_params)
+    assert failed["state"] == "failed"
+    assert post_status(conn, "failed-request", failed_params) == failed
+
+    assert_status_error(
+      conn,
+      "failed-request",
+      %{"etl_run_id" => "etl-failed", "state" => "completed"},
+      "terminal_status_conflict"
+    )
+
+    assert_status_error(
+      conn,
+      "queued-request",
+      %{"etl_run_id" => "etl-queued", "state" => "completed"},
+      "invalid_status_transition"
+    )
+  end
+
+  test "rejects an ineligible fetch without exposing sensitive identifiers or content", %{
+    conn: conn
+  } do
+    {student_user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_request!(user_fixture().id, student.id, configuration_id, "ineligible-request")
+    Repo.query!("UPDATE student SET status = 'dropout' WHERE id = $1", [student.id])
+
+    {response_conn, log} =
+      with_debug_log(fn ->
+        get(
+          conn,
+          "/api/holistic-mentorship/regeneration-requests/ineligible-request",
+          %{
+            "answers" => "private answers 624",
+            "source_user_id" => "private-source-624",
+            "summary" => "private summary 624"
+          }
+        )
+      end)
+
+    assert json_response(response_conn, 422) == %{
+             "error" => %{"code" => "dropout", "message" => "Student is not eligible"}
+           }
+
+    for sensitive <- [
+          Integer.to_string(student_user.id),
+          Integer.to_string(student.id),
+          "private answers 624",
+          "private-source-624",
+          "private summary 624"
+        ] do
+      refute response_conn.resp_body =~ sensitive
+      refute log =~ sensitive
+    end
+  end
+
+  test "rejects invalid and unbounded status metadata without changing the request", %{conn: conn} do
+    {_student_user, student} = eligible_student()
+    configuration_id = insert_prompt_configuration!()
+    insert_request!(user_fixture().id, student.id, configuration_id, "invalid-request")
+
+    for params <- [
+          %{"etl_run_id" => "etl-invalid", "state" => "queued"},
+          %{
+            "error_message" => String.duplicate("x", 501),
+            "etl_run_id" => "etl-invalid",
+            "state" => "failed"
+          }
+        ] do
+      assert conn
+             |> post(
+               "/api/holistic-mentorship/regeneration-requests/invalid-request/status",
+               params
+             )
+             |> json_response(422)
+             |> get_in(["error", "code"]) == "invalid_request"
+    end
+
+    assert Repo.query!(
+             "SELECT state, etl_run_id FROM holistic_mentorship_regeneration_requests WHERE request_key = 'invalid-request'"
+           ).rows == [["queued", nil]]
+  end
+
+  test "requires the existing Bearer token for both Regeneration Request routes" do
+    assert build_conn()
+           |> get("/api/holistic-mentorship/regeneration-requests/request-624")
+           |> response(401) == "Not Authorized"
+
+    assert build_conn()
+           |> post("/api/holistic-mentorship/regeneration-requests/request-624/status", %{})
+           |> response(401) == "Not Authorized"
+  end
+
+  defp eligible_student do
+    grade = grade_fixture(%{number: 11})
+    {user, student} = student_fixture(%{grade_id: grade.id, status: "active"})
+    school = school_fixture(%{program_ids: [1], code: "school-#{user.id}"})
+
+    enroll(user.id, "school", school.id)
+    enroll(user.id, "program", 1)
+    enroll(user.id, "grade", grade.id)
+
+    {user, student}
+  end
+
+  defp enroll(user_id, group_type, group_id) do
+    {:ok, _enrollment} =
+      Dbservice.EnrollmentRecords.create_enrollment_record(%{
+        user_id: user_id,
+        group_id: group_id,
+        group_type: group_type,
+        academic_year: "2026-27",
+        start_date: ~D[2026-06-01],
+        is_current: true
+      })
+  end
+
+  defp insert_prompt_configuration! do
+    [[prompt_version_id]] =
+      Repo.query!("""
+      INSERT INTO holistic_mentorship_prompt_versions (version, template_text, template_hash)
+      VALUES ('regeneration-v1', 'abc',
+              'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
+      RETURNING id
+      """).rows
+
+    [[configuration_id]] =
+      Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_prompt_configurations (prompt_version_id, model_id)
+        VALUES ($1, 'openai/gpt-5-mini')
+        RETURNING id
+        """,
+        [prompt_version_id]
+      ).rows
+
+    configuration_id
+  end
+
+  defp insert_request!(admin_id, student_id, configuration_id, request_key) do
+    Repo.query!(
+      """
+      INSERT INTO holistic_mentorship_regeneration_requests
+        (request_key, requested_by_user_id, student_id, prompt_configuration_id, force, state)
+      VALUES ($1, $2, $3, $4, true, 'queued')
+      """,
+      [request_key, admin_id, student_id, configuration_id]
+    )
+  end
+
+  defp post_status(conn, request_key, params) do
+    conn
+    |> post("/api/holistic-mentorship/regeneration-requests/#{request_key}/status", params)
+    |> json_response(200)
+  end
+
+  defp assert_status_error(conn, request_key, params, code) do
+    assert conn
+           |> post("/api/holistic-mentorship/regeneration-requests/#{request_key}/status", params)
+           |> json_response(409)
+           |> get_in(["error", "code"]) == code
+  end
+
+  defp with_debug_log(operation) do
+    previous_level = Logger.level()
+    Logger.configure(level: :debug)
+
+    try do
+      with_log([level: :debug], operation)
+    after
+      Logger.configure(level: previous_level)
+    end
+  end
+
+  defp assert_check_violation(operation) do
+    assert {:error, {:error, %Postgrex.Error{postgres: %{code: :check_violation}}}} =
+             Repo.transaction(fn -> Repo.rollback(operation.()) end, mode: :savepoint)
+  end
+
+  defp assert_unique_violation(operation) do
+    assert {:error, {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}}} =
+             Repo.transaction(fn -> Repo.rollback(operation.()) end, mode: :savepoint)
+  end
+end

--- a/test/dbservice_web/controllers/holistic_mentorship_regeneration_request_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_regeneration_request_controller_test.exs
@@ -246,7 +246,6 @@ defmodule DbserviceWeb.HolisticMentorshipRegenerationRequestControllerTest do
     school = school_fixture(%{program_ids: [1], code: "school-#{user.id}"})
 
     enroll(user.id, "school", school.id)
-    enroll(user.id, "program", 1)
     enroll(user.id, "grade", grade.id)
 
     {user, student}

--- a/test/dbservice_web/controllers/student_controller_test.exs
+++ b/test/dbservice_web/controllers/student_controller_test.exs
@@ -127,6 +127,22 @@ defmodule DbserviceWeb.StudentControllerTest do
       conn = put(conn, ~p"/api/student/#{student.id}", @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end
+
+    test "ends an active Holistic Mapping when status becomes dropout", %{
+      conn: conn,
+      student: student
+    } do
+      mapping_id = insert_active_mapping(student.id)
+
+      conn = put(conn, ~p"/api/student/#{student.id}", %{status: "dropout"})
+
+      assert json_response(conn, 200)["status"] == "dropout"
+
+      assert Dbservice.Repo.query!(
+               "SELECT end_reason FROM holistic_mentorship_mentor_mentee_mappings WHERE id = $1",
+               [mapping_id]
+             ).rows == [["student_dropout"]]
+    end
   end
 
   describe "delete student" do
@@ -145,5 +161,39 @@ defmodule DbserviceWeb.StudentControllerTest do
   defp create_student(_) do
     {_user, student} = student_fixture()
     %{student: student}
+  end
+
+  defp insert_active_mapping(student_id) do
+    mentor = user_fixture()
+
+    [[school_id]] =
+      Dbservice.Repo.query!(
+        "INSERT INTO school (inserted_at, updated_at) VALUES (now(), now()) RETURNING id"
+      ).rows
+
+    [[product_id]] =
+      Dbservice.Repo.query!(
+        "INSERT INTO product (name, inserted_at, updated_at) VALUES ('HTTP Cleanup', now(), now()) RETURNING id"
+      ).rows
+
+    [[program_id]] =
+      Dbservice.Repo.query!(
+        "INSERT INTO program (name, product_id, inserted_at, updated_at) VALUES ('HTTP Cleanup', $1, now(), now()) RETURNING id",
+        [product_id]
+      ).rows
+
+    [[mapping_id]] =
+      Dbservice.Repo.query!(
+        """
+        INSERT INTO holistic_mentorship_mentor_mentee_mappings
+          (student_id, mentor_user_id, school_id, program_id, academic_year, started_at,
+           assignment_source)
+        VALUES ($1, $2, $3, $4, '2026-27', timezone('UTC', now()), 'af_lms')
+        RETURNING id
+        """,
+        [student_id, mentor.id, school_id, program_id]
+      ).rows
+
+    mapping_id
   end
 end

--- a/test/support/fixtures/users_fixtures.ex
+++ b/test/support/fixtures/users_fixtures.ex
@@ -44,7 +44,7 @@ defmodule Dbservice.UsersFixtures do
     {:ok, student} =
       attrs
       |> Enum.into(%{
-        student_id: "some student id",
+        student_id: "some student id #{System.unique_integer([:positive])}",
         category: "Gen",
         father_name: "some father_name",
         father_phone: "some father_phone",

--- a/utils/README.md
+++ b/utils/README.md
@@ -39,7 +39,9 @@ FETCH_ENVIRONMENT=production
 TARGET_ENVIRONMENT=staging
 ```
 
-Staging sync skips data for `session`, `session_occurrence`, `group_session`, and `user_session`.
+Staging sync skips data for `session`, `session_occurrence`, `group_session`,
+`user_session`, and every table matching `public.holistic_mentorship_*`.
+Production-to-local syncs do not apply these staging-only exclusions.
 
 ### Configuration
 

--- a/utils/fetch-data.sh
+++ b/utils/fetch-data.sh
@@ -54,7 +54,7 @@ check_required_var "FETCH_ENVIRONMENT" "$FETCH_ENVIRONMENT"
 LOCAL_DB_PORT=${LOCAL_DB_PORT:-5432}
 DUMP_FILE=${DUMP_FILE:-dump.sql}
 TARGET_ENVIRONMENT=${TARGET_ENVIRONMENT:-local}
-STAGING_EXCLUDED_TABLE_DATA=(public.session public.session_occurrence public.group_session public.user_session)
+STAGING_EXCLUDED_TABLE_DATA=(public.session public.session_occurrence public.group_session public.user_session 'public.holistic_mentorship_*')
 
 # Validate source environment and set database credentials
 if [ "$FETCH_ENVIRONMENT" == "production" ]; then


### PR DESCRIPTION
## Summary

- Adds the database tables and rules for phase plans, mentor assignments, notes, prompt settings, student profiles, profile jobs, and retry requests.
- Adds protected APIs that ETL uses to check students, manage prompt settings, track profile jobs, save complete profiles, and process retry requests.
- When a student leaves or changes grade, school, or program, their current mentor assignment ends in the same database update.
- Keeps Holistic Mentorship row data out of production-to-staging copies.
- Includes focused tests and clear rollout, monitoring, and rollback instructions.

## Linked Issues

- Closes #615
- Closes #616
- Closes #617
- Closes #618
- Closes #619
- Closes #620
- Closes #621
- Closes #622
- Closes #623
- Closes #624
- Closes #625
- Closes #626
- Closes #627
- Closes #628
- Closes #629

## Final Review

- Spec and standards review passed with no Holistic Mentorship gaps identified.
- `git diff --check holistic_mentorship...HEAD` and `mix check` passed.
- All Holistic Mentorship tests passed.
- Full `mix test` remains non-zero only for the exact eight failures reproduced on unchanged `main`: one ErrorJSON wording assertion, four GroupUpdateProcessor error-message assertions, one EnrollmentService school-enrollment assertion, and two StudentController status assertions.
- Accepted under Deepansh's 2026-07-16 release waiver recorded on #615; the waiver covers only those eight unchanged-main failures.
