### PR TITLE
Add responded_at to scholarship_review_flags

### DIFF
--- a/priv/repo/migrations/20260804120000_add_responded_at_to_scholarship_review_flags.exs
+++ b/priv/repo/migrations/20260804120000_add_responded_at_to_scholarship_review_flags.exs
@@ -1,0 +1,17 @@
+defmodule Dbservice.Repo.Migrations.AddRespondedAtToScholarshipReviewFlags do
+  use Ecto.Migration
+
+  # Reviewer flag-lifecycle redesign (af-scholarship): a flag now moves through
+  # three states — Open → Responded → Resolved — instead of open/resolved.
+  # `responded_at` marks the new middle state, stamped when the applicant
+  # resubmits after the flag was raised (this replaces the old behaviour where a
+  # resubmit auto-set `resolved_at`). `resolved_at` becomes an explicit reviewer
+  # action. State derives from the two timestamps: resolved_at → Resolved; else
+  # responded_at → Responded; else Open. Additive + nullable → deploy-safe, no
+  # backfill needed.
+  def change do
+    alter table(:scholarship_review_flags) do
+      add :responded_at, :utc_datetime
+    end
+  end
+end


### PR DESCRIPTION
**PR 1 of 3** for the af-scholarship reviewer flag-lifecycle redesign ([spec](https://claude.ai/code/artifact/c5d7b4e0-5bb2-4cf0-9cb3-597fcdb039a2)).

Adds a nullable `responded_at` timestamp to `scholarship_review_flags`. Flags move **Open → Responded → Resolved**: `responded_at` is stamped when the applicant resubmits after a flag was raised (the new middle state, replacing the old resubmit = auto-resolve), and `resolved_at` becomes an explicit reviewer action.

Purely additive + nullable → deploy-safe, no backfill (prod has ~no real flags yet). The af-scholarship server PR (PR 2) writes this column, so this must merge + migrate first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)