### PR TITLE
Add student_enrollment import type to backfill enrollments for existing students

### DIFF
--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -74,6 +74,7 @@ const Hooks = {
       // Register for all protected import types (basic auth required)
       this.handleEvent("submit_dropout_import", submitAuthenticatedImport);
       this.handleEvent("submit_re_enrollment_import", submitAuthenticatedImport);
+      this.handleEvent("submit_student_enrollment_import", submitAuthenticatedImport);
       this.handleEvent("submit_auth_group_import", submitAuthenticatedImport);
       this.handleEvent("submit_product_import", submitAuthenticatedImport);
       this.handleEvent("submit_program_import", submitAuthenticatedImport);

--- a/lib/dbservice/constants/mappings.ex
+++ b/lib/dbservice/constants/mappings.ex
@@ -89,7 +89,13 @@ defmodule Dbservice.Constants.Mappings do
         "update_incorrect_grade_to_correct_grade",
         "update_incorrect_auth_group_to_correct_auth_group"
       ],
-      optional: ["batch_movement", "student_update", "dropout", "re_enrollment"],
+      optional: [
+        "batch_movement",
+        "student_update",
+        "dropout",
+        "re_enrollment",
+        "student_enrollment"
+      ],
       type: :string
     },
     "student_father_name" => %{
@@ -327,7 +333,8 @@ defmodule Dbservice.Constants.Mappings do
         "update_incorrect_batch_id_to_correct_batch_id",
         "update_incorrect_school_to_correct_school",
         "update_incorrect_grade_to_correct_grade",
-        "update_incorrect_auth_group_to_correct_auth_group"
+        "update_incorrect_auth_group_to_correct_auth_group",
+        "student_enrollment"
       ],
       type: :string
     },
@@ -341,7 +348,7 @@ defmodule Dbservice.Constants.Mappings do
     },
     "auth_group" => %{
       db_field: "auth_group",
-      required: ["student", "teacher_addition", "re_enrollment"],
+      required: ["student", "teacher_addition", "re_enrollment", "student_enrollment"],
       optional: [],
       type: :string
     },
@@ -353,7 +360,8 @@ defmodule Dbservice.Constants.Mappings do
         "teacher_addition",
         "teacher_batch_assignment",
         "dropout",
-        "re_enrollment"
+        "re_enrollment",
+        "student_enrollment"
       ],
       optional: ["school_addition"],
       type: :string
@@ -364,7 +372,8 @@ defmodule Dbservice.Constants.Mappings do
         "student",
         "teacher_addition",
         "update_incorrect_grade_to_correct_grade",
-        "re_enrollment"
+        "re_enrollment",
+        "student_enrollment"
       ],
       optional: [
         "batch_movement",
@@ -383,7 +392,8 @@ defmodule Dbservice.Constants.Mappings do
         "teacher_addition",
         "teacher_batch_assignment",
         "update_incorrect_batch_id_to_correct_batch_id",
-        "re_enrollment"
+        "re_enrollment",
+        "student_enrollment"
       ],
       optional: [],
       type: :string
@@ -395,7 +405,8 @@ defmodule Dbservice.Constants.Mappings do
         "update_incorrect_school_to_correct_school",
         "re_enrollment",
         "school_addition",
-        "school_deletion"
+        "school_deletion",
+        "student_enrollment"
       ],
       optional: [],
       type: :string
@@ -492,7 +503,8 @@ defmodule Dbservice.Constants.Mappings do
         "teacher_addition",
         "teacher_batch_assignment",
         "dropout",
-        "re_enrollment"
+        "re_enrollment",
+        "student_enrollment"
       ],
       optional: [],
       type: :date

--- a/lib/dbservice/data_import.ex
+++ b/lib/dbservice/data_import.ex
@@ -14,6 +14,7 @@ defmodule Dbservice.DataImport do
   """
   def format_type_name("student"), do: "Student Addition"
   def format_type_name("student_update"), do: "Update Student Details"
+  def format_type_name("student_enrollment"), do: "Enroll Existing Students"
   def format_type_name("batch_movement"), do: "Student Batch Movement"
   def format_type_name("teacher_batch_assignment"), do: "Teacher Batch Assignment"
   def format_type_name("teacher_addition"), do: "Teacher Addition"

--- a/lib/dbservice/services/enrollment_service.ex
+++ b/lib/dbservice/services/enrollment_service.ex
@@ -85,6 +85,97 @@ defmodule Dbservice.Services.EnrollmentService do
   end
 
   @doc """
+  Strict pre-check used by the `student_enrollment` (backfill) import.
+
+  For each membership named in the row (auth_group / school / batch / grade),
+  returns `{:error, reason}` if the student is ALREADY mapped to that exact group —
+  either via a `group_user` row or a *current* (`is_current: true`) enrollment
+  record. Returns `:ok` when none of the row's memberships already exist.
+
+  Unlike `handle_group_user_enrollment/1` (which is idempotent and silently
+  no-ops on an identical mapping), this makes any pre-existing membership a hard
+  error so already-enrolled students are surfaced instead of quietly skipped.
+  Memberships whose identifier is blank/absent in the row are skipped; an
+  unresolvable identifier (unknown school/batch/grade/auth_group) is returned as
+  an error.
+  """
+  def validate_row_memberships_absent(user_id, params) do
+    [
+      {"auth_group", resolve_row_group("auth_group", params)},
+      {"school", resolve_row_group("school", params)},
+      {"batch", resolve_row_group("batch", params)},
+      {"grade", resolve_row_group("grade", params)}
+    ]
+    |> Enum.reduce_while(:ok, fn {label, resolution}, :ok ->
+      case resolution do
+        :skip ->
+          {:cont, :ok}
+
+        {:error, reason} ->
+          {:halt, {:error, reason}}
+
+        {:ok, group_id} ->
+          if membership_exists?(user_id, group_id) do
+            {:halt, {:error, existing_membership_message(label)}}
+          else
+            {:cont, :ok}
+          end
+      end
+    end)
+  end
+
+  # Resolves the row identifier for a given membership type to a group id.
+  # Returns {:ok, group_id}, {:error, reason} when the identifier is present but
+  # unresolvable, or :skip when the identifier is absent/blank.
+  defp resolve_row_group("auth_group", %{"auth_group" => name}) when name not in [nil, ""],
+    do: normalize_group_id(get_auth_group_id(name))
+
+  defp resolve_row_group("school", %{"school_code" => code}) when code not in [nil, ""],
+    do: normalize_group_id(get_school_group_id(code))
+
+  defp resolve_row_group("batch", %{"batch_id" => batch_id}) when batch_id not in [nil, ""],
+    do: normalize_group_id(get_batch_group_id(batch_id))
+
+  defp resolve_row_group("grade", %{"grade_id" => grade_id}) when grade_id not in [nil, ""],
+    do: normalize_group_id(get_grade_group_id(grade_id))
+
+  defp resolve_row_group(_type, _params), do: :skip
+
+  defp normalize_group_id({:error, reason}), do: {:error, reason}
+  defp normalize_group_id(group_id) when is_integer(group_id), do: {:ok, group_id}
+
+  # True if the user already has a group_user row for this group OR a current
+  # enrollment record for the group's underlying child_id + type.
+  defp membership_exists?(user_id, group_id) do
+    group = Groups.get_group!(group_id)
+
+    group_user_exists?(user_id, group_id) or
+      current_enrollment_exists?(user_id, group.type, group.child_id)
+  end
+
+  defp group_user_exists?(user_id, group_id) do
+    not is_nil(GroupUsers.get_group_user_by_user_id_and_group_id(user_id, group_id))
+  end
+
+  defp current_enrollment_exists?(user_id, group_type, child_id) do
+    query =
+      from er in EnrollmentRecord,
+        where:
+          er.user_id == ^user_id and
+            er.group_type == ^group_type and
+            er.group_id == ^child_id and
+            er.is_current == true,
+        limit: 1
+
+    not is_nil(Repo.one(query))
+  end
+
+  defp existing_membership_message(label) do
+    "Student is already enrolled in a #{label}. This import only backfills students " <>
+      "with no existing #{label} membership; use the appropriate update import type to change it."
+  end
+
+  @doc """
   Validates that a user doesn't have any other active enrollments for the given group type.
   Returns {:error, reason} if an active enrollment exists, :ok otherwise.
   """

--- a/lib/dbservice/utils/import_worker.ex
+++ b/lib/dbservice/utils/import_worker.ex
@@ -91,6 +91,7 @@ defmodule Dbservice.DataImport.ImportWorker do
       "school_deletion" => &process_school_deletion_record/1,
       "student" => &process_student_record/1,
       "student_update" => &process_student_update_record/1,
+      "student_enrollment" => &process_student_enrollment_record/1,
       "batch_movement" => &process_batch_movement_record/1,
       "alumni_addition" => &process_alumni_record/1,
       "teacher_batch_assignment" => &process_teacher_batch_assignment_record/1,
@@ -844,6 +845,33 @@ defmodule Dbservice.DataImport.ImportWorker do
 
         student ->
           StudentUpdateService.update_student_with_user_data(student, record)
+      end
+    end
+  end
+
+  # Backfills group-user + enrollment records for a student that ALREADY exists but
+  # has no enrollments (historical data). Reuses the same enrollment logic as the
+  # new-student branch of process_student_record/1; unlike that path it never creates
+  # a student — a missing student is a hard error.
+  defp process_student_enrollment_record(record) do
+    student_id = record["student_id"]
+    apaar_id = record["apaar_id"]
+
+    if (is_nil(student_id) or student_id == "") and (is_nil(apaar_id) or apaar_id == "") do
+      {:error, "Either student_id or apaar_id is required for student enrollment"}
+    else
+      case Users.get_student_by_id_or_apaar_id(record) do
+        nil ->
+          {:error,
+           "Student not found. student_id: #{record["student_id"]}, apaar_id: #{record["apaar_id"]}"}
+
+        student ->
+          student = Dbservice.Repo.preload(student, [:user])
+
+          case DataImport.StudentEnrollment.create_enrollments(student.user, record) do
+            {:ok, _} -> {:ok, student}
+            {:error, reason} -> {:error, reason}
+          end
       end
     end
   end

--- a/lib/dbservice/utils/import_worker.ex
+++ b/lib/dbservice/utils/import_worker.ex
@@ -23,6 +23,7 @@ defmodule Dbservice.DataImport.ImportWorker do
   alias Dbservice.Services.StudentUpdateService
   alias Dbservice.Services.DropoutService
   alias Dbservice.Services.ReEnrollmentService
+  alias Dbservice.Services.EnrollmentService
   alias Dbservice.Utils.ChangesetFormatter
   alias Dbservice.Utils.Util
   alias Dbservice.Colleges
@@ -853,6 +854,11 @@ defmodule Dbservice.DataImport.ImportWorker do
   # has no enrollments (historical data). Reuses the same enrollment logic as the
   # new-student branch of process_student_record/1; unlike that path it never creates
   # a student — a missing student is a hard error.
+  #
+  # Unlike the idempotent create path, this import is strict: if the student is
+  # already mapped to any of the auth_group / school / batch / grade in the row
+  # (via a group_user row or a current enrollment record), it is a hard error so
+  # already-enrolled students are surfaced rather than silently no-oped.
   defp process_student_enrollment_record(record) do
     student_id = record["student_id"]
     apaar_id = record["apaar_id"]
@@ -868,8 +874,10 @@ defmodule Dbservice.DataImport.ImportWorker do
         student ->
           student = Dbservice.Repo.preload(student, [:user])
 
-          case DataImport.StudentEnrollment.create_enrollments(student.user, record) do
-            {:ok, _} -> {:ok, student}
+          with :ok <- EnrollmentService.validate_row_memberships_absent(student.user.id, record),
+               {:ok, _} <- DataImport.StudentEnrollment.create_enrollments(student.user, record) do
+            {:ok, student}
+          else
             {:error, reason} -> {:error, reason}
           end
       end

--- a/lib/dbservice_web/controllers/import_controller.ex
+++ b/lib/dbservice_web/controllers/import_controller.ex
@@ -34,6 +34,29 @@ defmodule DbserviceWeb.ImportController do
     end
   end
 
+  def create_student_enrollment_import(conn, params) do
+    # Extract import params from nested "import" key
+    import_params =
+      params
+      |> Map.get("import", %{})
+      |> Map.put("type", "student_enrollment")
+
+    case DataImport.start_import(import_params) do
+      {:ok, _import} ->
+        conn
+        |> put_flash(
+          :info,
+          "Student enrollment import queued successfully! Processing will begin shortly. Check the imports page for progress updates."
+        )
+        |> redirect(to: ~p"/imports")
+
+      {:error, reason} ->
+        conn
+        |> put_flash(:error, "Import failed: #{reason}")
+        |> redirect(to: ~p"/imports/new")
+    end
+  end
+
   def create_re_enrollment_import(conn, params) do
     # Extract import params from nested "import" key
     import_params =

--- a/lib/dbservice_web/controllers/template_controller.ex
+++ b/lib/dbservice_web/controllers/template_controller.ex
@@ -10,6 +10,7 @@ defmodule DbserviceWeb.TemplateController do
     if import_type in [
          "student",
          "student_update",
+         "student_enrollment",
          "teacher_addition",
          "chapter_addition",
          "subject_addition",

--- a/lib/dbservice_web/live/import_live/new.ex
+++ b/lib/dbservice_web/live/import_live/new.ex
@@ -61,10 +61,12 @@ defmodule DbserviceWeb.ImportLive.New do
   defp handle_save(%{"import" => import_params}, socket) do
     import_type = Map.get(import_params, "type", "")
 
-    # Protected import types require basic auth (dropout, re_enrollment, auth_group, product, program, batch)
+    # Protected import types require basic auth (dropout, re_enrollment,
+    # student_enrollment, auth_group, product, program, batch, school, ...)
     protected_import_config = %{
       "dropout" => "submit_dropout_import",
       "re_enrollment" => "submit_re_enrollment_import",
+      "student_enrollment" => "submit_student_enrollment_import",
       "auth_group_addition" => "submit_auth_group_import",
       "product_addition" => "submit_product_import",
       "program_addition" => "submit_program_import",
@@ -127,6 +129,7 @@ defmodule DbserviceWeb.ImportLive.New do
 
   defp get_protected_import_url("dropout"), do: ~p"/imports/dropout"
   defp get_protected_import_url("re_enrollment"), do: ~p"/imports/re_enrollment"
+  defp get_protected_import_url("student_enrollment"), do: ~p"/imports/student_enrollment"
   defp get_protected_import_url("auth_group_addition"), do: ~p"/imports/auth_group"
   defp get_protected_import_url("product_addition"), do: ~p"/imports/product"
   defp get_protected_import_url("program_addition"), do: ~p"/imports/program"

--- a/lib/dbservice_web/live/import_live/new.ex
+++ b/lib/dbservice_web/live/import_live/new.ex
@@ -181,7 +181,9 @@ defmodule DbserviceWeb.ImportLive.New do
                   >
                     <option disabled value="">Select import type</option>
                     <option value="student" selected={@form[:type].value == "student"}>Student Addition</option>
-                    <option value="student_update" selected={@form[:type].value == "student_update"}>Update Student Details</option>                            <option value="teacher_addition" selected={@form[:type].value == "teacher_addition"}>Teacher Addition</option>
+                    <option value="student_update" selected={@form[:type].value == "student_update"}>Update Student Details</option>
+                    <option value="student_enrollment" selected={@form[:type].value == "student_enrollment"}>Enroll Existing Students</option>
+                    <option value="teacher_addition" selected={@form[:type].value == "teacher_addition"}>Teacher Addition</option>
                     <option value="chapter_addition" selected={@form[:type].value == "chapter_addition"}>Chapter Addition</option>
                     <option value="subject_addition" selected={@form[:type].value == "subject_addition"}>Subject Addition</option>
                     <option value="resource_addition" selected={@form[:type].value == "resource_addition"}>Resource Addition</option>

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -40,6 +40,7 @@ defmodule DbserviceWeb.Router do
 
     post("/imports/dropout", ImportController, :create_dropout_import)
     post("/imports/re_enrollment", ImportController, :create_re_enrollment_import)
+    post("/imports/student_enrollment", ImportController, :create_student_enrollment_import)
     post("/imports/auth_group", ImportController, :create_auth_group_import)
     post("/imports/product", ImportController, :create_product_import)
     post("/imports/program", ImportController, :create_program_import)

--- a/test/dbservice/services/enrollment_service_test.exs
+++ b/test/dbservice/services/enrollment_service_test.exs
@@ -132,6 +132,110 @@ defmodule Dbservice.Services.EnrollmentServiceTest do
     end
   end
 
+  describe "validate_row_memberships_absent/2" do
+    test "returns :ok when the student has none of the row's memberships" do
+      user = user_fixture()
+      _auth_group = auth_group_fixture(%{name: "VRMA_AUTH"})
+      _school = school_fixture(%{code: "VRMA_SCH"})
+      _batch = batch_fixture(%{batch_id: "VRMA_BATCH"})
+      grade = grade_fixture(%{number: 9})
+
+      row = %{
+        "auth_group" => "VRMA_AUTH",
+        "school_code" => "VRMA_SCH",
+        "batch_id" => "VRMA_BATCH",
+        "grade_id" => grade.id
+      }
+
+      assert :ok = EnrollmentService.validate_row_memberships_absent(user.id, row)
+    end
+
+    test "errors when a current enrollment record exists for the row's school" do
+      user = user_fixture()
+      school = school_fixture(%{code: "VRMA_SCH"})
+
+      {:ok, _} =
+        Dbservice.EnrollmentRecords.create_enrollment_record(%{
+          "user_id" => user.id,
+          "group_id" => school.id,
+          "group_type" => "school",
+          "academic_year" => "2024-25",
+          "start_date" => ~D[2024-01-01],
+          "is_current" => true
+        })
+
+      row = %{"school_code" => "VRMA_SCH"}
+
+      assert {:error, message} = EnrollmentService.validate_row_memberships_absent(user.id, row)
+      assert message =~ "already enrolled in a school"
+    end
+
+    test "errors when a group_user row exists for the row's grade (even without an ER)" do
+      user = user_fixture()
+      grade = grade_fixture(%{number: 9})
+      group_id = EnrollmentService.get_grade_group_id(grade.id)
+
+      {:ok, _} =
+        Dbservice.GroupUsers.create_group_user(%{
+          "user_id" => user.id,
+          "group_id" => group_id
+        })
+
+      row = %{"grade_id" => grade.id}
+
+      assert {:error, message} = EnrollmentService.validate_row_memberships_absent(user.id, row)
+      assert message =~ "already enrolled in a grade"
+    end
+
+    test "ignores a closed (non-current) enrollment record" do
+      user = user_fixture()
+      school = school_fixture(%{code: "VRMA_SCH"})
+
+      {:ok, _} =
+        Dbservice.EnrollmentRecords.create_enrollment_record(%{
+          "user_id" => user.id,
+          "group_id" => school.id,
+          "group_type" => "school",
+          "academic_year" => "2023-24",
+          "start_date" => ~D[2023-06-01],
+          "end_date" => ~D[2024-05-31],
+          "is_current" => false
+        })
+
+      row = %{"school_code" => "VRMA_SCH"}
+
+      assert :ok = EnrollmentService.validate_row_memberships_absent(user.id, row)
+    end
+
+    test "skips memberships whose identifier is blank or absent" do
+      user = user_fixture()
+
+      # No identifiers present at all -> nothing to check -> :ok
+      assert :ok = EnrollmentService.validate_row_memberships_absent(user.id, %{})
+
+      # Blank string identifiers are treated as absent
+      row = %{"school_code" => "", "auth_group" => nil}
+      assert :ok = EnrollmentService.validate_row_memberships_absent(user.id, row)
+    end
+
+    test "errors when a batch group_user already maps the student" do
+      user = user_fixture()
+      _batch = batch_fixture(%{batch_id: "VRMA_BATCH"})
+      group_id = EnrollmentService.get_batch_group_id("VRMA_BATCH")
+
+      {:ok, _} =
+        Dbservice.GroupUsers.create_group_user(%{
+          "user_id" => user.id,
+          "group_id" => group_id
+        })
+
+      row = %{"batch_id" => "VRMA_BATCH"}
+
+      assert {:error, message} = EnrollmentService.validate_row_memberships_absent(user.id, row)
+      assert message =~ "already enrolled in a batch"
+    end
+  end
+
   describe "resolve_academic_year/2" do
     test "returns nil for auth_group type" do
       params = %{"academic_year" => "2024-25"}


### PR DESCRIPTION
## Problem

We need to backfill historical enrollment data for students whose **student records already exist** in the DB but who have **no group-user and no enrollment (ER) records** (auth_group / school / batch / grade memberships).

The existing `student` import can't do this — when a student already exists, `process_student_record/1` deliberately short-circuits with *"Student already exists ... Use 'Update Student Details' import type for updates."* And `student_update` only patches profile fields; it never creates group-user/ER records. So there was no bulk path to create enrollments for an already-existing student.

## Solution

Add a new, non-breaking import type **`student_enrollment` ("Enroll Existing Students")** that:
- looks up the existing student by `student_id` / `apaar_id`,
- errors strictly with *"Student not found"* if the student doesn't exist (these students are expected to already exist — a miss signals a data problem worth surfacing),
- **hard-errors if the student is already mapped to any of the row's memberships** (see "Strict already-enrolled guard" below),
- otherwise reuses the existing `StudentEnrollment.create_enrollments/2` logic to create the auth_group/school/batch/grade group-user + ER records.

## Strict already-enrolled guard

`create_enrollments/2` is *idempotent* by design: for an identical existing mapping it silently no-ops, and it only errors when the student is enrolled in a *different* exclusive group (school/grade/auth_group). For this backfill that's too lenient — an already-enrolled student would be silently skipped instead of surfaced.

So before calling `create_enrollments/2`, the import now runs a strict pre-check, `EnrollmentService.validate_row_memberships_absent/2`:

- **Per-membership**: for each of `auth_group` / `school` / `batch` / `grade` named in the row, it independently checks whether the student is already mapped to *that exact group*.
- **Both tables**: it hard-errors if a `group_user` row exists **or** a **current** (`is_current: true`) enrollment record exists for that group.
- **Current ERs only**: closed/historical ERs (`is_current: false`) are ignored, so a previously-dropped-out student can still be backfilled.
- Blank/absent identifiers are skipped; an unresolvable school/batch/grade/auth_group surfaces its normal "not found" error.

This also closes the group_user/ER drift gap for the row's own memberships: if a `group_user` is missing but a current ER exists (or vice-versa), the guard catches it instead of letting the idempotent path insert a duplicate ER.

## Changes (standard 5 integration points for a new import type)

- **`lib/dbservice/utils/import_worker.ex`** — register `student_enrollment` in `processor_map` + add `process_student_enrollment_record/1` (runs the strict guard, then `create_enrollments/2`).
- **`lib/dbservice/services/enrollment_service.ex`** — add `validate_row_memberships_absent/2` and its helpers.
- **`lib/dbservice/constants/mappings.ex`** — register the type on only the enrollment columns: `student_id` / `student_apaar_id` (optional) and `auth_group`, `academic_year`, `grade`, `batch_id`, `school_code`, `start_date` (required). `grade_id` is derived from `grade` automatically.
- **`lib/dbservice/data_import.ex`** — `format_type_name/1` → "Enroll Existing Students".
- **`lib/dbservice_web/controllers/template_controller.ex`** — add to the CSV-template whitelist.
- **`lib/dbservice_web/live/import_live/new.ex`** — add the dropdown option.
- Basic-auth protected route wired through `import_controller.ex` / `router.ex` / `hooks.js`.

## Notes / semantics

- Reused `create_new_group_user/1` writes the ER with `is_current: true` (matching the normal `student` import), so backfilled rows read as *current* enrollments. If some historical rows should instead be closed/non-current, that's a separate follow-up (the CSV has `start_date` but no `end_date`/`is_current` column today).

## Testing

- `mix compile --warnings-as-errors` — clean
- `mix format --check-formatted` on changed files — clean
- `mix credo` on the logic + test files — no issues
- `mix test test/dbservice/services/enrollment_service_test.exs` — the 6 new `validate_row_memberships_absent/2` tests pass. (One unrelated, pre-existing failure in `handle_group_user_enrollment/1 updates existing group user` exists on this branch independent of these changes.)
- Runtime verification (importing a CSV against a test DB and confirming `group_user`/`enrollment_record` rows appear, plus the negative cases) pending manual run via `/imports`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
