### PR TITLE
fix(resources): include paragraph in all-languages problem response (#664)

### DIFF
--- a/lib/dbservice/problem_languages.ex
+++ b/lib/dbservice/problem_languages.ex
@@ -7,6 +7,7 @@ defmodule Dbservice.ProblemLanguages do
   alias Dbservice.Repo
 
   alias Dbservice.Languages.Language
+  alias Dbservice.Resources.Paragraph
   alias Dbservice.Resources.ProblemLanguage
 
   @doc """
@@ -83,6 +84,35 @@ defmodule Dbservice.ProblemLanguages do
     )
     |> Repo.all()
     |> Enum.group_by(& &1.res_id, &Map.take(&1, [:lang_code, :meta_data]))
+  end
+
+  @doc """
+  Batch-fetches the comprehension paragraph for many problems in a single query
+  and returns a map of `resource_id => %Paragraph{}`. A comprehension problem
+  shares one paragraph across all its language versions, so the first (lowest
+  `problem_lang.id`) paragraph per resource is kept. Resources without a linked
+  paragraph are absent from the map.
+
+  Use this to attach the paragraph on the all-languages listing responses, which
+  carry no single `problem_lang` row to preload it from.
+  ## Examples
+      iex> list_paragraphs_by_resource_ids([1, 2])
+      %{1 => %Paragraph{}, 2 => %Paragraph{}}
+  """
+  def list_paragraphs_by_resource_ids([]), do: %{}
+
+  def list_paragraphs_by_resource_ids(resource_ids) do
+    from(pl in ProblemLanguage,
+      join: p in Paragraph,
+      on: p.id == pl.paragraph_id,
+      where: pl.res_id in ^resource_ids,
+      order_by: [asc: pl.id],
+      select: {pl.res_id, p}
+    )
+    |> Repo.all()
+    |> Enum.reduce(%{}, fn {res_id, paragraph}, acc ->
+      Map.put_new(acc, res_id, paragraph)
+    end)
   end
 
   @doc """

--- a/lib/dbservice_web/controllers/resource_controller.ex
+++ b/lib/dbservice_web/controllers/resource_controller.ex
@@ -11,6 +11,7 @@ defmodule DbserviceWeb.ResourceController do
   alias Dbservice.Repo
   alias Dbservice.ResourceCurriculums
   alias Dbservice.Resources
+  alias Dbservice.Resources.Paragraph
   alias Dbservice.Resources.ProblemLanguage
   alias Dbservice.Resources.Resource
   alias Dbservice.Resources.ResourceChapter
@@ -1445,7 +1446,7 @@ defmodule DbserviceWeb.ResourceController do
     query =
       from(r in Resource,
         where: r.id == ^res_id and r.type == "problem",
-        preload: [:resource_curriculum]
+        preload: [:resource_curriculum, problem_language: :paragraph]
       )
 
     case Repo.one(query) do
@@ -1471,11 +1472,25 @@ defmodule DbserviceWeb.ResourceController do
               resource: resource,
               meta_data: nil,
               lang_code: nil,
-              resource_curriculum: rc
+              resource_curriculum: rc,
+              paragraph: paragraph_for_all_languages(resource)
             )
         end
     end
   end
+
+  # For the all-languages variant we still surface the comprehension paragraph
+  # even though no single language is requested. The passage is shared across a
+  # comprehension problem's language versions, so any loaded problem_lang row's
+  # paragraph works — pick the first one that has one.
+  defp paragraph_for_all_languages(%Resource{problem_language: problem_languages})
+       when is_list(problem_languages) do
+    problem_languages
+    |> Enum.map(& &1.paragraph)
+    |> Enum.find(&match?(%Paragraph{}, &1))
+  end
+
+  defp paragraph_for_all_languages(_resource), do: nil
 
   swagger_path :search_problems do
     get("/api/problems/search")

--- a/lib/dbservice_web/json/resource_json.ex
+++ b/lib/dbservice_web/json/resource_json.ex
@@ -1,5 +1,6 @@
 defmodule DbserviceWeb.ResourceJSON do
   alias DbserviceWeb.ConceptJSON
+  alias Dbservice.Resources.Paragraph
   alias Dbservice.Resources.ResourceTopic
   alias Dbservice.Resources.ResourceChapter
   alias Dbservice.Concepts
@@ -11,18 +12,22 @@ defmodule DbserviceWeb.ResourceJSON do
   import Ecto.Query
 
   def index(%{resource: resources}) do
-    # Batch-fetch lang_versions for the problem-structure entries to avoid an
-    # N+1 query inside render_problem/2.
-    lang_versions_by_res_id =
+    # Batch-fetch lang_versions and paragraphs for the problem-structure entries
+    # to avoid N+1 queries inside render_problem/3.
+    problem_res_ids =
       resources
       |> Enum.filter(&Map.has_key?(&1, :resource))
       |> Enum.map(& &1.resource.id)
-      |> ProblemLanguages.list_lang_versions_by_resource_ids()
+
+    lang_versions_by_res_id =
+      ProblemLanguages.list_lang_versions_by_resource_ids(problem_res_ids)
+
+    paragraphs_by_res_id = ProblemLanguages.list_paragraphs_by_resource_ids(problem_res_ids)
 
     Enum.map(resources, fn resource ->
       # If resource is a map with :resource key, it's the new structure
       if Map.has_key?(resource, :resource) do
-        render_problem(resource, lang_versions_by_res_id)
+        render_problem(resource, lang_versions_by_res_id, paragraphs_by_res_id)
       else
         render(resource)
       end
@@ -145,17 +150,18 @@ defmodule DbserviceWeb.ResourceJSON do
   end
 
   def problems(%{problems: problems}) do
-    # Batch-fetch lang_versions for every problem up front to avoid an N+1
-    # query (one lookup per problem inside render_problem/2).
-    lang_versions_by_res_id =
-      problems
-      |> Enum.map(& &1.resource.id)
-      |> ProblemLanguages.list_lang_versions_by_resource_ids()
+    # Batch-fetch lang_versions and paragraphs for every problem up front to
+    # avoid N+1 queries (one lookup per problem inside render_problem/3).
+    res_ids = Enum.map(problems, & &1.resource.id)
+    lang_versions_by_res_id = ProblemLanguages.list_lang_versions_by_resource_ids(res_ids)
+    paragraphs_by_res_id = ProblemLanguages.list_paragraphs_by_resource_ids(res_ids)
 
-    Enum.map(problems, fn problem -> render_problem(problem, lang_versions_by_res_id) end)
+    Enum.map(problems, fn problem ->
+      render_problem(problem, lang_versions_by_res_id, paragraphs_by_res_id)
+    end)
   end
 
-  defp render_problem(problem, lang_versions_by_res_id) do
+  defp render_problem(problem, lang_versions_by_res_id, paragraphs_by_res_id) do
     # First get the base resource
     resource = problem.resource
     resource_topic = Map.get(problem, :resource_topic, %{})
@@ -261,7 +267,20 @@ defmodule DbserviceWeb.ResourceJSON do
 
     problem_map
     |> Map.put(:concepts, concepts)
-    |> Paragraphs.maybe_put_paragraph(resource, Map.get(problem_lang, :paragraph))
+    |> Paragraphs.maybe_put_paragraph(
+      resource,
+      resolve_paragraph(problem_lang, paragraphs_by_res_id, resource.id)
+    )
+  end
+
+  # The single-language path preloads the paragraph onto problem_lang; the
+  # all-languages listings carry no problem_lang row, so fall back to the
+  # batched paragraph map keyed by resource id (issue #664).
+  defp resolve_paragraph(problem_lang, paragraphs_by_res_id, res_id) do
+    case Map.get(problem_lang, :paragraph) do
+      %Paragraph{} = paragraph -> paragraph
+      _ -> Map.get(paragraphs_by_res_id, res_id)
+    end
   end
 
   def problem_lang(

--- a/test/dbservice_web/controllers/problem_all_languages_test.exs
+++ b/test/dbservice_web/controllers/problem_all_languages_test.exs
@@ -8,6 +8,7 @@ defmodule DbserviceWeb.ProblemAllLanguagesTest do
 
   alias Dbservice.Curriculums
   alias Dbservice.Languages
+  alias Dbservice.Paragraphs
   alias Dbservice.ProblemLanguages
   alias Dbservice.ResourceCurriculums
   alias Dbservice.ResourceTopics
@@ -39,15 +40,32 @@ defmodule DbserviceWeb.ProblemAllLanguagesTest do
     resource
   end
 
-  defp problem_language_fixture(resource, language, meta_data) do
+  defp problem_language_fixture(resource, language, meta_data, opts \\ []) do
     {:ok, problem_lang} =
       ProblemLanguages.create_problem_language(%{
         res_id: resource.id,
         lang_id: language.id,
-        meta_data: meta_data
+        meta_data: meta_data,
+        paragraph_id: Keyword.get(opts, :paragraph_id)
       })
 
     problem_lang
+  end
+
+  defp comprehension_problem_fixture do
+    {:ok, resource} =
+      Resources.create_resource(%{
+        "type" => "problem",
+        "subtype" => "comprehension",
+        "type_params" => %{}
+      })
+
+    resource
+  end
+
+  defp paragraph_fixture(body) do
+    {:ok, paragraph} = Paragraphs.create_paragraph(%{"body" => body})
+    paragraph
   end
 
   defp curriculum_fixture do
@@ -103,6 +121,26 @@ defmodule DbserviceWeb.ProblemAllLanguagesTest do
                %{"lang_code" => "aae", "meta_data" => en_meta},
                %{"lang_code" => "aah", "meta_data" => hi_meta}
              ]
+    end
+
+    test "includes the paragraph for a comprehension problem (issue #664)", %{conn: conn} do
+      en = language_fixture("afe", "AF EN")
+      hi = language_fixture("afh", "AF HI")
+      curriculum = curriculum_fixture()
+      problem = comprehension_problem_fixture()
+      resource_curriculum_fixture(problem, curriculum)
+
+      paragraph = paragraph_fixture("A gas that follows Boyle's law...")
+      problem_language_fixture(problem, en, %{"text" => "EN"}, paragraph_id: paragraph.id)
+      problem_language_fixture(problem, hi, %{"text" => "HI"}, paragraph_id: paragraph.id)
+
+      conn = get(conn, ~p"/api/resource/problem/#{problem.id}/#{curriculum.id}")
+      body = json_response(conn, 200)
+
+      assert body["paragraph"] == %{
+               "id" => paragraph.id,
+               "body" => "A gas that follows Boyle's law..."
+             }
     end
 
     test "404 when the curriculum is not linked to the problem", %{conn: conn} do

--- a/test/dbservice_web/controllers/problem_all_languages_test.exs
+++ b/test/dbservice_web/controllers/problem_all_languages_test.exs
@@ -178,6 +178,26 @@ defmodule DbserviceWeb.ProblemAllLanguagesTest do
                %{"lang_code" => "abh", "meta_data" => hi_meta}
              ]
     end
+
+    test "includes the paragraph for a comprehension problem (issue #664)", %{conn: conn} do
+      en = language_fixture("bbe", "BB EN")
+      hi = language_fixture("bbh", "BB HI")
+      curriculum = curriculum_fixture()
+      problem = comprehension_problem_fixture()
+      resource_curriculum_fixture(problem, curriculum)
+
+      paragraph = paragraph_fixture("Test passage body")
+      problem_language_fixture(problem, en, %{"text" => "EN"}, paragraph_id: paragraph.id)
+      problem_language_fixture(problem, hi, %{"text" => "HI"}, paragraph_id: paragraph.id)
+
+      test = test_fixture([problem.id])
+
+      conn = get(conn, ~p"/api/resource/test/#{test.id}/problems?curriculum_id=#{curriculum.id}")
+      body = json_response(conn, 200)
+
+      assert [entry] = body
+      assert entry["paragraph"] == %{"id" => paragraph.id, "body" => "Test passage body"}
+    end
   end
 
   describe "GET /api/problems (no lang_code)" do
@@ -232,6 +252,26 @@ defmodule DbserviceWeb.ProblemAllLanguagesTest do
       # Backward-compatible: flat meta_data is the requested language.
       assert entry["meta_data"] == en_meta
     end
+
+    test "includes the paragraph for a comprehension problem (issue #664)", %{conn: conn} do
+      en = language_fixture("bce", "BC EN")
+      hi = language_fixture("bch", "BC HI")
+      curriculum = curriculum_fixture()
+      topic = topic_fixture()
+      problem = comprehension_problem_fixture()
+      resource_curriculum_fixture(problem, curriculum)
+      resource_topic_fixture(problem, topic)
+
+      paragraph = paragraph_fixture("Topic passage body")
+      problem_language_fixture(problem, en, %{"text" => "EN"}, paragraph_id: paragraph.id)
+      problem_language_fixture(problem, hi, %{"text" => "HI"}, paragraph_id: paragraph.id)
+
+      conn = get(conn, ~p"/api/problems?topic_id=#{topic.id}&curriculum_id=#{curriculum.id}")
+      body = json_response(conn, 200)
+
+      assert [entry] = body
+      assert entry["paragraph"] == %{"id" => paragraph.id, "body" => "Topic passage body"}
+    end
   end
 
   describe "GET /api/problems/search (no lang_code)" do
@@ -260,6 +300,27 @@ defmodule DbserviceWeb.ProblemAllLanguagesTest do
                %{"lang_code" => "aee", "meta_data" => en_meta},
                %{"lang_code" => "aeh", "meta_data" => hi_meta}
              ]
+    end
+
+    test "includes the paragraph for a comprehension problem (issue #664)", %{conn: conn} do
+      en = language_fixture("bde", "BD EN")
+      curriculum = curriculum_fixture()
+      problem = comprehension_problem_fixture()
+      resource_curriculum_fixture(problem, curriculum)
+
+      term = "zzparagraphtoken"
+      paragraph = paragraph_fixture("Search passage body")
+
+      problem_language_fixture(problem, en, %{"text" => "english #{term}"},
+        paragraph_id: paragraph.id
+      )
+
+      conn = get(conn, ~p"/api/problems/search?search=#{term}")
+      body = json_response(conn, 200)
+
+      assert [entry] = body
+      assert entry["id"] == problem.id
+      assert entry["paragraph"] == %{"id" => paragraph.id, "body" => "Search passage body"}
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #664.

The comprehension `paragraph` field was dropped from **every** no-`lang_code` problem response, while the single-language variants returned it. This PR restores the paragraph on all of them:

- `GET /api/resource/problem/:problem_id/:curriculum_id` (all-languages)
- `GET /api/resource/test/:id/problems` (no `lang_code`)
- `GET /api/problems?topic_id=&curriculum_id=` (no `lang_code`)
- `GET /api/problems/search` (no `lang_code`)

### Root cause

The single-language paths preload `problem_lang.paragraph` and pass it to the renderer. The no-`lang_code` paths build problem structs with an empty/paragraph-less `problem_lang`, so `Paragraphs.maybe_put_paragraph/3` received `nil` and left the field out.

### Fix

- `get_problem_all_languages/2`: preload `problem_language: :paragraph` and pass the shared comprehension paragraph to the render.
- The listing endpoints (`test/:id/problems`, `/api/problems`, `/api/problems/search`) all render through `ResourceJSON.render_problem/3`. Added `ProblemLanguages.list_paragraphs_by_resource_ids/1` to batch-fetch a `resource_id => %Paragraph{}` map (single query, no N+1), threaded it through `index/1` and `problems/1`, and used it as a fallback in `render_problem/3` when the single-language path hasn't preloaded a paragraph.

A comprehension problem shares one paragraph across all its language versions, so the first paragraph per resource is used. Non-comprehension problems are unaffected — `maybe_put_paragraph/3` only adds the field for comprehension subtypes.

## Testing

- Added regression tests asserting the `paragraph` field is present for a comprehension problem on all four no-`lang_code` endpoints.
- `mix test test/dbservice_web/controllers/problem_all_languages_test.exs` — 10 tests, 0 failures.
- `mix test test/dbservice_web/controllers/resource_controller_test.exs` — no regressions.
- `mix format --check-formatted` and `mix credo` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)