### PR TITLE
Fix holistic Profile eligibility to use the Centre roster

### DIFF
--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -1168,8 +1168,8 @@ defmodule Dbservice.HolisticMentorship do
 
     with :ok <- not_dropout(status),
          :ok <- eligible_grade_number(grade_number),
-         :ok <- eligible_school(user_id) do
-      consistent_grade(user_id, grade_id)
+         :ok <- consistent_grade(user_id, grade_id) do
+      eligible_school(user_id)
     end
   end
 
@@ -1180,20 +1180,36 @@ defmodule Dbservice.HolisticMentorship do
   defp eligible_grade_number(_grade_number), do: {:error, :grade_ineligible}
 
   defp eligible_school(user_id) do
-    case Repo.query!(
-           """
-           SELECT school.program_ids
-           FROM enrollment_record
-           LEFT JOIN school ON school.id = enrollment_record.group_id
-           WHERE enrollment_record.user_id = $1
-             AND enrollment_record.is_current
-             AND enrollment_record.group_type = 'school'
-           """,
-           [user_id],
-           log: false
-         ).rows do
-      [[program_ids]] when is_list(program_ids) ->
-        if 1 in program_ids, do: :ok, else: {:error, :program_ineligible}
+    school_ids =
+      Repo.query!(
+        """
+        SELECT DISTINCT school_group.child_id
+        FROM group_user
+        JOIN "group" school_group
+          ON school_group.id = group_user.group_id
+         AND school_group.type = 'school'
+        WHERE group_user.user_id = $1
+        """,
+        [user_id],
+        log: false
+      ).rows
+
+    case school_ids do
+      [[_school_id]] ->
+        case Repo.query!(
+               """
+               SELECT 1
+               FROM centre_students
+               WHERE centre_students.user_id = $1
+                 AND centre_students.program_id = 1
+               LIMIT 1
+               """,
+               [user_id],
+               log: false
+             ).rows do
+          [[1]] -> :ok
+          [] -> {:error, :program_ineligible}
+        end
 
       _ ->
         {:error, :school_missing_or_ambiguous}

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller_test.exs
@@ -3,6 +3,7 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
 
   alias Dbservice.Repo
 
+  import Dbservice.BatchesFixtures
   import Dbservice.GradesFixtures
   import Dbservice.SchoolsFixtures
   import Dbservice.UsersFixtures
@@ -307,24 +308,13 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
     {mismatched_grade_user, _student} = eligible_student(11, "GRADE-MISMATCH")
     {dropout_user, _student} = eligible_student(11, "DROPOUT")
 
-    Repo.query!(
-      """
-      UPDATE school SET program_ids = '{}'
-      FROM enrollment_record
-      WHERE enrollment_record.user_id = $1
-        AND enrollment_record.group_type = 'school'
-        AND school.id = enrollment_record.group_id
-      """,
-      [school_program_user.id]
-    )
+    remove_group_membership(school_program_user.id, "batch")
 
-    Repo.query!(
-      "DELETE FROM enrollment_record WHERE user_id = $1 AND group_type = 'school'",
-      [school_user.id]
-    )
+    remove_group_membership(school_user.id, "school")
 
-    second_school = school_fixture(%{program_ids: [1], code: "second-school"})
+    second_school = school_fixture(%{program_ids: [], code: "second-school"})
     enroll(duplicate_school_user.id, "school", second_school.id)
+    add_group_membership(duplicate_school_user.id, "school", second_school.id)
 
     Repo.query!("DELETE FROM enrollment_record WHERE user_id = $1 AND group_type = 'grade'", [
       missing_grade_user.id
@@ -409,12 +399,58 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
         student_id: business_student_id
       })
 
-    school = school_fixture(%{program_ids: [1], code: "school-#{user.id}"})
+    school = school_fixture(%{program_ids: [], code: "school-#{user.id}"})
 
     enroll(user.id, "school", school.id)
     enroll(user.id, "grade", grade.id)
+    add_program_roster(user.id, school.id, business_student_id)
 
     {user, student}
+  end
+
+  defp add_program_roster(user_id, school_id, suffix) do
+    ensure_program_one()
+    batch = batch_fixture(%{name: "Program 1 #{suffix}", batch_id: "P1-#{suffix}", program_id: 1})
+    add_group_membership(user_id, "school", school_id)
+    add_group_membership(user_id, "batch", batch.id)
+
+    Repo.query!(
+      """
+      INSERT INTO centres (name, school_id, program_id, is_active)
+      VALUES ($1, $2, 1, true)
+      """,
+      ["Program 1 #{suffix}", school_id]
+    )
+  end
+
+  defp ensure_program_one do
+    Repo.get(Dbservice.Programs.Program, 1) ||
+      Repo.insert!(%Dbservice.Programs.Program{
+        id: 1,
+        name: "JNV CoE",
+        product_id: Dbservice.ProductsFixtures.product_fixture().id
+      })
+  end
+
+  defp add_group_membership(user_id, type, child_id) do
+    group =
+      Repo.get_by(Dbservice.Groups.Group, type: type, child_id: child_id) ||
+        Repo.insert!(%Dbservice.Groups.Group{type: type, child_id: child_id})
+
+    Repo.insert!(%Dbservice.Groups.GroupUser{user_id: user_id, group_id: group.id})
+  end
+
+  defp remove_group_membership(user_id, type) do
+    Repo.query!(
+      """
+      DELETE FROM group_user
+      USING "group"
+      WHERE group_user.group_id = "group".id
+        AND group_user.user_id = $1
+        AND "group".type = $2
+      """,
+      [user_id, type]
+    )
   end
 
   defp enroll(user_id, group_type, group_id) do


### PR DESCRIPTION
## What changed

- Replaced the legacy `school.program_ids` Profile eligibility check with the canonical `centre_students` roster.
- Kept school ambiguity checks while deriving Program 1 eligibility from the student's Batch membership.
- Validated grade consistency before roster eligibility so existing rejection reasons remain stable.
- Updated Profile preflight tests to cover an empty `school.program_ids` field with a valid Batch → Program mapping.

## Why

Profile generation skipped valid production students at JNV Ujjain-2 because that school's legacy `program_ids` field is empty. The students are correctly linked to Program 1 through their Batch, which is the source used by `centre_students` and the LMS roster.

## Impact

Valid students in the canonical Program 1 Centre roster can pass Profile preflight without relying on `school.program_ids`. Students missing a school, Batch, eligible Program, or consistent grade remain rejected.

## Validation

- `mix test test/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller_test.exs test/dbservice/centre_schema_test.exs` — 12 tests, 0 failures
- `mix check` — compiler, formatter, Credo, Dialyzer, unused dependency, and npm checks passed
- `git diff --check`