### PR TITLE
Add scholarship_email_otps table + email_verified flag

### DIFF
--- a/priv/repo/migrations/20260731120000_create_scholarship_email_otps.exs
+++ b/priv/repo/migrations/20260731120000_create_scholarship_email_otps.exs
@@ -1,0 +1,29 @@
+defmodule Dbservice.Repo.Migrations.CreateScholarshipEmailOtps do
+  use Ecto.Migration
+
+  # Email-OTP verification for the scholarship application flow (Task 1). A
+  # dedicated store, deliberately isolated from the phone OTP table
+  # (scholarship_otps) since its identifier is an email, plus a verified flag on
+  # the application that the submit gate evaluates. Owned by the scholarship app
+  # at runtime (read/write via `pg`), authored here per team convention.
+  def change do
+    create table(:scholarship_email_otps) do
+      add :email, :string, null: false
+      add :otp_hash, :string, null: false
+      add :expires_at, :utc_datetime, null: false
+      add :attempts, :integer, null: false, default: 0
+      add :consumed_at, :utc_datetime
+
+      timestamps()
+    end
+
+    create index(:scholarship_email_otps, [:email])
+    create index(:scholarship_email_otps, [:expires_at])
+
+    # The verified-email flag lives as a typed column (the submit gate evaluates
+    # it — ADR 0003), defaulting false so existing rows read as unverified.
+    alter table(:scholarship_applications) do
+      add :email_verified, :boolean, null: false, default: false
+    end
+  end
+end


### PR DESCRIPTION
Schema for the scholarship **email-OTP verification** flow (Task 1 in af-scholarship — verify the applicant's email by OTP right after the eligibility gate).

- New `scholarship_email_otps` table — mirrors `scholarship_otps` but keyed by `email` (phone and email don't share a column, since the phone column is sized/semantically for phone numbers). Indexes on `email` and `expires_at`.
- `scholarship_applications.email_verified` boolean (default false) — promoted to a typed column because the submit gate evaluates it (ADR 0003).

Additive + reversible. Stacked on `feat/scholarship-tables` (like #662), so it doesn't force the seeds / review-flags PRs to rebase. Staging already has the equivalent DDL applied manually (Aman) for immediate testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)