### PR TITLE
Fix duplicate batch/exclusive group_user memberships (NVS)

### DIFF
--- a/lib/dbservice/lms_student_update.ex
+++ b/lib/dbservice/lms_student_update.ex
@@ -699,11 +699,27 @@ defmodule Dbservice.LmsStudentUpdate do
     end
   end
 
-  defp replace_existing_group_user(old_group_users, user_id, new_group_id) do
-    case old_group_users do
-      [] -> GroupUsers.create_group_user(%{user_id: user_id, group_id: new_group_id})
-      [old_group_user] -> GroupUsers.update_group_user(old_group_user, %{group_id: new_group_id})
-      _ -> {:error, :multiple_group_users}
+  defp replace_existing_group_user([], user_id, new_group_id),
+    do: GroupUsers.create_group_user(%{user_id: user_id, group_id: new_group_id})
+
+  defp replace_existing_group_user(old_group_users, _user_id, new_group_id) do
+    # Self-heal legacy duplicates instead of erroring: keep one row (preferring one
+    # already pointing at the target), repoint it, and delete the rest. Callers scope
+    # `old_group_users` (batch by program, other types by type), so collapsing the
+    # list to a single row is safe and unblocks grade/stream edits for students who
+    # still carry duplicate batch memberships.
+    {keep, drop} =
+      case Enum.split_with(old_group_users, &(&1.group_id == new_group_id)) do
+        {[match | extra], others} -> {match, extra ++ others}
+        {[], [first | rest]} -> {first, rest}
+      end
+
+    Enum.each(drop, &GroupUsers.delete_group_user/1)
+
+    if keep.group_id == new_group_id do
+      {:ok, keep}
+    else
+      GroupUsers.update_group_user(keep, %{group_id: new_group_id})
     end
   end
 

--- a/lib/dbservice/services/batch_enrollment_service.ex
+++ b/lib/dbservice/services/batch_enrollment_service.ex
@@ -12,6 +12,7 @@ defmodule Dbservice.Services.BatchEnrollmentService do
   alias Dbservice.EnrollmentRecords.EnrollmentRecord
   alias Dbservice.Batches.Batch
   alias Dbservice.Groups.Group
+  alias Dbservice.Groups.GroupUser
   alias Dbservice.Statuses.Status
   alias Dbservice.Grades.Grade
   alias Dbservice.Users
@@ -136,35 +137,102 @@ defmodule Dbservice.Services.BatchEnrollmentService do
   end
 
   @doc """
-  Updates or creates a group user record for the batch
-  """
-  def update_batch_user(user_id, group_id, group_users) do
-    batch_group_user = Enum.find(group_users, &group_user_by_type?(&1, "batch"))
+  Reconciles the batch group_user memberships for a user after a batch move.
 
-    if batch_group_user do
-      # Update existing group user with the new group ID
-      GroupUsers.update_group_user(batch_group_user, %{group_id: group_id})
-    else
-      # Create a new group user record
-      GroupUsers.create_group_user(%{user_id: user_id, group_id: group_id})
+  Scoped to the *target batch's program*, so a student legitimately enrolled in
+  batches of other programs keeps those memberships. Within the program it
+  collapses the batch memberships to exactly one row pointing at `group_id`,
+  deleting any stale/duplicate batch group_user rows. This is the fix for the
+  duplicate-batch-membership bug: the previous `Enum.find` repointed only the
+  first matching row and left the rest behind.
+
+  The passed-in `group_users` list is ignored on purpose — scoping is re-queried
+  with the program/type joins the caller's list does not carry.
+  """
+  def update_batch_user(user_id, group_id, _group_users) do
+    case batch_for_group_id(group_id) do
+      nil ->
+        GroupUsers.create_group_user(%{user_id: user_id, group_id: group_id})
+
+      new_batch ->
+        user_id
+        |> batch_group_users_in_program(new_batch.program_id)
+        |> reconcile_group_user(user_id, group_id)
     end
   end
 
   @doc """
-  Updates grade in group_user table
-  """
-  def update_grade_user(user_id, grade_group_id, group_users) do
-    grade_group_user = Enum.find(group_users, &group_user_by_type?(&1, "grade"))
+  Reconciles the grade group_user membership for a user.
 
-    if grade_group_user do
-      # Update existing grade group user with the new group ID
-      GroupUsers.update_group_user(grade_group_user, %{group_id: grade_group_id})
-    else
-      # Create a new grade group user if one doesn't exist
-      GroupUsers.create_group_user(%{
-        user_id: user_id,
-        group_id: grade_group_id
-      })
+  Grade is an exclusive membership type, so this collapses *all* of the user's
+  grade group_user rows to exactly one pointing at `grade_group_id`.
+  """
+  def update_grade_user(user_id, grade_group_id, _group_users) do
+    user_id
+    |> grade_group_users()
+    |> reconcile_group_user(user_id, grade_group_id)
+  end
+
+  # Resolves the batch behind a "batch"-type group id (returns %Batch{} or nil).
+  defp batch_for_group_id(group_id) do
+    from(g in Group,
+      join: b in Batch,
+      on: b.id == g.child_id,
+      where: g.id == ^group_id and g.type == "batch",
+      select: b
+    )
+    |> Repo.one()
+  end
+
+  defp batch_group_users_in_program(user_id, nil) do
+    from(gu in GroupUser,
+      join: g in Group,
+      on: g.id == gu.group_id and g.type == "batch",
+      join: b in Batch,
+      on: b.id == g.child_id,
+      where: gu.user_id == ^user_id and is_nil(b.program_id),
+      order_by: [asc: gu.inserted_at, asc: gu.id]
+    )
+    |> Repo.all()
+  end
+
+  defp batch_group_users_in_program(user_id, program_id) do
+    from(gu in GroupUser,
+      join: g in Group,
+      on: g.id == gu.group_id and g.type == "batch",
+      join: b in Batch,
+      on: b.id == g.child_id,
+      where: gu.user_id == ^user_id and b.program_id == ^program_id,
+      order_by: [asc: gu.inserted_at, asc: gu.id]
+    )
+    |> Repo.all()
+  end
+
+  defp grade_group_users(user_id) do
+    from(gu in GroupUser,
+      join: g in Group,
+      on: g.id == gu.group_id and g.type == "grade",
+      where: gu.user_id == ^user_id,
+      order_by: [asc: gu.inserted_at, asc: gu.id]
+    )
+    |> Repo.all()
+  end
+
+  # Collapses the (already scoped) `existing` group_user rows to exactly one row
+  # pointing at `target_group_id`, deleting the rest. Prefers reusing a row that
+  # already points at the target.
+  defp reconcile_group_user(existing, user_id, target_group_id) do
+    case Enum.split_with(existing, &(&1.group_id == target_group_id)) do
+      {[keep | dup_matches], others} ->
+        Enum.each(dup_matches ++ others, &GroupUsers.delete_group_user/1)
+        {:ok, keep}
+
+      {[], [keep | drop]} ->
+        Enum.each(drop, &GroupUsers.delete_group_user/1)
+        GroupUsers.update_group_user(keep, %{group_id: target_group_id})
+
+      {[], []} ->
+        GroupUsers.create_group_user(%{user_id: user_id, group_id: target_group_id})
     end
   end
 
@@ -181,16 +249,5 @@ defmodule Dbservice.Services.BatchEnrollmentService do
   def grade_changed?(user_id, new_grade_id) do
     current_grade = EnrollmentRecords.get_current_grade_id(user_id)
     current_grade != new_grade_id
-  end
-
-  @doc """
-  Checks if a group user is associated with a specific type
-  """
-  def group_user_by_type?(group_user, type) do
-    from(g in Group,
-      where: g.id == ^group_user.group_id and g.type == ^type,
-      select: g.id
-    )
-    |> Repo.exists?()
   end
 end

--- a/priv/repo/migrations/20260725120000_dedup_exclusive_enrollment_records.exs
+++ b/priv/repo/migrations/20260725120000_dedup_exclusive_enrollment_records.exs
@@ -1,0 +1,166 @@
+defmodule Dbservice.Repo.Migrations.DedupExclusiveEnrollmentRecords do
+  @moduledoc """
+  ISSUE 1 remediation. Some users hold more than one `is_current = true`
+  `enrollment_record` for an exclusive `group_type` (`auth_group`, `school`,
+  `grade`). App code treats these as exclusive (`EnrollmentService`
+  `@exclusive_group_types` / `validate_no_existing_enrollment/3`) but nothing
+  enforced it at the DB level. This migration collapses the duplicates:
+
+    (2a) Keep the current ER with the newest `start_date`
+         (tie-break: newest `inserted_at`, then max `id`); mark the rest
+         `is_current = false` and stamp `end_date` (mirrors how the app
+         supersedes an enrollment).
+    (2b) Mirror the result into `group_user`: keep only the group_user rows that
+         match the surviving current ER child (per exclusive type); delete stale
+         and exact-duplicate rows. Users whose surviving current ER has no
+         matching group_user are skipped for manual review (RAISE NOTICE).
+
+  Reversible: the rows changed/deleted are snapshotted into `bak_*` tables that
+  `down/0` restores from and then drops. The backup tables persist after `up/0`
+  as the safety net for this destructive repair.
+  """
+  use Ecto.Migration
+
+  def up do
+    # --- Snapshot the ER rows we are about to flip (the "losers") -------------
+    execute("""
+    CREATE TABLE bak_20260725120000_er AS
+    SELECT er.id, er.is_current, er.end_date, er.updated_at
+    FROM enrollment_record er
+    JOIN (
+      SELECT id FROM (
+        SELECT id,
+               ROW_NUMBER() OVER (
+                 PARTITION BY user_id, group_type
+                 ORDER BY start_date DESC NULLS LAST, inserted_at DESC, id DESC
+               ) AS rn
+        FROM enrollment_record
+        WHERE is_current = true
+          AND group_type IN ('auth_group','school','grade')
+      ) ranked
+      WHERE ranked.rn > 1
+    ) losers ON losers.id = er.id;
+    """)
+
+    # --- (2a) Flip surplus current exclusive ER rows --------------------------
+    execute("""
+    WITH ranked AS (
+      SELECT id, user_id, group_type, start_date,
+             ROW_NUMBER() OVER (
+               PARTITION BY user_id, group_type
+               ORDER BY start_date DESC NULLS LAST, inserted_at DESC, id DESC
+             ) AS rn
+      FROM enrollment_record
+      WHERE is_current = true
+        AND group_type IN ('auth_group','school','grade')
+    ),
+    winners AS (SELECT user_id, group_type, start_date FROM ranked WHERE rn = 1),
+    losers  AS (SELECT id, user_id, group_type FROM ranked WHERE rn > 1)
+    UPDATE enrollment_record er
+    SET is_current = false,
+        end_date   = GREATEST(er.start_date, w.start_date),
+        updated_at = NOW()
+    FROM losers l
+    JOIN winners w ON w.user_id = l.user_id AND w.group_type = l.group_type
+    WHERE er.id = l.id;
+    """)
+
+    # --- Snapshot the group_user rows we are about to delete ------------------
+    # For each (user, exclusive type) that HAS a current ER with a matching
+    # group_user (i.e. not manual-review, and in scope), keep exactly one row —
+    # the one matching the surviving current ER child, latest inserted_at (max id
+    # tie-break) — and delete the rest (stale-child rows and exact duplicates).
+    # (user,type) pairs with no current ER, or whose current child has no matching
+    # group_user, are left entirely untouched. Uses window functions + anti-join
+    # instead of correlated subqueries so it runs in a single pass.
+    execute("""
+    CREATE TABLE bak_20260725120000_group_user AS
+    WITH exclusive_gu AS (
+      SELECT gu.id AS gu_id, gu.user_id, gu.inserted_at,
+             g.type AS group_type, g.child_id
+      FROM group_user gu
+      JOIN "group" g ON g.id = gu.group_id
+                    AND g.type IN ('auth_group','school','grade')
+    ),
+    current_er AS (
+      SELECT er.user_id, er.group_type, er.group_id AS child_id
+      FROM enrollment_record er
+      WHERE er.is_current = true
+        AND er.group_type IN ('auth_group','school','grade')
+    ),
+    -- (user,type) whose surviving current ER child is present in group_user.
+    -- Post-2a there is exactly one current child per (user,type).
+    prunable AS (
+      SELECT DISTINCT ce.user_id, ce.group_type, ce.child_id
+      FROM current_er ce
+      JOIN exclusive_gu eg
+        ON eg.user_id = ce.user_id
+       AND eg.group_type = ce.group_type
+       AND eg.child_id = ce.child_id
+    ),
+    ranked AS (
+      SELECT eg.gu_id,
+             ROW_NUMBER() OVER (
+               PARTITION BY eg.user_id, eg.group_type
+               ORDER BY (eg.child_id = p.child_id) DESC,
+                        eg.inserted_at DESC,
+                        eg.gu_id DESC
+             ) AS rn
+      FROM exclusive_gu eg
+      JOIN prunable p
+        ON p.user_id = eg.user_id AND p.group_type = eg.group_type
+    )
+    SELECT gu.*
+    FROM group_user gu
+    JOIN ranked r ON r.gu_id = gu.id
+    WHERE r.rn > 1;
+    """)
+
+    # --- (2b) Delete those group_user rows ------------------------------------
+    execute("""
+    DELETE FROM group_user gu
+    USING bak_20260725120000_group_user b
+    WHERE gu.id = b.id;
+    """)
+
+    # --- Report the manual-review population ----------------------------------
+    execute("""
+    DO $$
+    DECLARE n integer;
+    BEGIN
+      SELECT count(*) INTO n FROM (
+        SELECT DISTINCT ce.user_id, ce.group_type
+        FROM enrollment_record ce
+        LEFT JOIN "group" g
+          ON g.type = ce.group_type AND g.child_id = ce.group_id
+        LEFT JOIN group_user gu
+          ON gu.group_id = g.id AND gu.user_id = ce.user_id
+        WHERE ce.is_current = true
+          AND ce.group_type IN ('auth_group','school','grade')
+          AND gu.id IS NULL
+      ) s;
+      RAISE NOTICE 'ISSUE-1: % (user,type) pairs skipped for manual review (current ER with no matching group_user)', n;
+    END $$;
+    """)
+  end
+
+  def down do
+    execute("""
+    UPDATE enrollment_record er
+    SET is_current = b.is_current,
+        end_date   = b.end_date,
+        updated_at = b.updated_at
+    FROM bak_20260725120000_er b
+    WHERE er.id = b.id;
+    """)
+
+    execute("""
+    INSERT INTO group_user (id, group_id, user_id, inserted_at, updated_at)
+    SELECT id, group_id, user_id, inserted_at, updated_at
+    FROM bak_20260725120000_group_user;
+    """)
+
+    execute("DROP TABLE IF EXISTS bak_20260725120000_group_user;")
+    execute("DROP TABLE IF EXISTS bak_20260725120000_er;")
+  end
+end

--- a/priv/repo/migrations/20260725120001_dedup_batch_group_users.exs
+++ b/priv/repo/migrations/20260725120001_dedup_batch_group_users.exs
@@ -1,0 +1,109 @@
+defmodule Dbservice.Repo.Migrations.DedupBatchGroupUsers do
+  @moduledoc """
+  ISSUE 2 remediation. Students can have a single current batch in
+  `enrollment_record` but multiple batch rows in `group_user` (root cause:
+  `BatchEnrollmentService.update_batch_user/3` used to repoint only the first
+  matching row and never delete the rest). Duplicate batch memberships then made
+  grade/stream edits fail in `LmsStudentUpdate` (`:multiple_group_users`).
+
+  Keep rule (ER-anchored — the enrollment_record is the source of truth, because
+  `inserted_at` on group_user is unreliable after in-place repointing):
+
+    * Keep batch group_user rows whose `group.child_id` is one of the user's
+      CURRENT batch-ER `group_id`s.
+    * Delete batch group_user rows that match no current batch ER (orphans).
+    * For exact duplicates on the same current batch, keep the latest
+      `inserted_at` (tie-break max id).
+    * If any current-ER batch is absent from the user's batch group_user rows,
+      skip the WHOLE user for manual review (RAISE NOTICE) — we never risk
+      stripping a live membership.
+
+  Safe for legitimately multi-batch students: every current batch is kept.
+
+  Reversible: deleted rows are snapshotted into a `bak_*` table that `down/0`
+  re-inserts and then drops.
+  """
+  use Ecto.Migration
+
+  def up do
+    # Keepers = one row per current batch (latest inserted_at, max id tie-break)
+    # for users NOT in manual review. Deletable = every other batch group_user of
+    # those users (orphans + extra dups). Window function + anti-joins, single pass.
+    execute("""
+    CREATE TABLE bak_20260725120001_group_user AS
+    WITH batch_gu AS (
+      SELECT gu.id AS gu_id, gu.user_id, gu.inserted_at, g.child_id AS batch_id
+      FROM group_user gu
+      JOIN "group" g ON g.id = gu.group_id AND g.type = 'batch'
+    ),
+    current_batch_er AS (
+      SELECT DISTINCT er.user_id, er.group_id AS batch_id
+      FROM enrollment_record er
+      WHERE er.group_type = 'batch' AND er.is_current = true
+    ),
+    manual_review_users AS (
+      SELECT DISTINCT cbe.user_id
+      FROM current_batch_er cbe
+      LEFT JOIN batch_gu bg
+        ON bg.user_id = cbe.user_id AND bg.batch_id = cbe.batch_id
+      WHERE bg.gu_id IS NULL
+    ),
+    keepers AS (
+      SELECT gu_id FROM (
+        SELECT bg.gu_id,
+               ROW_NUMBER() OVER (
+                 PARTITION BY bg.user_id, bg.batch_id
+                 ORDER BY bg.inserted_at DESC, bg.gu_id DESC
+               ) AS rn
+        FROM batch_gu bg
+        JOIN current_batch_er cbe
+          ON cbe.user_id = bg.user_id AND cbe.batch_id = bg.batch_id
+        LEFT JOIN manual_review_users mru ON mru.user_id = bg.user_id
+        WHERE mru.user_id IS NULL
+      ) r
+      WHERE r.rn = 1
+    )
+    SELECT gu.*
+    FROM group_user gu
+    JOIN batch_gu bg ON bg.gu_id = gu.id
+    LEFT JOIN manual_review_users mru ON mru.user_id = bg.user_id
+    LEFT JOIN keepers k ON k.gu_id = gu.id
+    WHERE mru.user_id IS NULL
+      AND k.gu_id IS NULL;
+    """)
+
+    execute("""
+    DELETE FROM group_user gu
+    USING bak_20260725120001_group_user b
+    WHERE gu.id = b.id;
+    """)
+
+    execute("""
+    DO $$
+    DECLARE n integer;
+    BEGIN
+      SELECT count(*) INTO n FROM (
+        SELECT DISTINCT cbe.user_id
+        FROM enrollment_record cbe
+        LEFT JOIN "group" g
+          ON g.type = 'batch' AND g.child_id = cbe.group_id
+        LEFT JOIN group_user gu
+          ON gu.group_id = g.id AND gu.user_id = cbe.user_id
+        WHERE cbe.group_type = 'batch' AND cbe.is_current = true
+          AND gu.id IS NULL
+      ) s;
+      RAISE NOTICE 'ISSUE-2: % users skipped for manual review (current batch ER with no group_user)', n;
+    END $$;
+    """)
+  end
+
+  def down do
+    execute("""
+    INSERT INTO group_user (id, group_id, user_id, inserted_at, updated_at)
+    SELECT id, group_id, user_id, inserted_at, updated_at
+    FROM bak_20260725120001_group_user;
+    """)
+
+    execute("DROP TABLE IF EXISTS bak_20260725120001_group_user;")
+  end
+end

--- a/priv/repo/migrations/20260725120002_add_enrollment_record_exclusive_current_unique_index.exs
+++ b/priv/repo/migrations/20260725120002_add_enrollment_record_exclusive_current_unique_index.exs
@@ -1,0 +1,43 @@
+defmodule Dbservice.Repo.Migrations.AddEnrollmentRecordExclusiveCurrentUniqueIndex do
+  @moduledoc """
+  Enforces the exclusive-membership invariant at the DB level: at most one
+  `is_current = true` `enrollment_record` per `(user_id, group_type)` for the
+  exclusive types (`auth_group`, `school`, `grade`). Must run AFTER
+  `20260725120000_dedup_exclusive_enrollment_records`; the guard aborts the
+  migration if any duplicate remains.
+
+  `batch` is deliberately excluded — it is legitimately non-exclusive (a student
+  may hold current batch enrollments across multiple programs, which the
+  `centre_students` view depends on).
+  """
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM enrollment_record
+        WHERE is_current = true
+          AND group_type IN ('auth_group','school','grade')
+        GROUP BY user_id, group_type
+        HAVING COUNT(*) > 1
+      ) THEN
+        RAISE EXCEPTION 'enrollment_record has users with >1 current exclusive enrollment; run 20260725120000_dedup_exclusive_enrollment_records first';
+      END IF;
+    END $$;
+    """)
+
+    create unique_index(:enrollment_record, [:user_id, :group_type],
+             where: "is_current AND group_type IN ('auth_group','school','grade')",
+             name: :enrollment_record_current_exclusive_type_unique
+           )
+  end
+
+  def down do
+    drop_if_exists index(:enrollment_record, [:user_id, :group_type],
+                     name: :enrollment_record_current_exclusive_type_unique
+                   )
+  end
+end

--- a/test/dbservice/services/batch_enrollment_service_test.exs
+++ b/test/dbservice/services/batch_enrollment_service_test.exs
@@ -120,46 +120,6 @@ defmodule Dbservice.Services.BatchEnrollmentServiceTest do
     end
   end
 
-  describe "group_user_by_type?/2" do
-    test "returns true when group user is associated with type" do
-      user = user_fixture()
-      school = school_fixture()
-
-      # Get the group that was automatically created for the school
-      group = Dbservice.Groups.get_group_by_child_id_and_type(school.id, "school")
-
-      # Create group user
-      {:ok, group_user} =
-        Dbservice.GroupUsers.create_group_user(%{
-          user_id: user.id,
-          group_id: group.id
-        })
-
-      result = BatchEnrollmentService.group_user_by_type?(group_user, "school")
-
-      assert result == true
-    end
-
-    test "returns false when group user is not associated with type" do
-      user = user_fixture()
-      school = school_fixture()
-
-      # Get the group that was automatically created for the school
-      group = Dbservice.Groups.get_group_by_child_id_and_type(school.id, "school")
-
-      # Create group user
-      {:ok, group_user} =
-        Dbservice.GroupUsers.create_group_user(%{
-          user_id: user.id,
-          group_id: group.id
-        })
-
-      result = BatchEnrollmentService.group_user_by_type?(group_user, "batch")
-
-      assert result == false
-    end
-  end
-
   describe "get_grade_info/1" do
     test "returns grade info when grade exists" do
       grade = grade_fixture(%{number: 10})
@@ -281,6 +241,41 @@ defmodule Dbservice.Services.BatchEnrollmentServiceTest do
       assert {:ok, new_group_user} = result
       assert new_group_user.group_id == group.id
       assert new_group_user.user_id == user.id
+    end
+
+    test "collapses duplicate batch group users to the target, deleting the stale ones" do
+      user = user_fixture()
+      old_batch = batch_fixture()
+      stale_batch = batch_fixture()
+      new_batch = batch_fixture()
+
+      old_group = Dbservice.Groups.get_group_by_child_id_and_type(old_batch.id, "batch")
+      stale_group = Dbservice.Groups.get_group_by_child_id_and_type(stale_batch.id, "batch")
+      new_group = Dbservice.Groups.get_group_by_child_id_and_type(new_batch.id, "batch")
+
+      {:ok, _} =
+        Dbservice.GroupUsers.create_group_user(%{user_id: user.id, group_id: old_group.id})
+
+      {:ok, _} =
+        Dbservice.GroupUsers.create_group_user(%{user_id: user.id, group_id: stale_group.id})
+
+      # group_users arg is intentionally ignored by the implementation
+      result = BatchEnrollmentService.update_batch_user(user.id, new_group.id, [])
+
+      assert {:ok, kept} = result
+      assert kept.group_id == new_group.id
+
+      remaining =
+        Dbservice.Repo.all(
+          from(gu in Dbservice.Groups.GroupUser,
+            join: g in Dbservice.Groups.Group,
+            on: g.id == gu.group_id and g.type == "batch",
+            where: gu.user_id == ^user.id,
+            select: gu.group_id
+          )
+        )
+
+      assert remaining == [new_group.id]
     end
 
     test "creates new batch group user when existing group user is not of batch type" do

--- a/test/dbservice/services/enrollment_service_test.exs
+++ b/test/dbservice/services/enrollment_service_test.exs
@@ -359,33 +359,23 @@ defmodule Dbservice.Services.EnrollmentServiceTest do
       assert records == []
     end
 
-    test "updates multiple enrollment records for different academic years" do
+    test "supersedes the current enrollment when the academic year changes" do
       user = user_fixture()
       school = school_fixture(%{code: "TEST_SCHOOL"})
 
-      # Create multiple existing enrollment records for different academic years
-      enrollments = [
-        %{
-          "user_id" => user.id,
-          "group_id" => school.id,
-          "group_type" => "school",
-          "academic_year" => "2022-23",
-          "start_date" => ~D[2022-06-01],
-          "is_current" => true
-        },
-        %{
+      # A single current enrollment for the prior academic year. The
+      # exclusive-current unique index now allows at most one current exclusive
+      # enrollment per user, so the pre-existing multi-current state is no longer
+      # representable (it was the Issue-1 defect this constraint prevents).
+      {:ok, _} =
+        Dbservice.EnrollmentRecords.create_enrollment_record(%{
           "user_id" => user.id,
           "group_id" => school.id,
           "group_type" => "school",
           "academic_year" => "2023-24",
           "start_date" => ~D[2023-06-01],
           "is_current" => true
-        }
-      ]
-
-      Enum.each(enrollments, fn enrollment ->
-        {:ok, _} = Dbservice.EnrollmentRecords.create_enrollment_record(enrollment)
-      end)
+        })
 
       # Update with new academic year
       EnrollmentService.update_school_enrollment(
@@ -395,7 +385,7 @@ defmodule Dbservice.Services.EnrollmentServiceTest do
         ~D[2024-05-31]
       )
 
-      # Verify both records were updated
+      # The prior-year record is superseded
       records =
         Dbservice.Repo.all(
           from er in Dbservice.EnrollmentRecords.EnrollmentRecord,
@@ -404,7 +394,7 @@ defmodule Dbservice.Services.EnrollmentServiceTest do
                 er.academic_year != "2024-25"
         )
 
-      assert length(records) == 2
+      assert length(records) == 1
 
       Enum.each(records, fn record ->
         assert record.is_current == false
@@ -504,14 +494,17 @@ defmodule Dbservice.Services.EnrollmentServiceTest do
       school = school_fixture()
       start_date = ~D[2024-01-01]
 
-      # Create record for 2023-24
+      # A historical (already superseded) record for 2023-24. In production the
+      # prior year's record is marked non-current before the new one is created;
+      # the exclusive-current unique index enforces that only one is current.
       {:ok, _} =
         Dbservice.EnrollmentRecords.create_enrollment_record(%{
           "user_id" => user.id,
           "group_id" => school.id,
           "group_type" => "school",
           "academic_year" => "2023-24",
-          "start_date" => start_date
+          "start_date" => start_date,
+          "is_current" => false
         })
 
       # Handle enrollment for 2024-25


### PR DESCRIPTION
## Context

Dhyanesh reported two NVS data-integrity defects. Both stem from the same root cause: `group_user` memberships are updated in place / created on batch/enrollment moves but never cleaned up, and nothing enforces the "one current membership per exclusive type" invariant at the DB level.

- **Issue 1** — users with more than one `is_current=true` `enrollment_record` for an exclusive `group_type` (`auth_group`/`school`/`grade`).
- **Issue 2** — one current batch in ER but multiple batch rows in `group_user`. Root cause: `BatchEnrollmentService.update_batch_user/3` repointed only the *first* batch `group_user` (`Enum.find`) and never deleted the rest, so `LmsStudentUpdate.replace_existing_group_user/3` hit `{:error, :multiple_group_users}` and grade/stream edits failed.

## Key finding

`group_user.inserted_at` is **not** a reliable "latest" signal — in-place repointing freezes it, so a stale batch row can be newer than the current one (verified on student `22107508`: stale batch 697 inserted *after* current batch 922). The dedup is therefore **ER-anchored** (keep the membership matching the current enrollment_record; `inserted_at` only breaks ties). This is also why it's safe for legitimately multi-batch students — every current batch is preserved.

## Changes

**Root-cause code fix**
- `update_batch_user/3` reconciles batch `group_user` **scoped to the target batch's program** (collapse to one, delete stale/dups); `update_grade_user/3` collapses all grade rows. New shared `reconcile_group_user/3`.
- `LmsStudentUpdate.replace_existing_group_user/3` **self-heals** duplicates instead of erroring — unblocks grade/stream edits even before the data cleanup.

**Data remediation migrations** (reversible — each snapshots changed rows into `bak_*` tables and restores in `down`)
- `20260725120000` — collapse >1 current exclusive ER (keep newest `start_date`), mirror into `group_user`.
- `20260725120001` — ER-anchored batch `group_user` dedup; users whose current batch has no `group_user` are skipped for manual review (`RAISE NOTICE`).
- `20260725120002` — guarded partial unique index `enrollment_record_current_exclusive_type_unique` on `(user_id, group_type) WHERE is_current AND group_type IN exclusive`. **Batch excluded** (legitimately multi-program).

Dedup SQL uses window-function / anti-join plans — the initial correlated-subquery versions ran 10+ hours on the 1.9M-row `group_user` table.

## Verified on dev
- Exclusive current-ER duplicates: **8,572 → 0**
- Student `22107508`: 2 batch `group_user` → **1** (batch 922, matching the ER)
- True Issue-2 population (1 current batch ER + >1 group_user): **0**; ~5,279 legitimately multi-batch users preserved
- Manual-review skipped: 110 (Issue 1), 13 (Issue 2)
- `mix check` green; `mix test` — 3 failures, all pre-existing on `main` (auth-group `student_id` unique-index tension from #558), unrelated to this PR

## Notes for reviewers / ops
- The exclusive dedup touches ~8,500 users (grade/school far beyond the reported 141) — please confirm those are genuine bug rows before running on prod. `bak_*` tables make it reversible.
- Two `enrollment_service_test.exs` tests were updated: they previously seeded multiple current exclusive ERs directly, which the new invariant forbids. That file overlaps with #647's academic-year formatting; expect a trivial conflict on the two edited tests when both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)