### PR TITLE
fix(session): match comma-separated batch filters in meta_data

### DIFF
--- a/lib/dbservice_web/controllers/session_controller.ex
+++ b/lib/dbservice_web/controllers/session_controller.ex
@@ -11,6 +11,12 @@ defmodule DbserviceWeb.SessionController do
 
   action_fallback DbserviceWeb.FallbackController
 
+  # meta_data keys holding a comma-separated list of batch_ids rather than a single value:
+  # a quiz session can target several quiz (parent) batches and several class batches.
+  # Filtering these with `=` would miss every multi-batch session, so match against the
+  # list instead (same treatment as Dbservice.GroupSessions.add_batch_filter/2).
+  @comma_separated_meta_data_keys ~w(parent_id batch_id)
+
   use PhoenixSwagger
 
   alias DbserviceWeb.SwaggerSchema.Session, as: SwaggerSchemaSession
@@ -104,11 +110,18 @@ defmodule DbserviceWeb.SessionController do
   end
 
   defp apply_filter_based_on_schema(atom, key, value, acc) do
-    if atom in Session.__schema__(:fields) do
-      from(u in acc, where: field(u, ^atom) == ^value)
-    else
-      from u in acc,
-        where: fragment("?->>? = ?", u.meta_data, ^key, ^value)
+    cond do
+      atom in Session.__schema__(:fields) ->
+        from(u in acc, where: field(u, ^atom) == ^value)
+
+      key in @comma_separated_meta_data_keys ->
+        from u in acc,
+          where:
+            fragment("? = ANY(string_to_array(trim(?->>?), ','))", ^value, u.meta_data, ^key)
+
+      true ->
+        from u in acc,
+          where: fragment("?->>? = ?", u.meta_data, ^key, ^value)
     end
   end
 

--- a/lib/dbservice_web/controllers/session_controller.ex
+++ b/lib/dbservice_web/controllers/session_controller.ex
@@ -116,8 +116,7 @@ defmodule DbserviceWeb.SessionController do
 
       key in @comma_separated_meta_data_keys ->
         from u in acc,
-          where:
-            fragment("? = ANY(string_to_array(trim(?->>?), ','))", ^value, u.meta_data, ^key)
+          where: fragment("? = ANY(string_to_array(trim(?->>?), ','))", ^value, u.meta_data, ^key)
 
       true ->
         from u in acc,


### PR DESCRIPTION
## Why

A quiz session can be attached to several class batches, and — since the session-manager
change that allows picking multiple quiz batches — to several parent batches too. Both are
stored as a comma-separated list in `session.meta_data`:

```
parent_id: "CG-TP-2028-common-A01,CG-TP-2027-common-A01"
batch_id:  "ChhattisgarhStudents_TP_2028_common_A001,ChhattisgarhStudents_TP_2027_common_A001"
```

`GET /session?parent_id=…` filtered those keys with `=` against the **whole string**, so a
session carrying two batches matches neither of them individually and simply vanishes from the
session-manager table whenever the Quiz Batch filter is used. Live example: prod session 18069.

`batch_id` had the same latent bug — 1,733 prod sessions already store a multi-value
`batch_id`, so filtering by a single class batch was already broken. Fixing only `parent_id`
would have been a half-fix.

## What

Match against the list instead, mirroring what `Dbservice.GroupSessions.add_batch_filter/2`
already does for `meta_data.batch_id` when resolving a student's sessions.

## Verified against prod data

| stored `parent_id` | old `=` | new `ANY(...)` |
|---|---|---|
| `EN-11-25` | ✅ | ✅ |
| `EN-11-25,EN-12-25` | ❌ | ✅ |

Single-value metadata is unaffected: `'X' = ANY(string_to_array('X', ','))` is still true. I ran
the generated SQL against real prod sessions and it returns the expected rows.

Also checked:
- `key` is the original **string** from params (the atom is derived separately), so the `~w(...)`
  membership test is correct.
- Neither `parent_id` nor `batch_id` is a `Session` schema field, so both reach the new branch
  rather than the first one.
- No existing session stores these lists with spaces around commas (0 of 1,733 multi-batch
  rows), so the plain split matches the stored format and stays consistent with
  `add_batch_filter/2`. Deliberately not handling `"A , B"` for that reason.

## Caveat

**Not compiled or tested locally** — Elixir isn't installed on my machine, so this has had no
`mix compile` / `mix test`. The change is small and conventional, but please let CI confirm it
before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)