### PR TITLE
Prod deployment: match comma-separated batch filters in session meta_data

### DIFF
--- a/lib/dbservice_web/controllers/session_controller.ex
+++ b/lib/dbservice_web/controllers/session_controller.ex
@@ -11,6 +11,12 @@ defmodule DbserviceWeb.SessionController do
 
   action_fallback DbserviceWeb.FallbackController
 
+  # meta_data keys holding a comma-separated list of batch_ids rather than a single value:
+  # a quiz session can target several quiz (parent) batches and several class batches.
+  # Filtering these with `=` would miss every multi-batch session, so match against the
+  # list instead (same treatment as Dbservice.GroupSessions.add_batch_filter/2).
+  @comma_separated_meta_data_keys ~w(parent_id batch_id)
+
   use PhoenixSwagger
 
   alias DbserviceWeb.SwaggerSchema.Session, as: SwaggerSchemaSession
@@ -104,11 +110,18 @@ defmodule DbserviceWeb.SessionController do
   end
 
   defp apply_filter_based_on_schema(atom, key, value, acc) do
-    if atom in Session.__schema__(:fields) do
-      from(u in acc, where: field(u, ^atom) == ^value)
-    else
-      from u in acc,
-        where: fragment("?->>? = ?", u.meta_data, ^key, ^value)
+    cond do
+      atom in Session.__schema__(:fields) ->
+        from(u in acc, where: field(u, ^atom) == ^value)
+
+      key in @comma_separated_meta_data_keys ->
+        from u in acc,
+          where:
+            fragment("? = ANY(string_to_array(trim(?->>?), ','))", ^value, u.meta_data, ^key)
+
+      true ->
+        from u in acc,
+          where: fragment("?->>? = ?", u.meta_data, ^key, ^value)
     end
   end
 

--- a/lib/dbservice_web/controllers/session_controller.ex
+++ b/lib/dbservice_web/controllers/session_controller.ex
@@ -116,8 +116,7 @@ defmodule DbserviceWeb.SessionController do
 
       key in @comma_separated_meta_data_keys ->
         from u in acc,
-          where:
-            fragment("? = ANY(string_to_array(trim(?->>?), ','))", ^value, u.meta_data, ^key)
+          where: fragment("? = ANY(string_to_array(trim(?->>?), ','))", ^value, u.meta_data, ^key)
 
       true ->
         from u in acc,


### PR DESCRIPTION
Promotes #671 to production.

## What

`GET /session?parent_id=…` (and `batch_id`) filtered `meta_data` with `=` against the whole
string. Both keys hold a comma-separated list, so a session attached to several batches matched
none of them individually and vanished from the session-manager table whenever the Quiz Batch
filter was used.

Now matched against the list, mirroring `Dbservice.GroupSessions.add_batch_filter/2`.

## Why now

quiz-creator can create sessions with multiple quiz batches, and prod already has one:
**session 18069** carries `parent_id = "CG-TP-2028-common-A01,CG-TP-2027-common-A01"`. It works
for students (both quiz batches are linked via `group_session`, and both class batches pass the
hierarchy walk), but the session-manager table's Quiz Batch filter cannot find it until this
ships.

`batch_id` had the same latent bug — 1,733 prod sessions already store a multi-value `batch_id`,
so filtering by a single class batch was already broken.

## Contents

Only #671 — `session_controller.ex`, +17/−5. No other commits ride along.

## Verified

- `mix check` passes locally on Elixir 1.18.4 (compiler with warnings-as-errors, credo,
  dialyzer, formatter, unused_deps) and CI's `verify (27, 1.18.4)` is green.
- Generated SQL run against real prod sessions: single-value filtering unchanged
  (`'X' = ANY(string_to_array('X', ','))` is still true), multi-value now matches.
- No prod session stores these lists with spaces around commas (0 of 1,733), so the plain split
  matches the stored format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)