### PR TITLE
fix(import): validate duplicate identifiers in student_update import (#641)

### DIFF
--- a/lib/dbservice/services/student_update_service.ex
+++ b/lib/dbservice/services/student_update_service.ex
@@ -49,7 +49,12 @@ defmodule Dbservice.Services.StudentUpdateService do
     # Filter out nil/empty values to only update provided fields
     filtered_params = filter_update_params(params)
 
-    Users.update_student_with_user(student, user, filtered_params)
+    # Reject a row that would move another student's identifier onto this student
+    # before writing, so the import fails with a clear message instead of a raw
+    # unique-constraint error (see issue #641).
+    with :ok <- Users.validate_identifier_conflicts(filtered_params, student) do
+      Users.update_student_with_user(student, user, filtered_params)
+    end
   end
 
   # Private helper functions

--- a/lib/dbservice/users.ex
+++ b/lib/dbservice/users.ex
@@ -691,6 +691,48 @@ defmodule Dbservice.Users do
     end
   end
 
+  @doc """
+  Validates that the globally-unique identifiers in `params` (`apaar_id`, `pen_number`)
+  do not already belong to another student, mirroring the student table's global unique
+  constraints so a conflict is reported clearly before the write instead of surfacing as
+  a raw constraint error.
+
+  `student_id` is deliberately NOT checked here: it is only unique within an auth group
+  (see `create_or_update_student/1`), so a global check would falsely flag a student
+  whose id is legitimately reused in another auth group. Only the identifiers the
+  database enforces globally are validated.
+
+  Only identifiers that are present and non-empty in `params` are checked, so a partial
+  update touching unrelated fields passes untouched. Accepts string or atom keys. When
+  `existing_student` is given, that student is excluded from the check (re-saving its
+  own identifiers is allowed); pass `nil` when validating a brand new student.
+
+  Returns `:ok`, or `{:error, message}` naming the conflicting identifier.
+  """
+  def validate_identifier_conflicts(params, existing_student \\ nil) do
+    apaar_id = identifier_param(params, :apaar_id)
+    pen_number = identifier_param(params, :pen_number)
+
+    cond do
+      identifier_present?(apaar_id) and
+          duplicate_exists?(:apaar_id, apaar_id, existing_student) ->
+        {:error, "APAAR ID '#{apaar_id}' already exists for another student"}
+
+      identifier_present?(pen_number) and
+          duplicate_exists?(:pen_number, pen_number, existing_student) ->
+        {:error, "PEN Number '#{pen_number}' already exists for another student"}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp identifier_param(params, key) do
+    Map.get(params, key) || Map.get(params, Atom.to_string(key))
+  end
+
+  defp identifier_present?(value), do: not (is_nil(value) or value == "")
+
   # Validates that student_id and apaar_id are not duplicated in other students
   # When updating, validates that the NEW values in params don't conflict with other students
   defp validate_identifiers_not_duplicated(student_id, apaar_id, existing_student) do
@@ -726,6 +768,7 @@ defmodule Dbservice.Users do
       case field do
         :student_id -> from(s in Student, where: s.student_id == ^value)
         :apaar_id -> from(s in Student, where: s.apaar_id == ^value)
+        :pen_number -> from(s in Student, where: s.pen_number == ^value)
       end
 
     query =

--- a/test/dbservice/services/student_update_service_test.exs
+++ b/test/dbservice/services/student_update_service_test.exs
@@ -117,4 +117,71 @@ defmodule Dbservice.Services.StudentUpdateServiceTest do
       assert updated_user.first_name == original_first_name
     end
   end
+
+  describe "update_student_with_user_data/2 duplicate identifier validation (issue #641)" do
+    alias Dbservice.Users
+
+    test "rejects a row that moves another student's apaar_id onto this student" do
+      {_u1, target} = student_fixture(%{student_id: "TARGET-641", apaar_id: "111111111111"})
+      {_u2, other} = student_fixture(%{student_id: "OTHER-641", apaar_id: "222222222222"})
+
+      result =
+        StudentUpdateService.update_student_with_user_data(target, %{
+          "apaar_id" => "222222222222",
+          "first_name" => "ShouldNotApply"
+        })
+
+      assert {:error, message} = result
+      assert message =~ "APAAR ID '222222222222' already exists for another student"
+
+      # The conflicting student keeps its APAAR ID; the target is not overwritten.
+      assert Users.get_student!(other.id).apaar_id == "222222222222"
+      assert Users.get_student!(target.id).apaar_id == "111111111111"
+      assert Users.get_user!(target.user_id).first_name != "ShouldNotApply"
+    end
+
+    test "rejects a row that moves another student's pen_number onto this student" do
+      {_u1, target} = student_fixture(%{student_id: "TARGET-PEN", pen_number: "12345678901"})
+      {_u2, _other} = student_fixture(%{student_id: "OTHER-PEN", pen_number: "19999999999"})
+
+      result =
+        StudentUpdateService.update_student_with_user_data(target, %{
+          "pen_number" => "19999999999"
+        })
+
+      assert {:error, message} = result
+      assert message =~ "PEN Number '19999999999' already exists for another student"
+      assert Users.get_student!(target.id).pen_number == "12345678901"
+    end
+
+    test "allows re-saving the student's own identifiers alongside other updates" do
+      {_u, target} =
+        student_fixture(%{
+          student_id: "TARGET-SELF",
+          apaar_id: "333333333333",
+          pen_number: "13333333333"
+        })
+
+      result =
+        StudentUpdateService.update_student_with_user_data(target, %{
+          "apaar_id" => "333333333333",
+          "pen_number" => "13333333333",
+          "first_name" => "Renamed"
+        })
+
+      assert {:ok, updated} = result
+      assert updated.apaar_id == "333333333333"
+      assert Users.get_user!(target.user_id).first_name == "Renamed"
+    end
+
+    test "allows assigning a brand new, non-conflicting apaar_id" do
+      {_u, target} = student_fixture(%{student_id: "TARGET-NEW"})
+
+      result =
+        StudentUpdateService.update_student_with_user_data(target, %{"apaar_id" => "444444444444"})
+
+      assert {:ok, updated} = result
+      assert updated.apaar_id == "444444444444"
+    end
+  end
 end

--- a/test/dbservice/users_test.exs
+++ b/test/dbservice/users_test.exs
@@ -620,6 +620,51 @@ defmodule Dbservice.UsersTest do
     end
   end
 
+  describe "validate_identifier_conflicts/2" do
+    alias Dbservice.Users.Student
+
+    import Dbservice.UsersFixtures
+
+    test "flags an apaar_id already used by another student" do
+      {_u, _s} = student_fixture(%{apaar_id: "123456789012"})
+
+      assert {:error, message} =
+               Users.validate_identifier_conflicts(%{"apaar_id" => "123456789012"})
+
+      assert message =~ "APAAR ID '123456789012' already exists for another student"
+    end
+
+    test "flags a pen_number already used by another student" do
+      {_u, _s} = student_fixture(%{pen_number: "12345678901"})
+
+      assert {:error, message} =
+               Users.validate_identifier_conflicts(%{"pen_number" => "12345678901"})
+
+      assert message =~ "PEN Number '12345678901' already exists for another student"
+    end
+
+    test "excludes the student being updated from its own identifiers" do
+      {_u, %Student{} = s} =
+        student_fixture(%{apaar_id: "123456789012", pen_number: "12345678901"})
+
+      assert :ok =
+               Users.validate_identifier_conflicts(
+                 %{"apaar_id" => "123456789012", "pen_number" => "12345678901"},
+                 s
+               )
+    end
+
+    test "does not flag a student_id (auth-group-scoped, not globally unique)" do
+      {_u, _s} = student_fixture(%{student_id: "SHARED-ID"})
+
+      assert :ok = Users.validate_identifier_conflicts(%{"student_id" => "SHARED-ID"})
+    end
+
+    test "returns :ok when no globally-unique identifiers are present" do
+      assert :ok = Users.validate_identifier_conflicts(%{"first_name" => "NoIdentifiers"})
+    end
+  end
+
   describe "teacher" do
     alias Dbservice.Users.Teacher
 

--- a/test/dbservice/utils/import_worker_test.exs
+++ b/test/dbservice/utils/import_worker_test.exs
@@ -6,6 +6,7 @@ defmodule Dbservice.DataImport.ImportWorkerTest do
   alias Dbservice.DataImport
   alias Dbservice.Users
   import Dbservice.DataImportFixtures
+  import Dbservice.UsersFixtures
 
   setup do
     # Create required entities for the test
@@ -205,6 +206,53 @@ defmodule Dbservice.DataImport.ImportWorkerTest do
       assert updated_import.total_rows == 2
 
       cleanup_test_csv("start_row_test.csv")
+    end
+  end
+
+  describe "student_update imports (issue #641)" do
+    test "halts with a clear error when a row moves another student's apaar_id, and does not overwrite either student" do
+      {_u1, _target} = student_fixture(%{student_id: "UPD-TARGET", apaar_id: "111111111111"})
+      {_u2, other} = student_fixture(%{student_id: "UPD-OTHER", apaar_id: "222222222222"})
+
+      # The row identifies UPD-TARGET but tries to set UPD-OTHER's APAAR ID on it.
+      csv_content = student_update_csv_content([{"UPD-TARGET", "222222222222", "Hacked"}])
+      filename = create_test_csv("student_update_conflict.csv", csv_content)
+      on_exit(fn -> cleanup_test_csv("student_update_conflict.csv") end)
+
+      import_record =
+        import_fixture(%{filename: filename, type: "student_update", status: "pending"})
+
+      job = %Oban.Job{args: %{"id" => import_record.id}}
+      perform_job(ImportWorker, job.args)
+
+      updated_import = DataImport.get_import!(import_record.id)
+      assert updated_import.error_count > 0
+
+      first_error = List.first(updated_import.error_details)
+      assert Map.has_key?(first_error, "row")
+      assert first_error["error"] =~ "APAAR ID '222222222222' already exists for another student"
+
+      # No duplicate created: the other student keeps its APAAR ID and the target row is untouched.
+      assert Users.get_student!(other.id).apaar_id == "222222222222"
+      assert Users.get_student_by_student_id("UPD-TARGET").apaar_id == "111111111111"
+    end
+
+    test "applies a clean update row with no identifier conflict" do
+      {_u, target} = student_fixture(%{student_id: "UPD-CLEAN", apaar_id: "333333333333"})
+
+      csv_content = student_update_csv_content([{"UPD-CLEAN", "", "Renamed"}])
+      filename = create_test_csv("student_update_clean.csv", csv_content)
+      on_exit(fn -> cleanup_test_csv("student_update_clean.csv") end)
+
+      import_record =
+        import_fixture(%{filename: filename, type: "student_update", status: "pending"})
+
+      job = %Oban.Job{args: %{"id" => import_record.id}}
+      assert :ok = perform_job(ImportWorker, job.args)
+
+      updated_import = DataImport.get_import!(import_record.id)
+      assert updated_import.status in ["completed", "processing"]
+      assert Users.get_user!(target.user_id).first_name == "Renamed"
     end
   end
 

--- a/test/support/fixtures/data_import_fixtures.ex
+++ b/test/support/fixtures/data_import_fixtures.ex
@@ -122,6 +122,21 @@ defmodule Dbservice.DataImportFixtures do
   end
 
   @doc """
+  Generate `student_update` CSV content: one row per {student_id, apaar_id, first_name}
+  tuple. `apaar_id`/`first_name` may be "" to omit that column value for a row.
+  """
+  def student_update_csv_content(rows) do
+    header = "student_id,student_apaar_id,user_first_name"
+
+    body =
+      Enum.map_join(rows, "\n", fn {student_id, apaar_id, first_name} ->
+        "#{student_id},#{apaar_id},#{first_name}"
+      end)
+
+    header <> "\n" <> body <> "\n"
+  end
+
+  @doc """
   Generate student CSV with missing headers.
   """
   def incomplete_student_csv_content do


### PR DESCRIPTION
Fixes #641.

## Problem
The `student_update` CSV import called the raw update service directly, bypassing the duplicate-identifier validation used by the normal create/update flow. A row could move another student's **APAAR ID** (or **PEN number**) onto a different student — recreating duplicate APAAR groups on prod (import 1574, 1,265 rows). Only the DB unique index caught it, surfacing as a raw `Ecto.Changeset` interpolated into a string and halting the run with an unclear message.

## Fix
- Add **`Users.validate_identifier_conflicts/2`** — a pre-write check that mirrors the student table's global unique constraints and returns a clear, human-readable message (`"APAAR ID '…' already exists for another student"`). Only identifiers present in the row are checked; the student being updated is excluded (re-saving its own identifiers is allowed).
- **`StudentUpdateService.update_student_with_user_data/2`** runs the check before writing, so it covers both the CSV import and `update_student_by_student_id/2`.
- The import framework already prepends the CSV row number, so a conflict is persisted as `%{row: N, error: "APAAR ID '…' already exists for another student"}` and the offending row fails cleanly instead of overwriting another student.

### Import behavior
Kept the existing fail-fast model (a row error halts the run), now with a clear, row-attributed message. Rows before the conflict stay applied; the operator fixes the sheet and re-runs. No change to the global import loop.

### Why `student_id` is not checked here
The merged auth-group-scoping work makes `student_id` unique only **within an auth group** (see `create_or_update_student/1`). A global `student_id` check would falsely reject an update to any student whose id is legitimately reused in another auth group (the update row carries the student's own id). So the guard covers only the genuinely-global identifiers the DB enforces: **`apaar_id`, `pen_number`**. (PEN is not yet an importable CSV column; the guard covers it at the service layer for when it is, and for direct service calls.)

## Tests
- Service-level: rejects moving another student's `apaar_id`/`pen_number`; allows re-saving own identifiers; allows a new non-conflicting identifier.
- Users context: unit tests for `validate_identifier_conflicts/2`, including that `student_id` is **not** flagged.
- End-to-end: first `student_update` worker test — a conflicting APAAR row halts the import with a clear error and leaves the other student untouched (reproduces the prod incident).

All new tests pass; `mix format`, `mix credo`, and `mix compile --warnings-as-errors` are clean.

## ⚠️ Pre-existing `main` issues (NOT introduced by this PR, not fixed here)
1. **Duplicate migration version `20260701120000`** — shared by `add_lms_student_ingestion.exs` and `add_user_session_indexes.exs`. This makes `mix ecto.migrate` fail on a fresh DB, so **CI on this PR will be red until it is resolved on `main`** (e.g. renumber one migration). Independent of this change.
2. **Global `student_id` unique index vs auth-group scoping** — the LMS-ingestion migration creates `student_student_id_unique_not_null` (never dropped in any `up`), while the auth-group-scoping feature expects `student_id` not to be globally unique. As a result, 3 tests in `users_test.exs` ("create_or_update_student/1 auth-group scoping") fail on clean `main`. Independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)