### PR TITLE
Require approval for staging ECS deploys

### DIFF
--- a/.github/workflows/staging_deploy_ecs.yml
+++ b/.github/workflows/staging_deploy_ecs.yml
@@ -37,6 +37,7 @@ concurrency:
 jobs:
   deploy:
     name: Build, migrate, deploy
+    environment: staging-ecs
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## What changed

- Added the `staging-ecs` environment gate to the staging ECS deployment job.
- Created the `staging-ecs` GitHub environment with the existing staging reviewer list and no environment secrets.

## Why

PR-triggered staging ECS deployments currently start automatically. Referencing the protected environment makes the job wait for explicit approval before building, migrating, or deploying. Existing repository-level AWS secrets remain unchanged.

## Validation

- Parsed `.github/workflows/staging_deploy_ecs.yml` as YAML.
- Confirmed `staging-ecs` has required reviewers and zero environment secrets through the GitHub API.