### PR TITLE
Biweekly LLM-generated release notes (release runner)

### DIFF
--- a/.github/workflows/biweekly-release.yml
+++ b/.github/workflows/biweekly-release.yml
@@ -1,0 +1,133 @@
+name: Biweekly Release
+
+# Biweekly LLM-written release notes (see avantifellows/af_lms#219 for the decision record).
+# GitHub cron can't express "every 14 days", so a weekly cron fires and the
+# gate step runs the job only on odd epoch-weeks: Jul 27 2026, Aug 10, … .
+# Manual runs bypass the gate. Local run:
+#   act workflow_dispatch -W .github/workflows/biweekly-release.yml \
+#     --secret-file .secrets --input provider=openrouter \
+#     -P ubuntu-latest=catthehacker/ubuntu:act-latest
+
+on:
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: LLM provider
+        type: choice
+        options: [anthropic, openrouter]
+        default: anthropic
+      window_days:
+        description: Days of history to include
+        default: "14"
+      thinking:
+        description: Thinking effort (off/minimal/low/medium/high/xhigh/max)
+        default: medium
+      dry_run:
+        description: Generate notes but skip the release and Discord post
+        type: boolean
+        default: false
+  schedule:
+    - cron: "30 3 * * 1" # Mondays 09:00 IST; gate skips every other week
+
+permissions:
+  contents: write
+
+jobs:
+  biweekly-release:
+    runs-on: ubuntu-latest
+    env:
+      GH_REPO: ${{ github.repository }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Biweekly gate
+        id: gate
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || \
+             [ $(( $(date +%s) / 86400 / 7 % 2 )) -eq 1 ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Off week — the biweekly cadence runs next Monday. Skipping."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.gate.outputs.run == 'true'
+
+      - name: Ensure gh and jq (preinstalled on hosted runners; act image lacks gh)
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          command -v jq >/dev/null || { sudo apt-get update -qq && sudo apt-get install -y -qq jq; }
+          if ! command -v gh >/dev/null; then
+            curl -fsSL https://github.com/cli/cli/releases/download/v2.86.0/gh_2.86.0_linux_amd64.tar.gz | tar -xz -C /tmp
+            sudo mv /tmp/gh_*/bin/gh /usr/local/bin/gh
+          fi
+
+      - name: Gather the release window's work
+        id: gather
+        if: steps.gate.outputs.run == 'true'
+        env:
+          WINDOW_DAYS: ${{ inputs.window_days || '14' }}
+        run: bash release-notes/gather.sh
+
+      - name: Set up Node
+        if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install pi
+        if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true'
+        # Pinned: the project moved from @mariozechner/pi-coding-agent (stuck at
+        # 0.73.x, breaks on claude-sonnet-5 thinking) to @earendil-works.
+        # 0.80.3+ speaks Anthropic adaptive thinking. --force overwrites a stale
+        # `pi` bin left in act's reused tool cache by the old package name.
+        run: npm install -g --force @earendil-works/pi-coding-agent@0.80.10
+
+      - name: Generate release notes
+        if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          PROVIDER: ${{ inputs.provider || 'anthropic' }}
+          THINKING: ${{ inputs.thinking || 'medium' }}
+        run: |
+          if [ "$PROVIDER" = "openrouter" ]; then
+            MODEL="deepseek/deepseek-v4-flash"
+          else
+            MODEL="claude-sonnet-5"
+          fi
+          pi -p --no-session --no-tools --no-skills --no-extensions --no-context-files \
+             --thinking "$THINKING" --provider "$PROVIDER" --model "$MODEL" \
+             --system-prompt "$(cat release-notes/system-prompt.md)" \
+             "$(cat out/context.md)" > out/notes.md
+          test -s out/notes.md
+          printf '\n' >> out/notes.md
+          cat out/changelog.md >> out/notes.md
+          echo "--- Generated notes ---"
+          cat out/notes.md
+
+      - name: Create draft release
+        id: release
+        if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true' && inputs.dry_run != true
+        run: |
+          TAG="${{ steps.gather.outputs.tag }}"
+          # Idempotent re-runs: replace an existing draft for the same tag.
+          EXISTING=$(gh release list --repo "$GH_REPO" --json tagName,isDraft \
+            --jq ".[] | select(.tagName == \"$TAG\" and .isDraft) | .tagName")
+          [ -n "$EXISTING" ] && gh release delete "$TAG" --repo "$GH_REPO" --yes
+          URL=$(gh release create "$TAG" --repo "$GH_REPO" --draft \
+            --title "Release $TAG" --notes-file out/notes.md)
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "Draft release: $URL"
+
+      - name: Post to Discord
+        if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true' && inputs.dry_run != true
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          jq -n \
+            --arg title "${GH_REPO#*/} — release ${{ steps.gather.outputs.tag }} (draft)" \
+            --arg url "${{ steps.release.outputs.url }}" \
+            --arg desc "$(head -c 4000 out/notes.md)" \
+            '{embeds: [{title: $title, url: $url, description: $desc, color: 5793266}]}' \
+          | curl -fsS -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK_URL"

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ config/service_account.json
 docs/ai
 
 .DS_Store
+
+# release runner
+.secrets
+out/

--- a/release-notes/gather.sh
+++ b/release-notes/gather.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Gather last week's merged work into a digest for the release-notes LLM.
+#
+# Walks: merged PRs -> closingIssuesReferences -> native sub-issue parent
+# (the PRD issue), deduping parents. PRs with no linked issues contribute
+# their body alone. Falls back to raw commits when no PRs merged; skips
+# the release entirely when there are neither.
+#
+# Env:   GITHUB_TOKEN (required), GH_REPO (owner/repo), WINDOW_DAYS (default 7),
+#        DEFAULT_BRANCH (default main), OUT_DIR (default out)
+# Writes: $OUT_DIR/context.md
+# Outputs (GITHUB_OUTPUT): skip=true|false, mode=prs|commits, tag=vYYYY.MM.DD
+
+set -euo pipefail
+
+REPO="${GH_REPO:?GH_REPO required (owner/repo)}"
+WINDOW_DAYS="${WINDOW_DAYS:-7}"
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+OUT_DIR="${OUT_DIR:-out}"
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
+
+PR_BODY_LIMIT=2000
+PARENT_BODY_LIMIT=3000
+
+mkdir -p "$OUT_DIR"
+CONTEXT="$OUT_DIR/context.md"
+
+# GNU date (CI) with BSD/macOS fallback for local runs outside a container.
+SINCE_DATE=$(date -u -d "-${WINDOW_DAYS} days" +%Y-%m-%d 2>/dev/null || date -u -v-"${WINDOW_DAYS}"d +%Y-%m-%d)
+SINCE_ISO="${SINCE_DATE}T00:00:00Z"
+TAG="v$(date -u +%Y.%m.%d)"
+
+echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+prs=$(gh pr list --repo "$REPO" --state merged \
+  --search "merged:>=$SINCE_DATE base:$DEFAULT_BRANCH" \
+  --json number,title,url,body,mergedAt,author --limit 100)
+
+pr_count=$(jq 'length' <<<"$prs")
+
+if [ "$pr_count" -gt 0 ]; then
+  echo "Found $pr_count merged PRs since $SINCE_DATE" >&2
+
+  # Deterministic changelog appended verbatim after the LLM's narrative notes.
+  {
+    echo "## 📋 Changelog"
+    echo
+    jq -r 'sort_by(.mergedAt) | reverse | .[] |
+      "- [#\(.number)](\(.url)) \(.title) — @\(.author.login)"' <<<"$prs"
+  } > "$OUT_DIR/changelog.md"
+
+  {
+    echo "# Work merged into $REPO ($DEFAULT_BRANCH) since $SINCE_DATE"
+    echo
+    echo "## Merged pull requests"
+  } > "$CONTEXT"
+
+  owner="${REPO%/*}"; name="${REPO#*/}"
+  parents="$OUT_DIR/parents.jsonl"; : > "$parents"
+
+  for pr in $(jq -r '.[].number' <<<"$prs"); do
+    jq -r --argjson n "$pr" --argjson limit "$PR_BODY_LIMIT" '
+      .[] | select(.number == $n) |
+      "\n### PR #\(.number): \(.title)\nAuthor: @\(.author.login) · Merged: \(.mergedAt) · \(.url)\n\n\(.body // "" | .[0:$limit])\n"
+    ' <<<"$prs" >> "$CONTEXT"
+
+    linked=$(gh api graphql \
+      -f query='query($owner:String!,$name:String!,$pr:Int!){
+        repository(owner:$owner,name:$name){
+          pullRequest(number:$pr){
+            closingIssuesReferences(first:10){
+              nodes{ number title parent{ number title body } }
+            }}}}' \
+      -f owner="$owner" -f name="$name" -F pr="$pr" \
+      --jq '.data.repository.pullRequest.closingIssuesReferences.nodes')
+
+    if [ "$(jq 'length' <<<"$linked")" -gt 0 ]; then
+      echo "Closes issues:" >> "$CONTEXT"
+      jq -r '.[] | "- #\(.number) \(.title)\(if .parent then " (part of initiative #\(.parent.number): \(.parent.title))" else "" end)"' \
+        <<<"$linked" >> "$CONTEXT"
+      jq -c '.[] | select(.parent) | .parent' <<<"$linked" >> "$parents"
+    fi
+  done
+
+  if [ -s "$parents" ]; then
+    {
+      echo
+      echo "## Parent initiatives (the why behind the PRs)"
+    } >> "$CONTEXT"
+    jq -rs --argjson limit "$PARENT_BODY_LIMIT" '
+      unique_by(.number) | .[] |
+      "\n### Initiative #\(.number): \(.title)\n\n\(.body // "" | .[0:$limit])\n"
+    ' "$parents" >> "$CONTEXT"
+  fi
+
+  echo "mode=prs" >> "$GITHUB_OUTPUT"
+  echo "skip=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+echo "No merged PRs since $SINCE_DATE; checking commits on $DEFAULT_BRANCH" >&2
+commits=$(gh api "repos/$REPO/commits?since=$SINCE_ISO&sha=$DEFAULT_BRANCH&per_page=100" \
+  --jq '[.[] | select(.commit.message | startswith("Merge pull request") | not)]')
+
+commit_count=$(jq 'length' <<<"$commits")
+
+if [ "$commit_count" -eq 0 ]; then
+  echo "Quiet week: no PRs, no commits. Skipping release." >&2
+  echo "mode=none" >> "$GITHUB_OUTPUT"
+  echo "skip=true" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+echo "Found $commit_count commits since $SINCE_DATE" >&2
+{
+  echo "## 📋 Changelog"
+  echo
+  jq -r '.[] | "- [`\(.sha[0:7])`](\(.html_url)) \(.commit.message | split("\n")[0]) — @\(.author.login // .commit.author.name)"' <<<"$commits"
+} > "$OUT_DIR/changelog.md"
+{
+  echo "# Work committed to $REPO ($DEFAULT_BRANCH) since $SINCE_DATE"
+  echo
+  echo "No pull requests were merged this week; these are direct commits."
+  echo
+  jq -r '.[] | "- \(.commit.message | split("\n")[0]) — @\(.author.login // .commit.author.name) (\(.html_url))"' <<<"$commits"
+} > "$CONTEXT"
+
+echo "mode=commits" >> "$GITHUB_OUTPUT"
+echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/release-notes/system-prompt.md
+++ b/release-notes/system-prompt.md
@@ -1,0 +1,19 @@
+You are the release-notes writer for Avanti Fellows engineering. You receive a digest of the pull requests merged into a repository during the release window (typically the last two weeks) — sometimes with the parent initiative issues ("the why behind the PRs"), sometimes a plain commit list. Write the release notes for that window.
+
+Audience: the whole organisation — program staff who never read code AND engineers. Lead for the non-technical reader; keep technical substance present but secondary.
+
+Output exactly this structure, in markdown, and nothing else (no preamble, no sign-off):
+
+1. The opener: a line containing only `**TL;DR**`, then 2 to 4 bullets. Each bullet is one short, plain sentence (about 15 words or fewer) naming one change and who it helps. No jargon, no PR numbers, no issue numbers. `**TL;DR**` is bold text, not a heading — the output's first character must never be `#`.
+2. `## ✨ New` — user-visible features and capabilities.
+3. `## 🐛 Fixes` — bugs fixed, phrased by user impact.
+4. `## 🔧 Maintenance` — refactors, CI, tooling, docs.
+
+Bullet rules:
+- One bullet per PR; merge trivially-related PRs into one bullet.
+- Phrase by outcome ("Program Admins can now manage their own visits"), never by implementation ("refactored visits-policy module").
+- When a parent initiative is given, use it to explain the why in the bullet.
+- End every bullet with the PR link and credit: `([#208](url)) — thanks @author`.
+- For a commit-only window, bullets cite commits instead of PRs and the TL;DR says the work landed as direct commits.
+
+Write simply, everywhere: short sentences, everyday words, one idea per bullet, no parenthetical detail-stacking. Readers skim this — a detailed changelog is appended after your output, so you never need to be exhaustive. Omit any section that has no items. Keep the whole output under 250 words. Never invent work that is not in the digest.


### PR DESCRIPTION
Ports the release runner that went live on af_lms (avantifellows/af_lms#219, #220, #221) to db-service, unchanged: every other Monday 09:00 IST (first run **Jul 27**), gather 14 days of PRs merged to **main**, Sonnet writes bulleted notes, deterministic changelog appended, **draft** release `vYYYY.MM.DD`, Discord post. Quiet windows skip. `workflow_dispatch` supports provider/window/thinking/dry_run overrides.

Note: the `base:main` filter means feature merges are what get summarized — the "Prod Deployment" PRs into `release` are excluded as merge vehicles. If we'd rather cut notes from what actually deployed, that's a one-env-var change (`DEFAULT_BRANCH: release`).

Verified: gather script run locally against this repo (10 PRs found since Jul 4, deployment PRs correctly excluded); the workflow itself is byte-identical to af_lms's, which passed real GitHub Actions runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)