### PR TITLE
fix(api): enforce default and max pagination limits on list endpoints

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -10,6 +10,12 @@ import Config
 config :dbservice,
   ecto_repos: [Dbservice.Repo]
 
+# Pagination guardrails for list endpoints: applied when no `limit` query
+# param is given (default_limit) and as a hard cap when one is (max_limit).
+config :dbservice, Dbservice.Utils.Pagination,
+  default_limit: 1000,
+  max_limit: 10_000
+
 # Configures the endpoint
 config :dbservice, DbserviceWeb.Endpoint,
   load_from_system_env: false,

--- a/lib/dbservice/resources.ex
+++ b/lib/dbservice/resources.ex
@@ -12,6 +12,7 @@ defmodule Dbservice.Resources do
   alias Dbservice.Languages.Language
   alias Dbservice.Resources.{ResourceTopic, ResourceChapter, ResourceConcept}
   alias Dbservice.Utils.Util
+  alias Dbservice.Utils.Pagination
   alias Dbservice.CmsStatuses
   alias Dbservice.Chapters.Chapter
   alias Dbservice.Topics.Topic
@@ -1207,13 +1208,10 @@ defmodule Dbservice.Resources do
 
   defp apply_pagination(query, params) do
     from(r in query,
-      offset: ^get_offset(params),
-      limit: ^get_limit(params)
+      offset: ^Pagination.offset(params),
+      limit: ^Pagination.limit(params)
     )
   end
-
-  defp get_offset(params), do: params["offset"]
-  defp get_limit(params), do: params["limit"]
 
   @doc """
   Searches for problems with optional filtering, sorting and pagination.
@@ -1365,8 +1363,8 @@ defmodule Dbservice.Resources do
 
   defp apply_problem_pagination(query, params) do
     from(pl in query,
-      offset: ^get_offset(params),
-      limit: ^get_limit(params)
+      offset: ^Pagination.offset(params),
+      limit: ^Pagination.limit(params)
     )
   end
 end

--- a/lib/dbservice/utils/pagination.ex
+++ b/lib/dbservice/utils/pagination.ex
@@ -1,0 +1,63 @@
+defmodule Dbservice.Utils.Pagination do
+  @moduledoc """
+  Sanitizes `offset`/`limit` query params for list endpoints.
+
+  Every list endpoint gets a default page size when no `limit` is given and a
+  hard cap when one is, so a single request can never ask the database for an
+  unbounded number of rows (e.g. `?limit=100000`).
+
+  Limits are configurable:
+
+      config :dbservice, Dbservice.Utils.Pagination,
+        default_limit: 1000,
+        max_limit: 10_000
+  """
+
+  @default_limit 1000
+  @max_limit 10_000
+
+  @doc """
+  Returns a sane limit from request params (or a raw param value).
+
+  Missing or unparseable values fall back to the default limit; values above
+  the max limit are clamped down to it; values below 1 become 1.
+  """
+  def limit(params) when is_map(params), do: params |> Map.get("limit") |> limit()
+
+  def limit(value) do
+    value
+    |> to_int(default_limit())
+    |> min(max_limit())
+    |> max(1)
+  end
+
+  @doc """
+  Returns a sane offset from request params (or a raw param value).
+
+  Missing, unparseable or negative values become 0.
+  """
+  def offset(params) when is_map(params), do: params |> Map.get("offset") |> offset()
+
+  def offset(value), do: value |> to_int(0) |> max(0)
+
+  def default_limit, do: config(:default_limit, @default_limit)
+
+  def max_limit, do: config(:max_limit, @max_limit)
+
+  defp config(key, default) do
+    :dbservice
+    |> Application.get_env(__MODULE__, [])
+    |> Keyword.get(key, default)
+  end
+
+  defp to_int(value, _default) when is_integer(value), do: value
+
+  defp to_int(value, default) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, ""} -> int
+      _ -> default
+    end
+  end
+
+  defp to_int(_, default), do: default
+end

--- a/lib/dbservice_web/controllers/alumni_controller.ex
+++ b/lib/dbservice_web/controllers/alumni_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.AlumniController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Alumnis
@@ -36,8 +38,8 @@ defmodule DbserviceWeb.AlumniController do
     query =
       from(m in Alumni,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/auth_group_controller.ex
+++ b/lib/dbservice_web/controllers/auth_group_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.AuthGroupController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.AuthGroups
@@ -37,8 +39,8 @@ defmodule DbserviceWeb.AuthGroupController do
     query =
       from m in AuthGroup,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
 
     query =
       Enum.reduce(params, query, fn {key, value}, acc ->

--- a/lib/dbservice_web/controllers/batch_controller.ex
+++ b/lib/dbservice_web/controllers/batch_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.BatchController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Batches
@@ -37,8 +39,8 @@ defmodule DbserviceWeb.BatchController do
     query =
       from(m in Batch,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/branch_controller.ex
+++ b/lib/dbservice_web/controllers/branch_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.BranchController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Branches
@@ -34,8 +36,8 @@ defmodule DbserviceWeb.BranchController do
     query =
       from(b in Branch,
         order_by: [asc: b.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/candidate_controller.ex
+++ b/lib/dbservice_web/controllers/candidate_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.CandidateController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Users
@@ -38,8 +40,8 @@ defmodule DbserviceWeb.CandidateController do
     query =
       from m in Candidate,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
 
     query =
       Enum.reduce(params, query, fn {key, value}, acc ->

--- a/lib/dbservice_web/controllers/chapter_controller.ex
+++ b/lib/dbservice_web/controllers/chapter_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.ChapterController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Chapters
@@ -43,8 +45,8 @@ defmodule DbserviceWeb.ChapterController do
     base_query =
       from(m in Chapter,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/chapter_curriculum_controller.ex
+++ b/lib/dbservice_web/controllers/chapter_curriculum_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.ChapterCurriculumController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.ChapterCurriculums.ChapterCurriculum
@@ -34,8 +36,8 @@ defmodule DbserviceWeb.ChapterCurriculumController do
     query =
       from(cc in ChapterCurriculum,
         order_by: [asc: cc.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/cms_status_controller.ex
+++ b/lib/dbservice_web/controllers/cms_status_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.CmsStatusController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.CmsStatuses
@@ -36,8 +38,8 @@ defmodule DbserviceWeb.CmsStatusController do
     query =
       from(m in CmsStatus,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/college_controller.ex
+++ b/lib/dbservice_web/controllers/college_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.CollegeController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Colleges
@@ -33,8 +35,8 @@ defmodule DbserviceWeb.CollegeController do
     query =
       from(m in College,
         order_by: [asc: m.college_id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/concept_controller.ex
+++ b/lib/dbservice_web/controllers/concept_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.ConceptController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Concepts
@@ -36,8 +38,8 @@ defmodule DbserviceWeb.ConceptController do
     query =
       from(m in Concept,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/curriculum_controller.ex
+++ b/lib/dbservice_web/controllers/curriculum_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.CurriculumController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Curriculums
@@ -38,8 +40,8 @@ defmodule DbserviceWeb.CurriculumController do
     query =
       from(m in Curriculum,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/cutoff_controller.ex
+++ b/lib/dbservice_web/controllers/cutoff_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.CutoffController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Cutoffs
@@ -37,8 +39,8 @@ defmodule DbserviceWeb.CutoffController do
     query =
       from(c in Cutoff,
         order_by: [asc: c.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"],
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params),
         preload: [:exam_occurrence, :college, :branch, :demographic_profile]
       )
 

--- a/lib/dbservice_web/controllers/demographic_profile_controller.ex
+++ b/lib/dbservice_web/controllers/demographic_profile_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.DemographicProfileController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Demographics
@@ -34,8 +36,8 @@ defmodule DbserviceWeb.DemographicProfileController do
     query =
       from(dp in DemographicProfile,
         order_by: [asc: dp.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/enrollment_record_controller.ex
+++ b/lib/dbservice_web/controllers/enrollment_record_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.EnrollmentRecordController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.EnrollmentRecords.EnrollmentRecord
@@ -46,8 +48,8 @@ defmodule DbserviceWeb.EnrollmentRecordController do
     query =
       from(m in EnrollmentRecord,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/exam_controller.ex
+++ b/lib/dbservice_web/controllers/exam_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.ExamController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Exams
@@ -33,8 +35,8 @@ defmodule DbserviceWeb.ExamController do
     query =
       from(m in Exam,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"],
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params),
         preload: [:exam_occurrences]
       )
 

--- a/lib/dbservice_web/controllers/exam_occurrence_controller.ex
+++ b/lib/dbservice_web/controllers/exam_occurrence_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.ExamOccurrenceController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Exams
@@ -34,8 +36,8 @@ defmodule DbserviceWeb.ExamOccurrenceController do
     query =
       from(eo in ExamOccurrence,
         order_by: [asc: eo.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/form_schema_controller.ex
+++ b/lib/dbservice_web/controllers/form_schema_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.FormSchemaController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.FormSchemas
@@ -33,8 +35,8 @@ defmodule DbserviceWeb.FormSchemaController do
     query =
       from(m in FormSchema,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/grade_controller.ex
+++ b/lib/dbservice_web/controllers/grade_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.GradeController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Grades
@@ -36,8 +38,8 @@ defmodule DbserviceWeb.GradeController do
     query =
       from(m in Grade,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/group_controller.ex
+++ b/lib/dbservice_web/controllers/group_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.GroupController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Groups
@@ -46,8 +48,8 @@ defmodule DbserviceWeb.GroupController do
     query =
       from m in Group,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
 
     query =
       Enum.reduce(params, query, fn {key, value}, acc ->

--- a/lib/dbservice_web/controllers/group_session_controller.ex
+++ b/lib/dbservice_web/controllers/group_session_controller.ex
@@ -4,6 +4,8 @@ defmodule DbserviceWeb.GroupSessionController do
   alias Dbservice.Groups
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.GroupSessions
@@ -32,8 +34,8 @@ defmodule DbserviceWeb.GroupSessionController do
     query =
       from m in GroupSession,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
 
     query =
       Enum.reduce(params, query, fn {key, value}, acc ->

--- a/lib/dbservice_web/controllers/group_user_controller.ex
+++ b/lib/dbservice_web/controllers/group_user_controller.ex
@@ -3,6 +3,8 @@ defmodule DbserviceWeb.GroupUserController do
   alias Dbservice.Services.GroupUpdateService
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.GroupUsers
@@ -31,8 +33,8 @@ defmodule DbserviceWeb.GroupUserController do
     query =
       from(m in GroupUser,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/language_controller.ex
+++ b/lib/dbservice_web/controllers/language_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.LanguageController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Languages
@@ -33,8 +35,8 @@ defmodule DbserviceWeb.LanguageController do
     query =
       from(m in Language,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/learning_objective_controller.ex
+++ b/lib/dbservice_web/controllers/learning_objective_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.LearningObjectiveController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.LearningObjectives
@@ -36,8 +38,8 @@ defmodule DbserviceWeb.LearningObjectiveController do
     query =
       from(m in LearningObjective,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/paragraph_controller.ex
+++ b/lib/dbservice_web/controllers/paragraph_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.ParagraphController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Paragraphs
@@ -29,8 +31,8 @@ defmodule DbserviceWeb.ParagraphController do
     query =
       from(m in Paragraph,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/problem_language_controller.ex
+++ b/lib/dbservice_web/controllers/problem_language_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.ProblemLanguageController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.ProblemLanguages
@@ -38,8 +40,8 @@ defmodule DbserviceWeb.ProblemLanguageController do
     query =
       from(m in ProblemLanguage,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"],
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params),
         preload: [:paragraph, :resource]
       )
 

--- a/lib/dbservice_web/controllers/product_controller.ex
+++ b/lib/dbservice_web/controllers/product_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.ProductController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Products
@@ -31,8 +33,8 @@ defmodule DbserviceWeb.ProductController do
     query =
       from m in Product,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
 
     query =
       Enum.reduce(params, query, fn {key, value}, acc ->

--- a/lib/dbservice_web/controllers/program_controller.ex
+++ b/lib/dbservice_web/controllers/program_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.ProgramController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Programs
@@ -36,8 +38,8 @@ defmodule DbserviceWeb.ProgramController do
     query =
       from m in Program,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
 
     query =
       Enum.reduce(params, query, fn {key, value}, acc ->

--- a/lib/dbservice_web/controllers/purpose_controller.ex
+++ b/lib/dbservice_web/controllers/purpose_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.PurposeController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Purposes
@@ -36,8 +38,8 @@ defmodule DbserviceWeb.PurposeController do
     query =
       from(m in Purpose,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/resource_chapter_controller.ex
+++ b/lib/dbservice_web/controllers/resource_chapter_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.ResourceChapterController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.ResourceChapters
@@ -38,8 +40,8 @@ defmodule DbserviceWeb.ResourceChapterController do
     query =
       from(m in ResourceChapter,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/resource_concept_controller.ex
+++ b/lib/dbservice_web/controllers/resource_concept_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.ResourceConceptController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.ResourceConcepts
@@ -38,8 +40,8 @@ defmodule DbserviceWeb.ResourceConceptController do
     query =
       from(m in ResourceConcept,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/resource_controller.ex
+++ b/lib/dbservice_web/controllers/resource_controller.ex
@@ -18,6 +18,7 @@ defmodule DbserviceWeb.ResourceController do
   alias Dbservice.Resources.ResourceTopic
   alias Dbservice.TopicCurriculums.TopicCurriculum
   alias Dbservice.Topics.Topic
+  alias Dbservice.Utils.Pagination
 
   action_fallback(DbserviceWeb.FallbackController)
 
@@ -981,21 +982,7 @@ defmodule DbserviceWeb.ResourceController do
   defp filter_by_subtype(query, _), do: query
 
   defp apply_pagination(query, params) do
-    case Map.get(params, "limit") do
-      nil ->
-        query
-
-      limit_str ->
-        limit = String.to_integer(limit_str)
-
-        offset =
-          case Map.get(params, "offset") do
-            nil -> 0
-            offset_str -> String.to_integer(offset_str)
-          end
-
-        from(r in query, limit: ^limit, offset: ^offset)
-    end
+    from(r in query, limit: ^Pagination.limit(params), offset: ^Pagination.offset(params))
   end
 
   swagger_path :test_problems do

--- a/lib/dbservice_web/controllers/resource_curriculum_controller.ex
+++ b/lib/dbservice_web/controllers/resource_curriculum_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.ResourceCurriculumController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.ResourceCurriculums
@@ -38,8 +40,8 @@ defmodule DbserviceWeb.ResourceCurriculumController do
     query =
       from(m in ResourceCurriculum,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/resource_topic_controller.ex
+++ b/lib/dbservice_web/controllers/resource_topic_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.ResourceTopicController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.ResourceTopics
@@ -38,8 +40,8 @@ defmodule DbserviceWeb.ResourceTopicController do
     query =
       from(m in ResourceTopic,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/school_batch_controller.ex
+++ b/lib/dbservice_web/controllers/school_batch_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.SchoolBatchController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.SchoolBatches
@@ -35,8 +37,8 @@ defmodule DbserviceWeb.SchoolBatchController do
     query =
       from(m in SchoolBatch,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/school_controller.ex
+++ b/lib/dbservice_web/controllers/school_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.SchoolController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Schools
@@ -47,8 +49,8 @@ defmodule DbserviceWeb.SchoolController do
     query =
       from m in School,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
 
     query =
       Enum.reduce(params, query, fn {key, value}, acc ->

--- a/lib/dbservice_web/controllers/session_controller.ex
+++ b/lib/dbservice_web/controllers/session_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.SessionController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Sessions
@@ -138,8 +140,8 @@ defmodule DbserviceWeb.SessionController do
 
     from m in Session,
       order_by: [{^sort_order, m.id}],
-      offset: ^params["offset"],
-      limit: ^params["limit"]
+      offset: ^Pagination.offset(params),
+      limit: ^Pagination.limit(params)
   end
 
   defp apply_session_id_null_filter(value, acc) do

--- a/lib/dbservice_web/controllers/session_occurence_controller.ex
+++ b/lib/dbservice_web/controllers/session_occurence_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.SessionOccurrenceController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Sessions
@@ -100,8 +102,8 @@ defmodule DbserviceWeb.SessionOccurrenceController do
     base_query =
       from(m in SessionOccurrence,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     params

--- a/lib/dbservice_web/controllers/skill_controller.ex
+++ b/lib/dbservice_web/controllers/skill_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.SkillController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Skills
@@ -33,8 +35,8 @@ defmodule DbserviceWeb.SkillController do
     query =
       from(m in Skill,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/status_controller.ex
+++ b/lib/dbservice_web/controllers/status_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.StatusController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Statuses
@@ -36,8 +38,8 @@ defmodule DbserviceWeb.StatusController do
     query =
       from(m in Status,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/student_controller.ex
+++ b/lib/dbservice_web/controllers/student_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.StudentController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Users.User
@@ -76,8 +78,8 @@ defmodule DbserviceWeb.StudentController do
     query =
       from(m in Student,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/student_exam_record_controller.ex
+++ b/lib/dbservice_web/controllers/student_exam_record_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.StudentExamRecordController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.StudentExamRecords
@@ -34,8 +36,8 @@ defmodule DbserviceWeb.StudentExamRecordController do
     query =
       from(m in StudentExamRecord,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/student_profile_controller.ex
+++ b/lib/dbservice_web/controllers/student_profile_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.StudentProfileController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Users
@@ -43,8 +45,8 @@ defmodule DbserviceWeb.StudentProfileController do
     query =
       from m in StudentProfile,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
 
     query =
       Enum.reduce(params, query, fn {key, value}, acc ->

--- a/lib/dbservice_web/controllers/subject_controller.ex
+++ b/lib/dbservice_web/controllers/subject_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.SubjectController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Subjects
@@ -41,8 +43,8 @@ defmodule DbserviceWeb.SubjectController do
     query =
       from(m in Subject,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/tag_controller.ex
+++ b/lib/dbservice_web/controllers/tag_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.TagController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Tags
@@ -38,8 +40,8 @@ defmodule DbserviceWeb.TagController do
     query =
       from m in Tag,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
 
     query =
       Enum.reduce(params, query, fn {key, value}, acc ->

--- a/lib/dbservice_web/controllers/teacher_controller.ex
+++ b/lib/dbservice_web/controllers/teacher_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.TeacherController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Users
@@ -44,8 +46,8 @@ defmodule DbserviceWeb.TeacherController do
     query =
       from m in Teacher,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
 
     query =
       Enum.reduce(params, query, fn {key, value}, acc ->

--- a/lib/dbservice_web/controllers/teacher_profile_controller.ex
+++ b/lib/dbservice_web/controllers/teacher_profile_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.TeacherProfileController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Users
@@ -43,8 +45,8 @@ defmodule DbserviceWeb.TeacherProfileController do
     query =
       from m in TeacherProfile,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
 
     query =
       Enum.reduce(params, query, fn {key, value}, acc ->

--- a/lib/dbservice_web/controllers/test_rule_controller.ex
+++ b/lib/dbservice_web/controllers/test_rule_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.TestRuleController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.TestRules
@@ -36,8 +38,8 @@ defmodule DbserviceWeb.TestRuleController do
     query =
       from(tr in TestRule,
         order_by: [asc: tr.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/topic_controller.ex
+++ b/lib/dbservice_web/controllers/topic_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.TopicController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Topics
@@ -42,8 +44,8 @@ defmodule DbserviceWeb.TopicController do
     query =
       from(m in Topic,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     # |> Ecto.Query.preload(:tag)

--- a/lib/dbservice_web/controllers/topic_curriculum_controller.ex
+++ b/lib/dbservice_web/controllers/topic_curriculum_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.TopicCurriculumController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.TopicCurriculums.TopicCurriculum
@@ -34,8 +36,8 @@ defmodule DbserviceWeb.TopicCurriculumController do
     query =
       from(cc in TopicCurriculum,
         order_by: [asc: cc.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/user_controller.ex
+++ b/lib/dbservice_web/controllers/user_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.UserController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Users
@@ -45,8 +47,8 @@ defmodule DbserviceWeb.UserController do
     query =
       from m in User,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
 
     query =
       Enum.reduce(params, query, fn {key, value}, acc ->

--- a/lib/dbservice_web/controllers/user_profile_controller.ex
+++ b/lib/dbservice_web/controllers/user_profile_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.UserProfileController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Profiles
@@ -40,8 +42,8 @@ defmodule DbserviceWeb.UserProfileController do
     query =
       from(m in UserProfile,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
       )
 
     query =

--- a/lib/dbservice_web/controllers/user_session_controller.ex
+++ b/lib/dbservice_web/controllers/user_session_controller.ex
@@ -1,6 +1,8 @@
 defmodule DbserviceWeb.UserSessionController do
   use DbserviceWeb, :controller
 
+  alias Dbservice.Utils.Pagination
+
   import Ecto.Query
   alias Dbservice.Repo
   alias Dbservice.Sessions
@@ -43,8 +45,8 @@ defmodule DbserviceWeb.UserSessionController do
     query =
       from m in UserSession,
         order_by: [asc: m.id],
-        offset: ^params["offset"],
-        limit: ^params["limit"]
+        offset: ^Pagination.offset(params),
+        limit: ^Pagination.limit(params)
 
     query =
       Enum.reduce(params, query, fn {key, value}, acc ->

--- a/test/dbservice/resources_test.exs
+++ b/test/dbservice/resources_test.exs
@@ -132,4 +132,55 @@ defmodule Dbservice.ResourcesTest do
       assert Enum.map(result, & &1.resource.id) == ordered_ids
     end
   end
+
+  describe "list_resources/1 and search_problems/1 pagination limits" do
+    setup do
+      # Shrink the guardrails so a handful of rows is enough to observe the cap.
+      original = Application.get_env(:dbservice, Dbservice.Utils.Pagination)
+
+      Application.put_env(:dbservice, Dbservice.Utils.Pagination,
+        default_limit: 2,
+        max_limit: 3
+      )
+
+      on_exit(fn ->
+        case original do
+          nil -> Application.delete_env(:dbservice, Dbservice.Utils.Pagination)
+          env -> Application.put_env(:dbservice, Dbservice.Utils.Pagination, env)
+        end
+      end)
+
+      :ok
+    end
+
+    test "list_resources caps the row count regardless of the requested limit" do
+      for _ <- 1..5, do: resource_fixture("video")
+
+      # An over-max limit (e.g. ?limit=100000) is clamped to max_limit, not honored verbatim.
+      assert length(Resources.list_resources(%{"limit" => "100000"})) == 3
+
+      # With no limit given, the default limit applies.
+      assert length(Resources.list_resources(%{})) == 2
+    end
+
+    test "search_problems caps the row count regardless of the requested limit" do
+      {:ok, language} =
+        Dbservice.Languages.create_language(%{"name" => "Cap Test", "code" => "zct"})
+
+      for _ <- 1..5 do
+        resource = resource_fixture("problem")
+
+        {:ok, _problem_lang} =
+          Dbservice.ProblemLanguages.create_problem_language(%{
+            "res_id" => resource.id,
+            "lang_id" => language.id,
+            "meta_data" => %{}
+          })
+      end
+
+      # The problem search runs extra per-row queries, so the cap matters most here.
+      assert length(Resources.search_problems(%{"limit" => "100000"})) == 3
+      assert length(Resources.search_problems(%{})) == 2
+    end
+  end
 end

--- a/test/dbservice/utils/pagination_test.exs
+++ b/test/dbservice/utils/pagination_test.exs
@@ -1,0 +1,49 @@
+defmodule Dbservice.Utils.PaginationTest do
+  use ExUnit.Case, async: true
+
+  alias Dbservice.Utils.Pagination
+
+  describe "limit/1" do
+    test "falls back to the default limit when the param is missing" do
+      assert Pagination.limit(%{}) == Pagination.default_limit()
+      assert Pagination.limit(%{"limit" => nil}) == Pagination.default_limit()
+    end
+
+    test "parses string and integer values" do
+      assert Pagination.limit(%{"limit" => "50"}) == 50
+      assert Pagination.limit(%{"limit" => 50}) == 50
+    end
+
+    test "clamps values above the max limit" do
+      assert Pagination.limit(%{"limit" => "100000"}) == Pagination.max_limit()
+      assert Pagination.limit(%{"limit" => 100_000}) == Pagination.max_limit()
+    end
+
+    test "clamps values below 1" do
+      assert Pagination.limit(%{"limit" => "0"}) == 1
+      assert Pagination.limit(%{"limit" => "-5"}) == 1
+    end
+
+    test "falls back to the default limit for unparseable values" do
+      assert Pagination.limit(%{"limit" => "abc"}) == Pagination.default_limit()
+      assert Pagination.limit(%{"limit" => "12abc"}) == Pagination.default_limit()
+    end
+  end
+
+  describe "offset/1" do
+    test "defaults to 0 when the param is missing" do
+      assert Pagination.offset(%{}) == 0
+      assert Pagination.offset(%{"offset" => nil}) == 0
+    end
+
+    test "parses string and integer values" do
+      assert Pagination.offset(%{"offset" => "20"}) == 20
+      assert Pagination.offset(%{"offset" => 20}) == 20
+    end
+
+    test "clamps negative and unparseable values to 0" do
+      assert Pagination.offset(%{"offset" => "-10"}) == 0
+      assert Pagination.offset(%{"offset" => "abc"}) == 0
+    end
+  end
+end


### PR DESCRIPTION
## Context

Prod went down today (2026-07-17) when a bot hit `GET /api/student?offset=0&limit=100000` and the Phoenix service hung trying to serve it. List endpoints passed the raw `limit`/`offset` query params straight into Ecto queries — no cap, and **no limit at all** when the param was omitted.

## Change

New `Dbservice.Utils.Pagination` module, applied to **all 52 controllers** that accept `offset`/`limit`:

| Input | Behavior |
|---|---|
| No `limit` param | default limit **1000** |
| `limit=100000` | clamped to max **10000** |
| `limit=0`, `limit=-5` | clamped to 1 |
| `limit=abc` (previously a 500) | falls back to default |
| `offset` missing / negative / garbage | 0 |

Limits are configurable in one place:

```elixir
config :dbservice, Dbservice.Utils.Pagination,
  default_limit: 1000,
  max_limit: 10_000
```

Also fixes `ResourceController.apply_pagination/2`, which skipped pagination entirely when `limit` was absent.

## ⚠️ Behavior change for consumers

Any client calling a list endpoint **without a `limit` param currently gets every row — after this it gets at most 1000**. Clients that genuinely need everything must paginate with `offset`/`limit` (max 10000 per page). If any known consumer (portal, Gurukul, ETL jobs) relies on fetch-all behavior, we should bump `default_limit` or fix that consumer before merging.

## Testing

- `mix test test/dbservice/utils/pagination_test.exs` — 8 new tests, all green
- `mix compile --warnings-as-errors`, `mix credo`, `mix format --check-formatted` all clean
- Verified generated SQL via `Repo.to_sql`: `limit=100000` → `LIMIT 10000`; no param → `LIMIT 1000`; `limit=50&offset=100` passes through untouched
- Full `mix test`: 8 failures, all pre-existing on main (enrollment service / group update processor / student create status codes — unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)