### PR TITLE
fix(resources): make curriculum_id optional on problem/test-problem endpoints (#651)

### DIFF
--- a/lib/dbservice/resources.ex
+++ b/lib/dbservice/resources.ex
@@ -54,12 +54,14 @@ defmodule Dbservice.Resources do
   ## Parameters
     - test_id: ID of the test resource
     - lang_code: Code of the language to fetch problems in (e.g., "en", "hi")
-    - curriculum_id: ID of the curriculum to get difficulty level
+    - curriculum_id: optional; deprecated. Each problem has exactly one
+      resource_curriculum row, so no curriculum filtering is needed. Accepted
+      for backward compatibility and ignored when nil (issue #651).
 
   ## Returns
     - List of problem resources with their metadata from problem_lang table and difficulty_level from resource_curriculum
   """
-  def get_problems_by_test_and_language(test_id, lang_code, curriculum_id) do
+  def get_problems_by_test_and_language(test_id, lang_code, curriculum_id \\ nil) do
     language = from(l in Language, where: l.code == ^lang_code, select: l) |> Repo.one()
 
     case language do
@@ -72,8 +74,12 @@ defmodule Dbservice.Resources do
   All-languages counterpart of `get_problems_by_test_and_language/3`. Returns
   every problem in the test once (no language filter); each problem's languages
   are attached as `lang_versions` by the JSON layer.
+
+  `curriculum_id` is optional and deprecated (see issue #651): each problem has
+  exactly one resource_curriculum row, so it is only used to pick which
+  curriculum's fields to surface and falls back to that single row when nil.
   """
-  def get_problems_by_test(test_id, curriculum_id) do
+  def get_problems_by_test(test_id, curriculum_id \\ nil) do
     test_resource = Repo.get(Resource, test_id)
 
     cond do

--- a/lib/dbservice_web/controllers/resource_controller.ex
+++ b/lib/dbservice_web/controllers/resource_controller.ex
@@ -1050,15 +1050,18 @@ defmodule DbserviceWeb.ResourceController do
       langCode(
         :query,
         :string,
-        "The code of the language to fetch problems in (e.g., 'en', 'hi')",
-        required: true
+        "The code of the language to fetch problems in (e.g., 'en', 'hi'). " <>
+          "Omit to get every problem once with all languages in lang_versions.",
+        required: false
       )
 
       curriculumId(
         :query,
         :integer,
-        "The ID of the curriculum to get difficulty level",
-        required: true
+        "Deprecated and optional. Each problem has exactly one resource_curriculum " <>
+          "row, so no curriculum filtering is needed. Accepted for backward " <>
+          "compatibility and ignored otherwise.",
+        required: false
       )
     end
 
@@ -1066,52 +1069,42 @@ defmodule DbserviceWeb.ResourceController do
   end
 
   @doc """
-  Returns all problems for a specific test in a specific language.
+  Returns all problems for a specific test.
 
-  GET /api/resource/test/:id/problems?lang_code=en&curriculum_id=1
+  GET /api/resource/test/:id/problems
+
+  - `lang_code` (optional): when given, returns problems in that single language
+    (top-level meta_data is that language); when omitted, every problem is
+    returned once with all languages in `lang_versions`.
+  - `curriculum_id` (optional, deprecated): each problem has exactly one
+    resource_curriculum row, so no curriculum filtering is needed. Accepted for
+    backward compatibility and ignored when absent (issue #651).
   """
-  def test_problems(conn, %{
-        "id" => test_id,
-        "lang_code" => lang_code,
-        "curriculum_id" => curriculum_id
-      }) do
-    # Parse test ID and curriculum ID to integer
+  def test_problems(conn, %{"id" => test_id} = params) do
     test_id = String.to_integer(test_id)
-    curriculum_id = String.to_integer(curriculum_id)
+    lang_code = params["lang_code"]
+    curriculum_id = param_as_integer(params, "curriculum_id")
 
-    result = Resources.get_problems_by_test_and_language(test_id, lang_code, curriculum_id)
+    conn
+    |> render_test_problems(fetch_test_problems(test_id, lang_code, curriculum_id), lang_code)
+  end
 
+  defp fetch_test_problems(test_id, lang_code, curriculum_id)
+       when is_binary(lang_code) and lang_code != "" do
+    Resources.get_problems_by_test_and_language(test_id, lang_code, curriculum_id)
+  end
+
+  defp fetch_test_problems(test_id, _lang_code, curriculum_id) do
+    Resources.get_problems_by_test(test_id, curriculum_id)
+  end
+
+  defp render_test_problems(conn, result, lang_code) do
     case result do
       {:error, :language_not_found} ->
         conn
         |> put_status(:not_found)
         |> json(%{error: "Language with code '#{lang_code}' not found"})
 
-      {:error, :test_not_found} ->
-        conn
-        |> put_status(:not_found)
-        |> json(%{error: "Test resource not found"})
-
-      {:error, :resource_not_test_type} ->
-        conn
-        |> put_status(:bad_request)
-        |> json(%{error: "The specified resource is not a test"})
-
-      problems ->
-        conn
-        |> put_status(:ok)
-        |> render("index.json", resource: problems)
-    end
-  end
-
-  # All-languages variant of test_problems/2: no lang_code, so every problem in
-  # the test is returned once with all its languages in lang_versions.
-  # GET /api/resource/test/:id/problems?curriculum_id=1
-  def test_problems(conn, %{"id" => test_id, "curriculum_id" => curriculum_id}) do
-    test_id = String.to_integer(test_id)
-    curriculum_id = String.to_integer(curriculum_id)
-
-    case Resources.get_problems_by_test(test_id, curriculum_id) do
       {:error, :test_not_found} ->
         conn
         |> put_status(:not_found)

--- a/lib/dbservice_web/controllers/resource_controller.ex
+++ b/lib/dbservice_web/controllers/resource_controller.ex
@@ -1127,15 +1127,23 @@ defmodule DbserviceWeb.ResourceController do
     summary("Fetch problems by topic and curriculum (optionally a language)")
 
     description(
-      "Returns problems filtered by topic_id and curriculum_id. When lang_code is " <>
-        "given, results are limited to that language (top-level meta_data is that " <>
-        "language). When lang_code is omitted, every problem is returned once with all " <>
-        "languages in lang_versions for client-side filtering."
+      "Returns problems filtered by topic_id. When lang_code is given, results are " <>
+        "limited to that language (top-level meta_data is that language). When lang_code " <>
+        "is omitted, every problem is returned once with all languages in lang_versions " <>
+        "for client-side filtering."
     )
 
     parameters do
       topic_id(:query, :integer, "Topic ID", required: true)
-      curriculum_id(:query, :integer, "Curriculum ID", required: true)
+
+      curriculum_id(
+        :query,
+        :integer,
+        "Deprecated and optional. Each problem/topic belongs to a single curriculum, so " <>
+          "no curriculum filtering is needed. Accepted for backward compatibility.",
+        required: false
+      )
+
       lang_code(:query, :string, "Language code (omit for all languages)", required: false)
 
       include_paragraph_siblings(
@@ -1151,33 +1159,35 @@ defmodule DbserviceWeb.ResourceController do
     response(200, "OK", Schema.ref(:ProblemResource))
   end
 
-  def fetch_problems(
-        conn,
-        %{
-          "topic_id" => topic_id,
-          "curriculum_id" => curriculum_id,
-          "lang_code" => lang_code
-        } = params
-      ) do
-    language = Repo.get_by(Language, code: lang_code)
+  # curriculum_id is optional and deprecated (issue #651): each problem/topic
+  # belongs to a single curriculum, so no curriculum filtering is needed. It is
+  # still accepted (and applied) for backward compatibility.
+  def fetch_problems(conn, %{"topic_id" => topic_id} = params) do
+    curriculum_id = param_as_integer(params, "curriculum_id")
+    fetch_problems_for_language(conn, topic_id, curriculum_id, params["lang_code"], params)
+  end
 
-    if is_nil(language) do
-      conn
-      |> put_status(:not_found)
-      |> json(%{error: "Language not found"})
-    else
-      problems =
-        topic_id
-        |> problems_query(curriculum_id, lang_code)
-        |> Repo.all()
-        |> preload_paragraphs()
-        |> maybe_add_paragraph_siblings(params, curriculum_id, lang_code)
+  defp fetch_problems_for_language(conn, topic_id, curriculum_id, lang_code, params)
+       when is_binary(lang_code) and lang_code != "" do
+    case Repo.get_by(Language, code: lang_code) do
+      nil ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{error: "Language not found"})
 
-      render(conn, "problems.json", problems: problems)
+      _language ->
+        problems =
+          topic_id
+          |> problems_query(curriculum_id, lang_code)
+          |> Repo.all()
+          |> preload_paragraphs()
+          |> maybe_add_paragraph_siblings(params, curriculum_id, lang_code)
+
+        render(conn, "problems.json", problems: problems)
     end
   end
 
-  def fetch_problems(conn, %{"topic_id" => topic_id, "curriculum_id" => curriculum_id} = params) do
+  defp fetch_problems_for_language(conn, topic_id, curriculum_id, _lang_code, params) do
     problems =
       topic_id
       |> problems_query_all_langs(curriculum_id)
@@ -1197,13 +1207,13 @@ defmodule DbserviceWeb.ResourceController do
       join: t in Topic,
       on: t.id == rt.topic_id,
       join: rc in ResourceCurriculum,
+      as: :resource_curriculum,
       on: rc.resource_id == r.id,
       join: pl in ProblemLanguage,
       as: :problem_lang,
       on: pl.res_id == r.id,
       join: l in Language,
       on: l.id == pl.lang_id,
-      where: rc.curriculum_id == ^curriculum_id,
       where: l.code == ^lang_code,
       where: r.type == "problem",
       order_by: [asc: r.code],
@@ -1212,10 +1222,20 @@ defmodule DbserviceWeb.ResourceController do
         resource_topic: rt,
         chapter_id: t.chapter_id,
         resource_curriculums: [rc],
-        requested_curriculum_id: ^curriculum_id,
+        requested_curriculum_id: rc.curriculum_id,
         problem_lang: pl
       }
     )
+    |> maybe_filter_by_curriculum(curriculum_id)
+  end
+
+  # curriculum_id is optional (issue #651). Each problem belongs to a single
+  # curriculum, so when it is omitted the ResourceCurriculum join already yields
+  # that one row; when provided, restrict to it for backward compatibility.
+  defp maybe_filter_by_curriculum(query, nil), do: query
+
+  defp maybe_filter_by_curriculum(query, curriculum_id) do
+    from([resource_curriculum: rc] in query, where: rc.curriculum_id == ^curriculum_id)
   end
 
   defp problems_query(topic_id, curriculum_id, lang_code) do
@@ -1278,8 +1298,8 @@ defmodule DbserviceWeb.ResourceController do
       join: t in Topic,
       on: t.id == rt.topic_id,
       join: rc in ResourceCurriculum,
+      as: :resource_curriculum,
       on: rc.resource_id == r.id,
-      where: rc.curriculum_id == ^curriculum_id,
       where: r.type == "problem",
       order_by: [asc: r.code],
       select: %{
@@ -1287,9 +1307,10 @@ defmodule DbserviceWeb.ResourceController do
         resource_topic: rt,
         chapter_id: t.chapter_id,
         resource_curriculums: [rc],
-        requested_curriculum_id: ^curriculum_id
+        requested_curriculum_id: rc.curriculum_id
       }
     )
+    |> maybe_filter_by_curriculum(curriculum_id)
   end
 
   defp problems_query_all_langs(topic_id, curriculum_id) do
@@ -1410,15 +1431,20 @@ defmodule DbserviceWeb.ResourceController do
     summary("Fetch a problem in all languages")
 
     description(
-      "All-languages variant of the problem endpoint. Returns the problem for the " <>
-        "given curriculum_id with every available language in `lang_versions`, so the " <>
-        "frontend can filter by language client-side. Top-level `meta_data`/`lang_code` " <>
-        "are null since no single language is requested."
+      "All-languages variant of the problem endpoint. Returns the problem with every " <>
+        "available language in `lang_versions`, so the frontend can filter by language " <>
+        "client-side. Top-level `meta_data`/`lang_code` are null since no single language " <>
+        "is requested. `curriculum_id` is optional and deprecated (issue #651): each " <>
+        "problem belongs to a single curriculum, so `/api/resource/problem/{problem_id}` " <>
+        "returns the same result. The path segment is kept for backward compatibility."
     )
 
     parameters do
       problem_id(:path, :integer, "The id of the problem resource", required: true)
-      curriculum_id(:path, :integer, "The curriculum ID", required: true)
+
+      curriculum_id(:path, :integer, "Deprecated and optional. The curriculum ID.",
+        required: false
+      )
     end
 
     response(200, "OK", Schema.ref(:ProblemResource))
@@ -1426,16 +1452,25 @@ defmodule DbserviceWeb.ResourceController do
   end
 
   @doc """
-  Get a specific problem in all languages by resource ID and curriculum ID.
+  Get a specific problem in all languages by resource ID.
 
   Unlike `get_problem/2`, this does not take a lang_code: the response carries
   every language in `lang_versions` and leaves the top-level single-language
   fields (`meta_data`, `lang_code`, `paragraph`) empty.
+
+  `curriculum_id` is optional and deprecated (issue #651): each problem belongs
+  to a single curriculum, so it is only used to pick which curriculum's fields
+  to surface and falls back to the problem's single row when omitted.
   """
-  def get_problem_all_languages(conn, %{
-        "problem_id" => res_id,
-        "curriculum_id" => curriculum_id
-      }) do
+  def get_problem_all_languages(conn, %{"problem_id" => res_id, "curriculum_id" => curriculum_id}) do
+    render_problem_all_languages(conn, res_id, curriculum_id)
+  end
+
+  def get_problem_all_languages(conn, %{"problem_id" => res_id}) do
+    render_problem_all_languages(conn, res_id, nil)
+  end
+
+  defp render_problem_all_languages(conn, res_id, curriculum_id) do
     query =
       from(r in Resource,
         where: r.id == ^res_id and r.type == "problem",
@@ -1449,16 +1484,11 @@ defmodule DbserviceWeb.ResourceController do
         |> json(%{error: "Problem not found for given inputs"})
 
       resource ->
-        resource_curriculum =
-          Enum.find(resource.resource_curriculum, fn rc ->
-            rc.curriculum_id == String.to_integer(curriculum_id)
-          end)
-
-        case resource_curriculum do
+        case select_resource_curriculum(resource.resource_curriculum, curriculum_id) do
           nil ->
             conn
             |> put_status(:not_found)
-            |> json(%{error: "No resource found for given curriculum_id"})
+            |> json(%{error: curriculum_not_found_message(curriculum_id)})
 
           rc ->
             render(conn, "problem_lang.json",
@@ -1471,6 +1501,19 @@ defmodule DbserviceWeb.ResourceController do
         end
     end
   end
+
+  # With no curriculum_id, fall back to the problem's single resource_curriculum
+  # row (issue #651); with one, restrict to the matching row as before.
+  defp select_resource_curriculum(resource_curriculums, nil), do: List.first(resource_curriculums)
+
+  defp select_resource_curriculum(resource_curriculums, curriculum_id) do
+    Enum.find(resource_curriculums, fn rc ->
+      rc.curriculum_id == String.to_integer(curriculum_id)
+    end)
+  end
+
+  defp curriculum_not_found_message(nil), do: "No curriculum mapping found for this problem"
+  defp curriculum_not_found_message(_), do: "No resource found for given curriculum_id"
 
   # For the all-languages variant we still surface the comprehension paragraph
   # even though no single language is requested. The passage is shared across a

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -236,6 +236,15 @@ defmodule DbserviceWeb.Router do
       :get_problem_all_languages
     )
 
+    # Same all-languages variant without the curriculum_id path segment. Each
+    # problem belongs to a single curriculum, so it need not be specified
+    # (issue #651); kept alongside the /:curriculum_id route for backward compat.
+    get(
+      "/resource/problem/:problem_id",
+      ResourceController,
+      :get_problem_all_languages
+    )
+
     resources("/cms-status", CmsStatusController, except: [:new, :edit])
 
     def swagger_info do

--- a/test/dbservice_web/controllers/problem_all_languages_test.exs
+++ b/test/dbservice_web/controllers/problem_all_languages_test.exs
@@ -152,6 +152,63 @@ defmodule DbserviceWeb.ProblemAllLanguagesTest do
     end
   end
 
+  describe "GET /api/resource/problem/:problem_id (curriculum_id optional, issue #651)" do
+    test "returns the problem with all languages when curriculum_id is omitted", %{conn: conn} do
+      en = language_fixture("dae", "DA EN")
+      hi = language_fixture("dah", "DA HI")
+      curriculum = curriculum_fixture()
+      problem = problem_fixture()
+      resource_curriculum_fixture(problem, curriculum)
+
+      en_meta = %{"text" => "no curr id EN"}
+      hi_meta = %{"text" => "no curr id HI"}
+      problem_language_fixture(problem, en, en_meta)
+      problem_language_fixture(problem, hi, hi_meta)
+
+      # No curriculum_id path segment.
+      conn = get(conn, ~p"/api/resource/problem/#{problem.id}")
+      body = json_response(conn, 200)
+
+      assert body["id"] == problem.id
+      assert body["meta_data"] == nil
+      assert body["lang_code"] == nil
+      # Top-level curriculum fields resolve from the single resource_curriculum row.
+      assert body["curriculum_id"] == curriculum.id
+      assert body["difficulty_level"] == "medium"
+
+      assert body["lang_versions"] == [
+               %{"lang_code" => "dae", "meta_data" => en_meta},
+               %{"lang_code" => "dah", "meta_data" => hi_meta}
+             ]
+    end
+
+    test "includes the paragraph for a comprehension problem without curriculum_id",
+         %{conn: conn} do
+      en = language_fixture("dbe", "DB EN")
+      curriculum = curriculum_fixture()
+      problem = comprehension_problem_fixture()
+      resource_curriculum_fixture(problem, curriculum)
+
+      paragraph = paragraph_fixture("Passage without curriculum_id")
+      problem_language_fixture(problem, en, %{"text" => "EN"}, paragraph_id: paragraph.id)
+
+      conn = get(conn, ~p"/api/resource/problem/#{problem.id}")
+      body = json_response(conn, 200)
+
+      assert body["paragraph"] == %{
+               "id" => paragraph.id,
+               "body" => "Passage without curriculum_id"
+             }
+    end
+
+    test "404 when the problem has no curriculum mapping", %{conn: conn} do
+      problem = problem_fixture()
+
+      conn = get(conn, ~p"/api/resource/problem/#{problem.id}")
+      assert json_response(conn, 404)
+    end
+  end
+
   describe "GET /api/resource/test/:id/problems (no lang_code)" do
     test "returns each test problem once with all languages", %{conn: conn} do
       en = language_fixture("abe", "AB EN")
@@ -350,6 +407,58 @@ defmodule DbserviceWeb.ProblemAllLanguagesTest do
 
       assert [entry] = body
       assert entry["paragraph"] == %{"id" => paragraph.id, "body" => "Topic passage body"}
+    end
+
+    test "returns problems when curriculum_id is omitted (all languages, issue #651)",
+         %{conn: conn} do
+      en = language_fixture("dce", "DC EN")
+      hi = language_fixture("dch", "DC HI")
+      curriculum = curriculum_fixture()
+      topic = topic_fixture()
+      problem = problem_fixture()
+      resource_curriculum_fixture(problem, curriculum)
+      resource_topic_fixture(problem, topic)
+
+      en_meta = %{"text" => "no curr topic EN"}
+      hi_meta = %{"text" => "no curr topic HI"}
+      problem_language_fixture(problem, en, en_meta)
+      problem_language_fixture(problem, hi, hi_meta)
+
+      # No curriculum_id query param.
+      conn = get(conn, ~p"/api/problems?topic_id=#{topic.id}")
+      body = json_response(conn, 200)
+
+      assert [entry] = body
+      assert entry["id"] == problem.id
+      assert entry["curriculum_id"] == curriculum.id
+      assert entry["difficulty_level"] == "medium"
+
+      assert entry["lang_versions"] == [
+               %{"lang_code" => "dce", "meta_data" => en_meta},
+               %{"lang_code" => "dch", "meta_data" => hi_meta}
+             ]
+    end
+
+    test "returns problems when curriculum_id is omitted (single language, issue #651)",
+         %{conn: conn} do
+      en = language_fixture("dde", "DD EN")
+      curriculum = curriculum_fixture()
+      topic = topic_fixture()
+      problem = problem_fixture()
+      resource_curriculum_fixture(problem, curriculum)
+      resource_topic_fixture(problem, topic)
+
+      en_meta = %{"text" => "single no curr topic"}
+      problem_language_fixture(problem, en, en_meta)
+
+      conn = get(conn, ~p"/api/problems?topic_id=#{topic.id}&lang_code=dde")
+      body = json_response(conn, 200)
+
+      assert [entry] = body
+      assert entry["id"] == problem.id
+      assert entry["meta_data"] == en_meta
+      assert entry["curriculum_id"] == curriculum.id
+      assert entry["difficulty_level"] == "medium"
     end
   end
 

--- a/test/dbservice_web/controllers/problem_all_languages_test.exs
+++ b/test/dbservice_web/controllers/problem_all_languages_test.exs
@@ -200,6 +200,85 @@ defmodule DbserviceWeb.ProblemAllLanguagesTest do
     end
   end
 
+  describe "GET /api/resource/test/:id/problems (curriculum_id optional, issue #651)" do
+    test "returns problems when curriculum_id is omitted (all languages)", %{conn: conn} do
+      en = language_fixture("cae", "CA EN")
+      hi = language_fixture("cah", "CA HI")
+      curriculum = curriculum_fixture()
+      problem = problem_fixture()
+      resource_curriculum_fixture(problem, curriculum)
+
+      en_meta = %{"text" => "no curr EN"}
+      hi_meta = %{"text" => "no curr HI"}
+      problem_language_fixture(problem, en, en_meta)
+      problem_language_fixture(problem, hi, hi_meta)
+
+      test = test_fixture([problem.id])
+
+      # No curriculum_id query param at all.
+      conn = get(conn, ~p"/api/resource/test/#{test.id}/problems")
+      body = json_response(conn, 200)
+
+      assert [entry] = body
+      assert entry["id"] == problem.id
+      # Top-level curriculum fields resolve from the single resource_curriculum row.
+      assert entry["curriculum_id"] == curriculum.id
+      assert entry["difficulty_level"] == "medium"
+
+      assert entry["lang_versions"] == [
+               %{"lang_code" => "cae", "meta_data" => en_meta},
+               %{"lang_code" => "cah", "meta_data" => hi_meta}
+             ]
+    end
+
+    test "returns problems when curriculum_id is omitted (single language)", %{conn: conn} do
+      en = language_fixture("cbe", "CB EN")
+      curriculum = curriculum_fixture()
+      problem = problem_fixture()
+      resource_curriculum_fixture(problem, curriculum)
+
+      en_meta = %{"text" => "single no curr"}
+      problem_language_fixture(problem, en, en_meta)
+
+      test = test_fixture([problem.id])
+
+      conn = get(conn, ~p"/api/resource/test/#{test.id}/problems?lang_code=cbe")
+      body = json_response(conn, 200)
+
+      assert [entry] = body
+      assert entry["id"] == problem.id
+      # Backward-compatible flat meta_data for the requested language.
+      assert entry["meta_data"] == en_meta
+      assert entry["curriculum_id"] == curriculum.id
+      assert entry["difficulty_level"] == "medium"
+    end
+
+    test "still accepts curriculum_id for backward compatibility", %{conn: conn} do
+      en = language_fixture("cce", "CC EN")
+      curriculum = curriculum_fixture()
+      problem = problem_fixture()
+      resource_curriculum_fixture(problem, curriculum)
+
+      en_meta = %{"text" => "with curr"}
+      problem_language_fixture(problem, en, en_meta)
+
+      test = test_fixture([problem.id])
+
+      conn =
+        get(
+          conn,
+          ~p"/api/resource/test/#{test.id}/problems?lang_code=cce&curriculum_id=#{curriculum.id}"
+        )
+
+      body = json_response(conn, 200)
+
+      assert [entry] = body
+      assert entry["id"] == problem.id
+      assert entry["meta_data"] == en_meta
+      assert entry["curriculum_id"] == curriculum.id
+    end
+  end
+
   describe "GET /api/problems (no lang_code)" do
     test "returns each problem once (deduped) with all languages", %{conn: conn} do
       en = language_fixture("ace", "AC EN")


### PR DESCRIPTION
## Summary

Fixes #651.

Each problem/topic belongs to exactly one `resource_curriculum` row, so `curriculum_id` filtering is redundant. This makes `curriculum_id` **optional** on the affected read endpoints, while keeping deployed clients that still send it working unchanged (per the issue note, it will be removed later once there are no such clients).

## Endpoints made curriculum_id-optional

1. **`GET /api/resource/test/:id/problems`** — query param `curriculum_id` now optional (also `lang_code`, which already had an all-languages path).
2. **`GET /api/problems?topic_id=…`** — query param `curriculum_id` now optional.
3. **`GET /api/resource/problem/:problem_id/:curriculum_id`** — added a curriculum-less route `GET /api/resource/problem/:problem_id` (same action); the `/:curriculum_id` route is kept for backward compatibility.

## How it stays backward compatible

`curriculum_id` was only ever used to *select* which `resource_curriculum` to surface, and the JSON/query layers already fall back to the single row when there's no explicit match. Concretely:

- **test-problems**: `get_problems_by_test/2` and `get_problems_by_test_and_language/3` default `curriculum_id` to `nil`; a nil `requested_curriculum_id` makes the JSON layer use the problem's single `resource_curriculum` (`List.first`).
- **/api/problems**: the two `fetch_problems/2` clauses are collapsed into one requiring only `topic_id`. The curriculum filter moved into a conditional `maybe_filter_by_curriculum/2` (skipped when nil), and `requested_curriculum_id` is derived from the joined `resource_curriculum` row.
- **/api/resource/problem/:problem_id**: a nil `curriculum_id` falls back to the problem's single `resource_curriculum` row.

For every combination that worked before (`curriculum_id` present, with or without `lang_code`), behavior is identical.

## Testing

- New tests cover, for each endpoint: `curriculum_id` omitted (all-languages **and** single-language), the top-level curriculum fields still resolving from the single row, comprehension paragraph still present, 404 when a problem has no curriculum mapping, and the existing `curriculum_id`-present paths (backward compat).
- `mix test` for the problem/resource/search suites — 33 tests, 0 failures.
- `mix phx.routes` confirms all three problem routes register with no conflicts.
- `mix format --check-formatted` and `mix credo` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)