### PR TITLE
Expose mentor mapping in Profile preflight

### DIFF
--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -1018,7 +1018,7 @@ defmodule Dbservice.HolisticMentorship do
     with :ok <- production_record(record),
          {:ok, user_id} <- source_user_id(record),
          :ok <- user_exists(user_id),
-         {:ok, student_id, mentor_mapped} <- student_id(user_id),
+         {:ok, student_id, mentor_mapped} <- student_with_mentor_mapping(user_id),
          :ok <- approved_profile_source(record),
          :ok <- privacy_not_deleted(student_id),
          {:ok, journey_id} <- matching_profile_journey(student_id, record),
@@ -1064,6 +1064,13 @@ defmodule Dbservice.HolisticMentorship do
   end
 
   defp student_id(user_id) do
+    case student_with_mentor_mapping(user_id) do
+      {:ok, student_id, _mentor_mapped} -> {:ok, student_id}
+      error -> error
+    end
+  end
+
+  defp student_with_mentor_mapping(user_id) do
     case Repo.query!(
            """
            SELECT student.id,

--- a/lib/dbservice/holistic_mentorship.ex
+++ b/lib/dbservice/holistic_mentorship.ex
@@ -1018,7 +1018,7 @@ defmodule Dbservice.HolisticMentorship do
     with :ok <- production_record(record),
          {:ok, user_id} <- source_user_id(record),
          :ok <- user_exists(user_id),
-         {:ok, student_id} <- student_id(user_id),
+         {:ok, student_id, mentor_mapped} <- student_id(user_id),
          :ok <- approved_profile_source(record),
          :ok <- privacy_not_deleted(student_id),
          {:ok, journey_id} <- matching_profile_journey(student_id, record),
@@ -1035,6 +1035,7 @@ defmodule Dbservice.HolisticMentorship do
         record_ref: record_ref,
         student_id: student_id,
         prompt_configuration_id: record["prompt_configuration_id"],
+        mentor_mapped: mentor_mapped,
         profile_state: profile_state,
         profile_revision: profile_revision
       }
@@ -1063,9 +1064,22 @@ defmodule Dbservice.HolisticMentorship do
   end
 
   defp student_id(user_id) do
-    case Repo.query!("SELECT id FROM student WHERE user_id = $1", [user_id], log: false).rows do
+    case Repo.query!(
+           """
+           SELECT student.id,
+                  EXISTS(
+                    SELECT 1
+                    FROM holistic_mentorship_mentor_mentee_mappings AS mapping
+                    WHERE mapping.student_id = student.id AND mapping.ended_at IS NULL
+                  )
+           FROM student
+           WHERE student.user_id = $1
+           """,
+           [user_id],
+           log: false
+         ).rows do
       [] -> {:error, :student_not_found}
-      [[student_id]] -> {:ok, student_id}
+      [[student_id, mentor_mapped]] -> {:ok, student_id, mentor_mapped}
       _ -> {:error, :ambiguous_student}
     end
   end

--- a/test/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller_test.exs
+++ b/test/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller_test.exs
@@ -27,6 +27,7 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
     prompt_configuration_id = prompt_configuration_id(conn)
     {grade_11_user, grade_11_student} = eligible_student(11, "BUSINESS-G11")
     {grade_12_user, grade_12_student} = eligible_student(12, "BUSINESS-G12")
+    assign_mentor!(grade_12_user.id, grade_12_student.id)
 
     assert Repo.query!("SELECT count(*) FROM enrollment_record WHERE group_type = 'program'").rows ==
              [[0]]
@@ -47,6 +48,7 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
                  "record_ref" => "second",
                  "student_id" => grade_12_student.id,
                  "prompt_configuration_id" => prompt_configuration_id,
+                 "mentor_mapped" => true,
                  "profile_state" => "missing",
                  "profile_revision" => nil
                },
@@ -54,6 +56,7 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
                  "record_ref" => "first",
                  "student_id" => grade_11_student.id,
                  "prompt_configuration_id" => prompt_configuration_id,
+                 "mentor_mapped" => false,
                  "profile_state" => "missing",
                  "profile_revision" => nil
                }
@@ -79,6 +82,7 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
                  "record_ref" => "emrs",
                  "student_id" => student.id,
                  "prompt_configuration_id" => prompt_configuration_id,
+                 "mentor_mapped" => false,
                  "profile_state" => "missing",
                  "profile_revision" => nil
                }
@@ -117,6 +121,7 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
                  "record_ref" => "original",
                  "student_id" => student.id,
                  "prompt_configuration_id" => prompt_configuration_id,
+                 "mentor_mapped" => false,
                  "profile_state" => "missing",
                  "profile_revision" => nil
                },
@@ -152,6 +157,7 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
                  "record_ref" => "unchanged",
                  "student_id" => student.id,
                  "prompt_configuration_id" => first_configuration_id,
+                 "mentor_mapped" => false,
                  "profile_state" => "unchanged",
                  "profile_revision" => 7
                },
@@ -159,6 +165,7 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
                  "record_ref" => "changed",
                  "student_id" => student.id,
                  "prompt_configuration_id" => first_configuration_id,
+                 "mentor_mapped" => false,
                  "profile_state" => "changed_answers",
                  "profile_revision" => 7
                },
@@ -166,6 +173,7 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
                  "record_ref" => "other-configuration",
                  "student_id" => student.id,
                  "prompt_configuration_id" => second_configuration_id,
+                 "mentor_mapped" => false,
                  "profile_state" => "missing",
                  "profile_revision" => nil
                }
@@ -493,6 +501,30 @@ defmodule DbserviceWeb.HolisticMentorshipProfilePreflightControllerTest do
         start_date: ~D[2026-06-01],
         is_current: true
       })
+  end
+
+  defp assign_mentor!(student_user_id, student_id) do
+    mentor = user_fixture()
+
+    [[school_id]] =
+      Repo.query!(
+        """
+        SELECT group_id
+        FROM enrollment_record
+        WHERE user_id = $1 AND group_type = 'school' AND is_current = true
+        """,
+        [student_user_id]
+      ).rows
+
+    Repo.query!(
+      """
+      INSERT INTO holistic_mentorship_mentor_mentee_mappings
+        (student_id, mentor_user_id, school_id, program_id, academic_year,
+         started_at, assigned_by_user_id, assignment_source)
+      VALUES ($1, $2, $3, 1, '2026-2027', now(), $2, 'test')
+      """,
+      [student_id, mentor.id, school_id]
+    )
   end
 
   defp prompt_configuration_id(conn, model_id \\ "openai/gpt-5-mini") do


### PR DESCRIPTION
## What changed

- Return `mentor_mapped: true/false` for each eligible Student in Holistic Profile preflight.
- Treat only mappings without an end date as active.

## Why

ETL needs this flag to generate Profiles for mentor-assigned Students before the general backlog. Existing preflight checks and rejection behavior are unchanged.

## QA

- `mix test test/dbservice_web/controllers/holistic_mentorship_profile_preflight_controller_test.exs` (11 tests pass)
- `mix format --check-formatted`
- `git diff --check`