### PR TITLE
Preserve batch metadata during Batch Addition imports

### DIFF
--- a/lib/dbservice/utils/import_worker.ex
+++ b/lib/dbservice/utils/import_worker.ex
@@ -1381,9 +1381,12 @@ defmodule Dbservice.DataImport.ImportWorker do
   defp create_or_update_batch(attrs) do
     existing = find_existing_batch(attrs["batch_id"])
 
-    if existing,
-      do: Batches.update_batch(existing, attrs),
-      else: Batches.create_batch_from_import(attrs)
+    if existing do
+      metadata = Map.merge(existing.metadata || %{}, attrs["metadata"] || %{})
+      Batches.update_batch(existing, Map.put(attrs, "metadata", metadata))
+    else
+      Batches.create_batch_from_import(attrs)
+    end
   end
 
   defp find_existing_batch(nil), do: nil

--- a/test/dbservice/utils/import_worker_test.exs
+++ b/test/dbservice/utils/import_worker_test.exs
@@ -18,6 +18,7 @@ defmodule Dbservice.DataImport.ImportWorkerTest do
     on_exit(fn ->
       cleanup_test_csv("test_student_import.csv")
       cleanup_test_csv("invalid_student_import.csv")
+      cleanup_test_csv("batch_metadata_import.csv")
     end)
 
     # Store IDs for use in CSV content
@@ -89,6 +90,43 @@ defmodule Dbservice.DataImport.ImportWorkerTest do
       assert user2.first_name == "Jane"
       assert user2.last_name == "Smith"
       assert user2.email == "jane.smith@email.com"
+    end
+
+    test "preserves existing batch metadata during batch import", %{batch_id: batch_id} do
+      batch = Dbservice.Batches.get_batch!(batch_id)
+
+      assert {:ok, _batch} =
+               Dbservice.Batches.update_batch(batch, %{
+                 metadata: %{
+                   "grade" => 12,
+                   "stream" => "engineering",
+                   "is_parent_batch" => false
+                 }
+               })
+
+      filename =
+        create_test_csv(
+          "batch_metadata_import.csv",
+          "Batch ID,Name,Is Parent Batch\nTEST_BATCH_001,Updated Batch,TRUE\n"
+        )
+
+      import_record =
+        import_fixture(%{
+          filename: filename,
+          type: "batch_addition",
+          status: "pending"
+        })
+
+      assert :ok = perform_job(ImportWorker, %{"id" => import_record.id})
+
+      updated_batch = Dbservice.Batches.get_batch!(batch_id)
+      assert updated_batch.name == "Updated Batch"
+
+      assert updated_batch.metadata == %{
+               "grade" => 12,
+               "stream" => "engineering",
+               "is_parent_batch" => true
+             }
     end
 
     test "handles import with invalid data gracefully" do


### PR DESCRIPTION
## What happened

A batch stores extra fields inside a `metadata` object. LMS uses fields such as `grade` and `stream` from this object to find the correct batch when a student is added or their grade/stream is changed.

The Batch Addition import also writes one metadata field: `is_parent_batch`.

For an existing batch, the import was replacing the **whole metadata object** with only the value from the import.

Example:

```json
// Before import
{"grade": 12, "stream": "engineering", "is_parent_batch": false}

// After import
{"is_parent_batch": false}
```

This removed `grade`, `stream`, and any other metadata that was not part of the import file.

The production import on 29 July updated 1,112 batches, including all 56 JNV NVS batches. After that, LMS could not find a batch matching Program + Grade + Stream, so student add and edit actions returned `No matching batch found`.

## Why this fix is needed

Batch Addition imports are still needed for normal batch updates. Restoring the current batch mapping fixes today's data, but the next import would delete it again unless the import code is fixed.

## What changed

When an existing batch is imported, DB Service now:

1. Keeps the batch's current metadata.
2. Adds or updates only the metadata fields supplied by the import.
3. Leaves other fields such as `grade`, `stream`, and `gurukul_config` unchanged.

If the import changes `is_parent_batch`, the new imported value still wins. Creating a new batch works as before.

## Important

This code fix prevents future imports from deleting metadata. It does **not** restore metadata already removed from production. The batch mapping must be restored separately.

## Checks

- Added a regression test that imports an existing batch and confirms `grade` and `stream` remain while `is_parent_batch` is updated.
- `mix check` passed.
- Import worker tests: 7 passed.
- Full local suite reached 671 passing tests; 21 unrelated existing Holistic Mentorship/fixture tests failed.
