### PR TITLE
Remove Holistic Phase question limit

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,7 +48,7 @@ _Avoid_: phase template, static eight-phase list
 
 **Phase**:
 A stable item in a Phase Plan with a Grade, title, order, Locked/Open state,
-Markdown Guidance, and one to four ordered Post-Session Questions.
+Markdown Guidance, and one or more ordered Post-Session Questions.
 _Avoid_: storing the displayed Phase number as identity
 
 **Active Phase**:

--- a/priv/repo/migrations/20260726120000_remove_holistic_phase_question_limit.exs
+++ b/priv/repo/migrations/20260726120000_remove_holistic_phase_question_limit.exs
@@ -1,0 +1,86 @@
+defmodule Dbservice.Repo.Migrations.RemoveHolisticPhaseQuestionLimit do
+  use Ecto.Migration
+
+  @unlimited_count_function """
+  CREATE OR REPLACE FUNCTION holistic_mentorship_validate_phase_question_count()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  AS $$
+  DECLARE
+    target_phase_id bigint;
+    question_count integer;
+  BEGIN
+    IF TG_TABLE_NAME = 'holistic_mentorship_phase_questions' THEN
+      IF TG_OP = 'UPDATE'
+        AND OLD.phase_id <> NEW.phase_id
+        AND EXISTS (SELECT 1 FROM holistic_mentorship_phases WHERE id = OLD.phase_id)
+      THEN
+        SELECT count(*) INTO question_count
+        FROM holistic_mentorship_phase_questions
+        WHERE phase_id = OLD.phase_id;
+
+        IF question_count < 1 THEN
+          RAISE EXCEPTION 'Holistic Mentorship Phase % must have at least one Question', OLD.phase_id
+            USING ERRCODE = '23514';
+        END IF;
+      END IF;
+    END IF;
+
+    IF TG_TABLE_NAME = 'holistic_mentorship_phases' THEN
+      target_phase_id := NEW.id;
+    ELSIF TG_OP = 'DELETE' THEN
+      target_phase_id := OLD.phase_id;
+    ELSE
+      target_phase_id := NEW.phase_id;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM holistic_mentorship_phases WHERE id = target_phase_id) THEN
+      SELECT count(*) INTO question_count
+      FROM holistic_mentorship_phase_questions
+      WHERE phase_id = target_phase_id;
+
+      IF question_count < 1 THEN
+        RAISE EXCEPTION 'Holistic Mentorship Phase % must have at least one Question', target_phase_id
+          USING ERRCODE = '23514';
+      END IF;
+    END IF;
+
+    IF TG_OP = 'DELETE' THEN
+      RETURN OLD;
+    END IF;
+
+    RETURN NEW;
+  END;
+  $$;
+  """
+
+  @limited_count_function String.replace(
+                            @unlimited_count_function,
+                            "question_count < 1",
+                            "question_count NOT BETWEEN 1 AND 4"
+                          )
+                          |> String.replace(
+                            "must have at least one Question",
+                            "must have one to four Questions"
+                          )
+
+  def up do
+    execute("""
+    ALTER TABLE holistic_mentorship_phase_questions
+      DROP CONSTRAINT hm_phase_questions_position_check,
+      ADD CONSTRAINT hm_phase_questions_position_check CHECK (position > 0)
+    """)
+
+    execute(@unlimited_count_function)
+  end
+
+  def down do
+    execute(@limited_count_function)
+
+    execute("""
+    ALTER TABLE holistic_mentorship_phase_questions
+      DROP CONSTRAINT hm_phase_questions_position_check,
+      ADD CONSTRAINT hm_phase_questions_position_check CHECK (position BETWEEN 1 AND 4)
+    """)
+  end
+end

--- a/test/dbservice/holistic_mentorship_phase_schema_test.exs
+++ b/test/dbservice/holistic_mentorship_phase_schema_test.exs
@@ -270,17 +270,15 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
         [phase_id]
       )
 
-      for position <- [0, 5] do
-        assert_constraint_violation(fn ->
-          Repo.query(
-            """
-            INSERT INTO holistic_mentorship_phase_questions (phase_id, text, position)
-            VALUES ($1, 'Invalid question', $2)
-            """,
-            [phase_id, position]
-          )
-        end)
-      end
+      assert_constraint_violation(fn ->
+        Repo.query(
+          """
+          INSERT INTO holistic_mentorship_phase_questions (phase_id, text, position)
+          VALUES ($1, 'Invalid question', 0)
+          """,
+          [phase_id]
+        )
+      end)
 
       assert_constraint_violation(fn ->
         Repo.query("UPDATE grade SET number = 10 WHERE id = $1", [grade_11_id])
@@ -500,7 +498,7 @@ defmodule Dbservice.HolisticMentorshipPhaseSchemaTest do
 
       assert {:error, %Postgrex.Error{postgres: %{code: :check_violation}}} = empty_result
       assert {:ok, _phase_id} = complete_result
-      assert {:error, %Postgrex.Error{postgres: %{code: :check_violation}}} = overfull_result
+      assert {:ok, _phase_id} = overfull_result
       assert {:error, %Postgrex.Error{postgres: %{code: :check_violation}}} = moved_result
     end
 


### PR DESCRIPTION
## Summary
- remove the four-question ceiling from Holistic Phase Questions
- keep positive ordering and at least one Question per Phase
- update the deferred database invariant and schema coverage

## Verification
- `mix check`
- `mix test test/dbservice/holistic_mentorship_phase_schema_test.exs`

Full `mix test` still has the existing unrelated failure in `StudentEligibilityCleanupTest` because its `enrolled` status fixture is missing.