### PR TITLE
Add is_scholarship_approved flag to college

### DIFF
--- a/lib/dbservice/colleges/college.ex
+++ b/lib/dbservice/colleges/college.ex
@@ -26,6 +26,7 @@ defmodule Dbservice.Colleges.College do
     field :median_salary, :float
     field :entrance_test, {:array, :integer}
     field :tuition_fees_annual, :float
+    field :is_scholarship_approved, :boolean, default: false
 
     has_many :cutoffs, Dbservice.Cutoffs.Cutoff
 
@@ -56,7 +57,8 @@ defmodule Dbservice.Colleges.College do
       :placement_rate,
       :median_salary,
       :entrance_test,
-      :tuition_fees_annual
+      :tuition_fees_annual,
+      :is_scholarship_approved
     ])
     |> validate_required([:college_id, :name])
   end

--- a/lib/dbservice_web/json/college_json.ex
+++ b/lib/dbservice_web/json/college_json.ex
@@ -29,7 +29,8 @@ defmodule DbserviceWeb.CollegeJSON do
       placement_rate: college.placement_rate,
       median_salary: college.median_salary,
       entrance_test: college.entrance_test,
-      tuition_fees_annual: college.tuition_fees_annual
+      tuition_fees_annual: college.tuition_fees_annual,
+      is_scholarship_approved: college.is_scholarship_approved
     }
   end
 end

--- a/lib/dbservice_web/swagger_schemas/college.ex
+++ b/lib/dbservice_web/swagger_schemas/college.ex
@@ -32,6 +32,7 @@ defmodule DbserviceWeb.SwaggerSchema.College do
             median_salary(:number, "Median salary", format: :float)
             entrance_test(:array, "Entrance test IDs", items: %{type: :integer})
             tuition_fees_annual(:number, "Annual tuition fees", format: :float)
+            is_scholarship_approved(:boolean, "Approved for the scholarship college dropdown")
           end
 
           example(%{
@@ -55,7 +56,8 @@ defmodule DbserviceWeb.SwaggerSchema.College do
             placement_rate: 95.5,
             median_salary: 1_500_000.00,
             entrance_test: [1, 2, 3],
-            tuition_fees_annual: 200_000.00
+            tuition_fees_annual: 200_000.00,
+            is_scholarship_approved: true
           })
         end
     }

--- a/priv/repo/migrations/20260728070045_add_is_scholarship_approved_to_college.exs
+++ b/priv/repo/migrations/20260728070045_add_is_scholarship_approved_to_college.exs
@@ -1,0 +1,9 @@
+defmodule Dbservice.Repo.Migrations.AddIsScholarshipApprovedToCollege do
+  use Ecto.Migration
+
+  def change do
+    alter table(:college) do
+      add :is_scholarship_approved, :boolean, default: false, null: false
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds a boolean `is_scholarship_approved` column (default `false`) to the `college` table so the af-scholarship platform can restrict its Stage-3 college dropdown to approved colleges only.

Changes:
- **Migration** `add_is_scholarship_approved_to_college` — `add :is_scholarship_approved, :boolean, default: false, null: false`
- **Schema + changeset** (`Colleges.College`) — new field, added to cast list
- **JSON serializer** (`CollegeJSON`) — field exposed in API responses
- **Swagger** — documented property + example

No controller change needed: the existing generic filter on `GET /api/college` already supports `?is_scholarship_approved=true`.

## Why

The scholarship's approved-college list is a curated program-team decision (engineering NIRF list + govt medical/dental list; anything off-list is an 'Other → reviewer' path). A boolean flag on the canonical `college` table is the single source of truth — cleaner than a separate join table or duplicating colleges into the scholarship service, which reads colleges from db-service and never writes core tables.

The af-scholarship Stage-3 dropdown consumes this via `listColleges({is_scholarship_approved: true})`.

## Follow-up (not in this PR)

Seeding the flag from the program team's two lists (299 NIRF engineering colleges + 447 govt medical/dental) — needs a matching key (college_id vs name) and a dry-run against real data; the medical list's names need cleaning. Happy to do it as a separate PR once we agree the matching approach.

Relates to af-scholarship #11 and PR #639 (scholarship_* tables). Can fold into #639 instead if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)