### PR TITLE
Deploy Student ID uniqueness migration to production

### DIFF
--- a/lib/dbservice/users/student.ex
+++ b/lib/dbservice/users/student.ex
@@ -134,7 +134,6 @@ defmodule Dbservice.Users.Student do
     |> validate_format(:pen_number, ~r/^[1-9][0-9]{10}$/,
       message: "must be exactly 11 digits and cannot start with zero"
     )
-    |> unique_constraint(:student_id, name: :student_student_id_unique_not_null)
     |> unique_constraint(:apaar_id, name: :student_apaar_id_unique_not_null)
     |> unique_constraint(:pen_number, name: :student_pen_number_unique_not_null)
     |> validate_required([:user_id])

--- a/priv/repo/migrations/20260723180512_drop_global_student_id_unique_index.exs
+++ b/priv/repo/migrations/20260723180512_drop_global_student_id_unique_index.exs
@@ -1,0 +1,20 @@
+defmodule Dbservice.Repo.Migrations.DropGlobalStudentIdUniqueIndex do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+
+  def up do
+    drop_if_exists index(:student, [:student_id],
+                     name: :student_student_id_unique_not_null,
+                     concurrently: true
+                   )
+  end
+
+  def down do
+    create_if_not_exists unique_index(:student, [:student_id],
+                           where: "student_id IS NOT NULL AND BTRIM(student_id) <> ''",
+                           name: :student_student_id_unique_not_null,
+                           concurrently: true
+                         )
+  end
+end

--- a/priv/repo/migrations/20260723180512_drop_global_student_id_unique_index.exs
+++ b/priv/repo/migrations/20260723180512_drop_global_student_id_unique_index.exs
@@ -2,6 +2,7 @@ defmodule Dbservice.Repo.Migrations.DropGlobalStudentIdUniqueIndex do
   use Ecto.Migration
 
   @disable_ddl_transaction true
+  @disable_migration_lock true
 
   def up do
     drop_if_exists index(:student, [:student_id],

--- a/test/dbservice_web/controllers/lms_student_ingestion_controller_test.exs
+++ b/test/dbservice_web/controllers/lms_student_ingestion_controller_test.exs
@@ -1090,7 +1090,7 @@ defmodule DbserviceWeb.LmsStudentIngestionControllerTest do
   end
 
   describe "student identifier schema constraints" do
-    test "enforces uniqueness only when Student ID or APAAR ID is present" do
+    test "allows duplicate Student IDs while keeping APAAR ID unique" do
       assert {:ok, _student} = create_student(%{"student_id" => nil, "apaar_id" => nil})
       assert {:ok, _student} = create_student(%{"student_id" => nil, "apaar_id" => nil})
       assert {:ok, _student} = create_student(%{"student_id" => " ", "apaar_id" => " "})
@@ -1099,10 +1099,8 @@ defmodule DbserviceWeb.LmsStudentIngestionControllerTest do
       assert {:ok, _student} =
                create_student(%{"student_id" => "SID-1", "apaar_id" => "111111111111"})
 
-      assert {:error, changeset} =
+      assert {:ok, _student} =
                create_student(%{"student_id" => "SID-1", "apaar_id" => "222222222222"})
-
-      assert {"has already been taken", _} = changeset.errors[:student_id]
 
       assert {:error, changeset} =
                create_student(%{"student_id" => "SID-2", "apaar_id" => "111111111111"})


### PR DESCRIPTION
Deploys #649 to production.

- Removes the global Student ID unique index.
- Keeps APAAR ID and PEN uniqueness.
- Includes the tested migration and validation changes from main.