### PR TITLE
fix(resources): drop lang_versions from curriculum listing to avoid 413

### DIFF
--- a/lib/dbservice_web/controllers/resource_controller.ex
+++ b/lib/dbservice_web/controllers/resource_controller.ex
@@ -898,7 +898,7 @@ defmodule DbserviceWeb.ResourceController do
       |> apply_pagination(params)
 
     resources = Repo.all(query)
-    render(conn, "index.json", resource: resources)
+    render(conn, "curriculum_index.json", resource: resources)
   end
 
   defp topic_scoped_curriculum_request?(params),

--- a/lib/dbservice_web/json/resource_json.ex
+++ b/lib/dbservice_web/json/resource_json.ex
@@ -33,7 +33,17 @@ defmodule DbserviceWeb.ResourceJSON do
     render(resource)
   end
 
-  defp render(resource) do
+  # Lightweight listing for GET /api/resources/curriculum. Identical to index/1
+  # for plain Resource structs, except it omits the per-problem lang_versions
+  # payload (full options + solution HTML). That payload can push a single
+  # chapter's response past the host's serverless response cap (~4.5 MB) -> 413,
+  # and the content library never renders problems anyway. Also avoids the
+  # N+1 lang_versions lookup (one per problem).
+  def curriculum_index(%{resource: resources}) do
+    Enum.map(resources, fn resource -> render(resource, include_lang_versions: false) end)
+  end
+
+  defp render(resource, opts \\ []) do
     topic_id =
       Repo.one(
         from(rt in ResourceTopic,
@@ -120,8 +130,10 @@ defmodule DbserviceWeb.ResourceJSON do
 
     # Problems always expose their language versions (create/show responses),
     # so the frontend gets lang_versions back on a successful create. Other
-    # resource types don't have this concept.
-    if resource.type == "problem" do
+    # resource types don't have this concept. Listing endpoints that don't need
+    # solutions (e.g. the curriculum library) pass include_lang_versions: false
+    # to keep the response small.
+    if resource.type == "problem" and Keyword.get(opts, :include_lang_versions, true) do
       Map.put(
         base_map,
         :lang_versions,


### PR DESCRIPTION
## Problem

In Gurukul's content library, expanding a chapter under one curriculum showed resources while the **same chapter under another curriculum showed none** — e.g. "Motion in One Dimension" renders under JEE Mains but is empty under NEET. Similar chapters (Newton's Laws, Motion in Two Dimensions, etc.) show the same thing.

Root cause is **not** a data/mapping gap. It's a **413 (payload too large)**:

- `GET /api/resources/curriculum?chapter_id=&curriculum_id=` renders through the shared `render/1`, which attaches each problem's full `lang_versions` — question HTML, all options, and complete MathJax **solutions** — to every problem in the listing (`resource_json.ex`).
- A chapter with many problems produces a multi-MB response (measured on synced prod data: **Motion in One Dimension / NEET = 5.6 MB**, JEE = 1.18 MB; **Newton's Laws / NEET = 8.5 MB**).
- Gurukul's library runs as a Next.js server function, so the response crosses the host's serverless response cap (~4.5 MB) → **413** → the card renders empty. Curricula/chapters differ only by how many problems they have, which is why it looks curriculum-specific.
- The content library **never displays these problems** (only Module / Video Lectures / PYQ / Assessment), so the entire payload was fetched and thrown away. It was also an **N+1** (one `lang_versions` lookup per problem).

## Fix

Add a dedicated `curriculum_index` render for this listing that omits `lang_versions` (and the N+1 lookup). Scoped to `curriculum_resources` only — `show`, create/update, and the problem/test endpoints are untouched and still return `lang_versions`.

## Verification (synced prod data)

| Chapter / curriculum | Before | After |
|---|---|---|
| Motion in One Dimension / NEET | 5.6 MB (→ 413) | **28 KB** |
| Motion in One Dimension / JEE | 1.18 MB | 19 KB |
| Newton's Laws / NEET | 8.5 MB (→ 413) | 19 KB |

Response still contains all displayable resources (Module, Video Lectures, PYQ, Assessment) plus lightweight problem metadata; `lang_versions` is absent.

- `mix format --check-formatted` ✓
- `mix credo` (changed files) — no issues ✓
- `mix test test/dbservice_web/controllers/resource_controller_test.exs` — 7 tests, 0 failures ✓
- `mix test .../resource_patch_lang_versions_test.exs` — 2 tests, 0 failures ✓

## Notes

- A separate, minor data gap exists (chapters "Hydrogen" and "The s-Block Elements" genuinely lack NEET `resource_curriculum` rows) — **not** addressed here.
- Optional follow-up: Gurukul could additionally skip fetching `type=problem` for the library, but this server-side fix resolves the 413 on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)