### PR TITLE
Deploy bulk student upload fixes to production

### DIFF
--- a/lib/dbservice/lms_student_ingestion.ex
+++ b/lib/dbservice/lms_student_ingestion.ex
@@ -22,6 +22,11 @@ defmodule Dbservice.LmsStudentIngestion do
   @auth_group "EnableStudents"
   @cbse_board "CBSE"
   @nvs_program_id 64
+  @duplicate_identifier_labels %{
+    "pen_number" => "PEN Number",
+    "g10_roll_no" => "Grade 10 Roll no",
+    "student_id" => "Generated Student ID"
+  }
   @empty_totals %{
     "created" => 0,
     "duplicate_in_file" => 0,
@@ -60,23 +65,36 @@ defmodule Dbservice.LmsStudentIngestion do
   def bulk_create(_params), do: {:error, :bad_request, %{"error" => "rows must be a list"}}
 
   defp classify_rows(rows, school, program_id) do
-    rows
-    |> Enum.map_reduce(MapSet.new(), fn row, seen ->
+    duplicate_keys =
+      rows
+      |> Enum.flat_map(&identifier_keys/1)
+      |> Enum.frequencies()
+      |> Enum.filter(fn {_key, count} -> count > 1 end)
+      |> Enum.map(&elem(&1, 0))
+      |> MapSet.new()
+
+    Enum.map(rows, fn row ->
       identifiers = identifier_keys(row)
+
+      duplicate_identifiers =
+        row
+        |> identifiers()
+        |> Enum.filter(fn {key, value} ->
+          MapSet.member?(duplicate_keys, "#{key}:#{value}")
+        end)
+        |> Enum.map(fn {key, _value} -> Map.fetch!(@duplicate_identifier_labels, key) end)
 
       cond do
         identifiers == [] ->
-          {{:skip, rejected(row, ["PEN Number or Grade 10 Roll no is required"])}, seen}
+          {:skip, rejected(row, ["PEN Number or Grade 10 Roll no is required"])}
 
-        Enum.any?(identifiers, &MapSet.member?(seen, &1)) ->
-          {{:skip, result(row, "duplicate_in_file")}, seen}
+        duplicate_identifiers != [] ->
+          {:skip, duplicate_in_file(row, duplicate_identifiers)}
 
         true ->
-          seen = Enum.reduce(identifiers, seen, &MapSet.put(&2, &1))
-          {classify_row(row, school, program_id), seen}
+          classify_row(row, school, program_id)
       end
     end)
-    |> elem(0)
   end
 
   defp classify_row(row, nil, _program_id), do: {:skip, rejected(row, ["School not found"])}
@@ -171,14 +189,14 @@ defmodule Dbservice.LmsStudentIngestion do
         {:error, :student, _changeset, _changes} ->
           result =
             case existing_student(row) do
-              nil -> rejected(row, ["Student could not be created"])
+              nil -> rejected(row, ["Student could not be created. Please contact the admin"])
               existing -> already_exists(row, existing, school.code)
             end
 
           {result, nil}
 
         {:error, _step, _reason, _changes} ->
-          {rejected(row, ["Student could not be created"]), nil}
+          {rejected(row, ["Student could not be created. Please contact the admin"]), nil}
       end
     else
       {:error, message} -> {rejected(row, [message]), nil}
@@ -370,18 +388,18 @@ defmodule Dbservice.LmsStudentIngestion do
   defp validate_pen(row) do
     case {row["pen_number"], get_in(row, ["student", "pen_number"])} do
       {value, _normalized} when not is_nil(value) and not is_binary(value) ->
-        {:error, "PEN Number must be exactly 11 digits and cannot start with zero"}
+        {:error, "PEN Number must be exactly 11 digits"}
 
       {_input, nil} ->
         :ok
 
       {_input, pen} when is_binary(pen) ->
-        if Regex.match?(~r/^[1-9][0-9]{10}$/, pen),
+        if Regex.match?(~r/^[0-9]{11}$/, pen),
           do: :ok,
-          else: {:error, "PEN Number must be exactly 11 digits and cannot start with zero"}
+          else: {:error, "PEN Number must be exactly 11 digits"}
 
       _ ->
-        {:error, "PEN Number must be exactly 11 digits and cannot start with zero"}
+        {:error, "PEN Number must be exactly 11 digits"}
     end
   end
 
@@ -454,13 +472,13 @@ defmodule Dbservice.LmsStudentIngestion do
   defp identifier_conflict(student_by_id, student_by_pen, student_id, pen_number) do
     cond do
       student_by_id && student_by_pen && student_by_id.id != student_by_pen.id ->
-        "PEN Number and generated Student ID match different existing students"
+        "The PEN Number and the Student ID generated from Grade and Grade 10 Roll no match different existing records. Correct the PEN Number, Grade, or Grade 10 Roll no."
 
       student_by_id && conflicting_identifier?(student_by_id.pen_number, pen_number) ->
-        "PEN Number conflicts with the existing generated Student ID"
+        "The Grade 10 Roll no already exists for a student with a different PEN Number. Correct or remove the Grade 10 Roll no to proceed using the PEN Number."
 
       student_by_pen && conflicting_identifier?(student_by_pen.student_id, student_id) ->
-        "Generated Student ID conflicts with the existing PEN Number"
+        "The PEN Number already exists with a different Student ID. Correct or remove the PEN Number to proceed using the Grade 10 Roll no."
 
       true ->
         nil
@@ -532,13 +550,12 @@ defmodule Dbservice.LmsStudentIngestion do
   end
 
   defp identifiers(row) do
-    %{
-      "student_id" => get_in(row, ["student", "student_id"]),
-      "pen_number" => get_in(row, ["student", "pen_number"]),
-      "g10_roll_no" => get_in(row, ["student", "g10_roll_no"])
-    }
+    [
+      {"pen_number", get_in(row, ["student", "pen_number"])},
+      {"g10_roll_no", get_in(row, ["student", "g10_roll_no"])},
+      {"student_id", get_in(row, ["student", "student_id"])}
+    ]
     |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
-    |> Map.new()
   end
 
   defp audit_identifiers(row, user, student) do
@@ -649,6 +666,12 @@ defmodule Dbservice.LmsStudentIngestion do
   end
 
   defp rejected(row, errors), do: row |> result("rejected") |> Map.put("row_errors", errors)
+
+  defp duplicate_in_file(row, identifiers) do
+    row
+    |> result("duplicate_in_file")
+    |> Map.put("duplicate_identifiers", identifiers)
+  end
 
   defp result(row, status) do
     %{

--- a/lib/dbservice/lms_student_ingestion.ex
+++ b/lib/dbservice/lms_student_ingestion.ex
@@ -22,6 +22,7 @@ defmodule Dbservice.LmsStudentIngestion do
   @auth_group "EnableStudents"
   @cbse_board "CBSE"
   @nvs_program_id 64
+  @row_concurrency 8
   @duplicate_identifier_labels %{
     "pen_number" => "PEN Number",
     "g10_roll_no" => "Grade 10 Roll no",
@@ -41,13 +42,17 @@ defmodule Dbservice.LmsStudentIngestion do
     classified =
       rows
       |> Enum.map(&normalize_row(&1, params["academic_year"]))
-      |> classify_rows(school, program_id)
+      |> classify_rows()
 
     results_with_audits =
-      Enum.map(classified, fn
-        {:create, row} -> create_row(params, school, row)
-        {:skip, result} -> {result, nil}
-      end)
+      classified
+      |> Task.async_stream(
+        &process_row(&1, params, school, program_id),
+        max_concurrency: @row_concurrency,
+        ordered: true,
+        timeout: :infinity
+      )
+      |> Enum.map(fn {:ok, result} -> result end)
 
     results = Enum.map(results_with_audits, &elem(&1, 0))
     final_totals = totals(results)
@@ -64,7 +69,7 @@ defmodule Dbservice.LmsStudentIngestion do
 
   def bulk_create(_params), do: {:error, :bad_request, %{"error" => "rows must be a list"}}
 
-  defp classify_rows(rows, school, program_id) do
+  defp classify_rows(rows) do
     duplicate_keys =
       rows
       |> Enum.flat_map(&identifier_keys/1)
@@ -92,9 +97,18 @@ defmodule Dbservice.LmsStudentIngestion do
           {:skip, duplicate_in_file(row, duplicate_identifiers)}
 
         true ->
-          classify_row(row, school, program_id)
+          {:process, row}
       end
     end)
+  end
+
+  defp process_row({:skip, result}, _params, _school, _program_id), do: {result, nil}
+
+  defp process_row({:process, row}, params, school, program_id) do
+    case classify_row(row, school, program_id) do
+      {:create, row} -> create_row(params, school, row)
+      {:skip, result} -> {result, nil}
+    end
   end
 
   defp classify_row(row, nil, _program_id), do: {:skip, rejected(row, ["School not found"])}

--- a/lib/dbservice/users/student.ex
+++ b/lib/dbservice/users/student.ex
@@ -131,9 +131,7 @@ defmodule Dbservice.Users.Student do
           value -> value
         end
     end)
-    |> validate_format(:pen_number, ~r/^[1-9][0-9]{10}$/,
-      message: "must be exactly 11 digits and cannot start with zero"
-    )
+    |> validate_format(:pen_number, ~r/^[0-9]{11}$/, message: "must be exactly 11 digits")
     |> unique_constraint(:student_id, name: :student_student_id_unique_not_null)
     |> unique_constraint(:apaar_id, name: :student_apaar_id_unique_not_null)
     |> unique_constraint(:pen_number, name: :student_pen_number_unique_not_null)

--- a/test/dbservice/users_test.exs
+++ b/test/dbservice/users_test.exs
@@ -254,20 +254,20 @@ defmodule Dbservice.UsersTest do
       assert student.pen_number == nil
     end
 
-    test "create_student/1 trims a non-blank PEN" do
-      assert {:ok, %Student{pen_number: "12345678901"}} =
-               Users.create_student(%{user_id: user_fixture().id, pen_number: " 12345678901 "})
+    test "create_student/1 trims a non-blank PEN and allows a leading zero" do
+      assert {:ok, %Student{pen_number: "01234567890"}} =
+               Users.create_student(%{user_id: user_fixture().id, pen_number: " 01234567890 "})
     end
 
     test "create_student/1 rejects invalid PEN formats" do
-      for pen_number <- ["abc", "01234567890", "1234567890", "123456789012"] do
+      for pen_number <- ["abc", "1234567890", "123456789012"] do
         assert {:error, changeset} =
                  Users.create_student(%{
                    user_id: user_fixture().id,
                    pen_number: pen_number
                  })
 
-        assert {"must be exactly 11 digits and cannot start with zero", _} =
+        assert {"must be exactly 11 digits", _} =
                  changeset.errors[:pen_number]
       end
     end

--- a/test/dbservice_web/controllers/lms_student_ingestion_controller_test.exs
+++ b/test/dbservice_web/controllers/lms_student_ingestion_controller_test.exs
@@ -164,16 +164,24 @@ defmodule DbserviceWeb.LmsStudentIngestionControllerTest do
         |> post("/api/lms/students/bulk-create-with-enrollments", payload(school, rows))
         |> json_response(200)
 
-      assert response["totals"]["rejected"] == 6
+      assert response["totals"] == %{
+               "total" => 6,
+               "created" => 1,
+               "duplicate_in_file" => 0,
+               "already_exists" => 0,
+               "rejected" => 5
+             }
 
       assert Enum.map(response["results"], & &1["row_errors"]) == [
-               ["PEN Number must be exactly 11 digits and cannot start with zero"],
-               ["PEN Number must be exactly 11 digits and cannot start with zero"],
-               ["PEN Number must be exactly 11 digits and cannot start with zero"],
+               [],
+               ["PEN Number must be exactly 11 digits"],
+               ["PEN Number must be exactly 11 digits"],
                ["PEN Number or Grade 10 Roll no is required"],
                ["Grade 10 Board must be CBSE or Others"],
                ["Grade 10 Board must be CBSE or Others"]
              ]
+
+      assert Repo.get_by!(Student, pen_number: "01234567890")
     end
 
     test "rejects leading-zero phone and CBSE roll numbers", %{conn: conn} do
@@ -446,7 +454,12 @@ defmodule DbserviceWeb.LmsStudentIngestionControllerTest do
         )
         |> json_response(200)
 
-      assert [%{"status" => "rejected", "row_errors" => ["Student could not be created"]}] =
+      assert [
+               %{
+                 "status" => "rejected",
+                 "row_errors" => ["Student could not be created. Please contact the admin"]
+               }
+             ] =
                response["results"]
 
       assert Repo.aggregate(User, :count, :id) == before_users
@@ -495,7 +508,7 @@ defmodule DbserviceWeb.LmsStudentIngestionControllerTest do
       assert Enum.map(response["results"], & &1["status"]) == [
                "already_exists",
                "rejected",
-               "created",
+               "duplicate_in_file",
                "duplicate_in_file"
              ]
 
@@ -513,8 +526,11 @@ defmodule DbserviceWeb.LmsStudentIngestionControllerTest do
              } = Enum.at(response["results"], 0)["existing_match"]
 
       assert Enum.at(response["results"], 1)["row_errors"] == [
-               "PEN Number and generated Student ID match different existing students"
+               "The PEN Number and the Student ID generated from Grade and Grade 10 Roll no match different existing records. Correct the PEN Number, Grade, or Grade 10 Roll no."
              ]
+
+      assert Enum.at(response["results"], 2)["duplicate_identifiers"] == ["PEN Number"]
+      assert Enum.at(response["results"], 3)["duplicate_identifiers"] == ["PEN Number"]
     end
 
     test "rejects a new PEN when the generated Student ID belongs to another PEN", %{conn: conn} do
@@ -546,7 +562,42 @@ defmodule DbserviceWeb.LmsStudentIngestionControllerTest do
                %{
                  "status" => "rejected",
                  "row_errors" => [
-                   "PEN Number conflicts with the existing generated Student ID"
+                   "The Grade 10 Roll no already exists for a student with a different PEN Number. Correct or remove the Grade 10 Roll no to proceed using the PEN Number."
+                 ]
+               }
+             ] = response["results"]
+    end
+
+    test "rejects an existing PEN when Grade and roll generate another Student ID", %{conn: conn} do
+      school = insert_school!(%{program_ids: []})
+      ensure_nvs_program!()
+      insert_auth_group!("EnableStudents")
+      insert_grade!(11)
+      insert_nvs_batch!(11, "nda")
+
+      Dbservice.UsersFixtures.student_fixture(%{
+        student_id: "202811111111",
+        pen_number: "12345678909"
+      })
+
+      response =
+        conn
+        |> post(
+          "/api/lms/students/bulk-create-with-enrollments",
+          payload(school, [
+            valid_pen_row("12345678909", %{
+              "g10_board" => "CBSE",
+              "g10_roll_no" => "12345678"
+            })
+          ])
+        )
+        |> json_response(200)
+
+      assert [
+               %{
+                 "status" => "rejected",
+                 "row_errors" => [
+                   "The PEN Number already exists with a different Student ID. Correct or remove the PEN Number to proceed using the Grade 10 Roll no."
                  ]
                }
              ] = response["results"]
@@ -759,10 +810,74 @@ defmodule DbserviceWeb.LmsStudentIngestionControllerTest do
 
       response = json_response(conn, 200)
 
-      assert response["totals"]["created"] == 1
-      assert response["totals"]["duplicate_in_file"] == 1
-      assert Enum.map(response["results"], & &1["status"]) == ["created", "duplicate_in_file"]
-      assert Repo.aggregate(Student, :count, :id) == before_students + 1
+      assert response["totals"]["created"] == 0
+      assert response["totals"]["duplicate_in_file"] == 2
+
+      assert Enum.map(response["results"], & &1["status"]) == [
+               "duplicate_in_file",
+               "duplicate_in_file"
+             ]
+
+      assert Enum.map(response["results"], & &1["duplicate_identifiers"]) == [
+               ["PEN Number", "Grade 10 Roll no", "Generated Student ID"],
+               ["PEN Number", "Grade 10 Roll no", "Generated Student ID"]
+             ]
+
+      assert Repo.aggregate(Student, :count, :id) == before_students
+    end
+
+    test "rejects every row sharing only a PEN Number", %{conn: conn} do
+      school = insert_eligible_school!()
+      insert_auth_group!("EnableStudents")
+      insert_grade!(11)
+      insert_nvs_batch!(11, "engineering")
+      before_students = Repo.aggregate(Student, :count, :id)
+
+      response =
+        conn
+        |> post(
+          "/api/lms/students/bulk-create-with-enrollments",
+          payload(school, [
+            valid_row(%{"g10_roll_no" => "12345678"}),
+            valid_row(%{"g10_roll_no" => "87654321"})
+          ])
+        )
+        |> json_response(200)
+
+      assert Enum.map(response["results"], & &1["duplicate_identifiers"]) == [
+               ["PEN Number"],
+               ["PEN Number"]
+             ]
+
+      assert Repo.aggregate(Student, :count, :id) == before_students
+    end
+
+    test "rejects every row sharing only a Grade 10 Roll no", %{conn: conn} do
+      school = insert_eligible_school!()
+      insert_auth_group!("EnableStudents")
+      insert_grade!(11)
+      insert_grade!(12)
+      insert_nvs_batch!(11, "engineering")
+      insert_nvs_batch!(12, "engineering")
+      before_students = Repo.aggregate(Student, :count, :id)
+
+      response =
+        conn
+        |> post(
+          "/api/lms/students/bulk-create-with-enrollments",
+          payload(school, [
+            valid_row(%{"grade" => 11, "pen_number" => "12345678901"}),
+            valid_row(%{"grade" => 12, "pen_number" => "12345678902"})
+          ])
+        )
+        |> json_response(200)
+
+      assert Enum.map(response["results"], & &1["duplicate_identifiers"]) == [
+               ["Grade 10 Roll no"],
+               ["Grade 10 Roll no"]
+             ]
+
+      assert Repo.aggregate(Student, :count, :id) == before_students
     end
 
     test "returns already_exists for existing identifiers without updating records", %{conn: conn} do


### PR DESCRIPTION
Deploys the DB Service changes from #650 to production.

- Finalizes bulk student upload validation and error handling.
- Processes valid upload rows concurrently to avoid timeouts.
- Updates the related tests.