### PR TITLE
Support curriculum log types and Centre Exam Tracks

### DIFF
--- a/lib/dbservice/lms_curriculum/chapter_exam_config.ex
+++ b/lib/dbservice/lms_curriculum/chapter_exam_config.ex
@@ -4,7 +4,7 @@ defmodule Dbservice.LmsCurriculum.ChapterExamConfig do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @exam_tracks ~w(jee_main jee_advanced neet)
+  @exam_tracks ~w(jee_main jee_advanced neet cet math_foundation)
 
   schema "lms_chapter_exam_configs" do
     field :exam_track, :string

--- a/lib/dbservice/lms_curriculum/curriculum_log.ex
+++ b/lib/dbservice/lms_curriculum/curriculum_log.ex
@@ -13,9 +13,12 @@ defmodule Dbservice.LmsCurriculum.CurriculumLog do
   alias Dbservice.LmsCurriculum.ChapterExamConfig
   alias Dbservice.LmsCurriculum.CurriculumLogTopic
 
+  @log_types ~w(regular class_cancelled doubt_solving)
+
   schema "lms_curriculum_logs" do
     field :school_code, :string
     field :exam_track, :string
+    field :log_type, :string, default: "regular"
     field :log_date, :date
     field :duration_minutes, :integer
     field :created_by_email, :string
@@ -26,6 +29,7 @@ defmodule Dbservice.LmsCurriculum.CurriculumLog do
     belongs_to :program, Dbservice.Programs.Program
     belongs_to :grade, Dbservice.Grades.Grade
     belongs_to :subject, Dbservice.Subjects.Subject
+    belongs_to :chapter, Dbservice.Chapters.Chapter
 
     has_many :curriculum_log_topics, CurriculumLogTopic
     has_many :topics, through: [:curriculum_log_topics, :topic]
@@ -42,8 +46,10 @@ defmodule Dbservice.LmsCurriculum.CurriculumLog do
       :grade_id,
       :subject_id,
       :exam_track,
+      :log_type,
       :log_date,
       :duration_minutes,
+      :chapter_id,
       :created_by_email,
       :inserted_by_email,
       :updated_by_email,
@@ -55,16 +61,58 @@ defmodule Dbservice.LmsCurriculum.CurriculumLog do
       :grade_id,
       :subject_id,
       :exam_track,
-      :log_date,
-      :duration_minutes
+      :log_type,
+      :log_date
     ])
     |> validate_length(:school_code, min: 1, max: 255)
     |> validate_inclusion(:exam_track, ChapterExamConfig.exam_tracks())
-    |> validate_number(:duration_minutes, greater_than: 0, less_than_or_equal_to: 720)
+    |> validate_inclusion(:log_type, @log_types)
+    |> validate_log_shape()
     |> foreign_key_constraint(:program_id)
     |> foreign_key_constraint(:grade_id)
     |> foreign_key_constraint(:subject_id)
+    |> foreign_key_constraint(:chapter_id)
     |> check_constraint(:exam_track, name: :lms_curriculum_logs_exam_track_check)
+    |> check_constraint(:log_type, name: :lms_curriculum_logs_log_type_check)
     |> check_constraint(:duration_minutes, name: :lms_curriculum_logs_duration_minutes_check)
+    |> check_constraint(:chapter_id, name: :lms_curriculum_logs_chapter_id_check)
+    |> unique_constraint(:school_code,
+      name: :lms_curriculum_logs_active_class_cancelled_unique
+    )
+  end
+
+  defp validate_log_shape(changeset) do
+    case get_field(changeset, :log_type) do
+      "regular" ->
+        changeset
+        |> validate_required([:duration_minutes])
+        |> validate_absent(:chapter_id)
+        |> validate_duration()
+
+      "class_cancelled" ->
+        changeset
+        |> validate_required([:chapter_id])
+        |> validate_absent(:duration_minutes)
+
+      "doubt_solving" ->
+        changeset
+        |> validate_required([:chapter_id, :duration_minutes])
+        |> validate_duration()
+
+      _other ->
+        changeset
+    end
+  end
+
+  defp validate_duration(changeset) do
+    validate_number(changeset, :duration_minutes, greater_than: 0, less_than_or_equal_to: 720)
+  end
+
+  defp validate_absent(changeset, field) do
+    if is_nil(get_field(changeset, field)) do
+      changeset
+    else
+      add_error(changeset, field, "must be empty for this log type")
+    end
   end
 end

--- a/priv/repo/migrations/20260807120000_expand_lms_curriculum_tracking.exs
+++ b/priv/repo/migrations/20260807120000_expand_lms_curriculum_tracking.exs
@@ -1,0 +1,94 @@
+defmodule Dbservice.Repo.Migrations.ExpandLmsCurriculumTracking do
+  use Ecto.Migration
+
+  @exam_tracks "('jee_main', 'jee_advanced', 'neet', 'cet', 'math_foundation')"
+
+  def up do
+    alter table(:lms_curriculum_logs) do
+      add :log_type, :string, size: 32, null: false, default: "regular"
+      add :chapter_id, references(:chapter, on_delete: :nothing)
+      modify :duration_minutes, :integer, null: true
+    end
+
+    replace_exam_track_constraint(:lms_chapter_exam_configs)
+    replace_exam_track_constraint(:lms_curriculum_logs)
+    replace_exam_track_constraint(:lms_curriculum_chapter_completions)
+
+    drop constraint(:lms_curriculum_logs, :lms_curriculum_logs_duration_minutes_check)
+
+    create constraint(:lms_curriculum_logs, :lms_curriculum_logs_duration_minutes_check,
+             check: """
+             CASE log_type
+               WHEN 'class_cancelled' THEN duration_minutes IS NULL
+               ELSE duration_minutes IS NOT NULL
+                 AND duration_minutes > 0
+                 AND duration_minutes <= 720
+             END
+             """
+           )
+
+    create constraint(:lms_curriculum_logs, :lms_curriculum_logs_log_type_check,
+             check: "log_type IN ('regular', 'class_cancelled', 'doubt_solving')"
+           )
+
+    create constraint(:lms_curriculum_logs, :lms_curriculum_logs_chapter_id_check,
+             check: """
+             CASE log_type
+               WHEN 'regular' THEN chapter_id IS NULL
+               ELSE chapter_id IS NOT NULL
+             END
+             """
+           )
+
+    create unique_index(
+             :lms_curriculum_logs,
+             [
+               :school_code,
+               :program_id,
+               :grade_id,
+               :subject_id,
+               :exam_track,
+               :chapter_id,
+               :log_date
+             ],
+             where: "log_type = 'class_cancelled' AND deleted_at IS NULL",
+             name: :lms_curriculum_logs_active_class_cancelled_unique
+           )
+  end
+
+  def down do
+    drop_if_exists index(:lms_curriculum_logs, [],
+                     name: :lms_curriculum_logs_active_class_cancelled_unique
+                   )
+
+    drop constraint(:lms_curriculum_logs, :lms_curriculum_logs_chapter_id_check)
+    drop constraint(:lms_curriculum_logs, :lms_curriculum_logs_log_type_check)
+    drop constraint(:lms_curriculum_logs, :lms_curriculum_logs_duration_minutes_check)
+
+    create constraint(:lms_curriculum_logs, :lms_curriculum_logs_duration_minutes_check,
+             check: "duration_minutes > 0 AND duration_minutes <= 720"
+           )
+
+    restore_exam_track_constraint(:lms_chapter_exam_configs)
+    restore_exam_track_constraint(:lms_curriculum_logs)
+    restore_exam_track_constraint(:lms_curriculum_chapter_completions)
+
+    alter table(:lms_curriculum_logs) do
+      modify :duration_minutes, :integer, null: false
+      remove :chapter_id
+      remove :log_type
+    end
+  end
+
+  defp replace_exam_track_constraint(table) do
+    name = String.to_atom("#{table}_exam_track_check")
+    drop constraint(table, name)
+    create constraint(table, name, check: "exam_track IN #{@exam_tracks}")
+  end
+
+  defp restore_exam_track_constraint(table) do
+    name = String.to_atom("#{table}_exam_track_check")
+    drop constraint(table, name)
+    create constraint(table, name, check: "exam_track IN ('jee_main', 'jee_advanced', 'neet')")
+  end
+end

--- a/priv/repo/migrations/20260807121000_create_centre_exam_tracks.exs
+++ b/priv/repo/migrations/20260807121000_create_centre_exam_tracks.exs
@@ -1,0 +1,19 @@
+defmodule Dbservice.Repo.Migrations.CreateCentreExamTracks do
+  use Ecto.Migration
+
+  def change do
+    create table(:centre_exam_tracks) do
+      add :centre_id, references(:centres, on_delete: :nothing), null: false
+      add :grade_id, references(:grade, on_delete: :nothing), null: false
+      add :exam_track_code, :string, null: false
+
+      timestamps(default: fragment("now()"), null: false)
+    end
+
+    create unique_index(:centre_exam_tracks, [:centre_id, :grade_id, :exam_track_code],
+             name: :centre_exam_tracks_centre_grade_track_unique
+           )
+
+    create index(:centre_exam_tracks, [:grade_id])
+  end
+end

--- a/test/dbservice/centre_schema_test.exs
+++ b/test/dbservice/centre_schema_test.exs
@@ -39,6 +39,15 @@ defmodule Dbservice.CentreSchemaTest do
                "updated_at"
              ]
 
+      assert Map.keys(columns("centre_exam_tracks")) |> Enum.sort() == [
+               "centre_id",
+               "exam_track_code",
+               "grade_id",
+               "id",
+               "inserted_at",
+               "updated_at"
+             ]
+
       assert_required_columns("centre_option_sets", [
         "id",
         "code",
@@ -70,6 +79,15 @@ defmodule Dbservice.CentreSchemaTest do
         "updated_at"
       ])
 
+      assert_required_columns("centre_exam_tracks", [
+        "id",
+        "centre_id",
+        "grade_id",
+        "exam_track_code",
+        "inserted_at",
+        "updated_at"
+      ])
+
       assert columns("centres")["school_id"].nullable?
       assert columns("centres")["program_id"].nullable?
       assert columns("centres")["type_code"].nullable?
@@ -91,6 +109,7 @@ defmodule Dbservice.CentreSchemaTest do
       # PK plus the active-centre guard: at most one ACTIVE centre per
       # (school, program), the pair centre_students attributes students by.
       assert ["school_id", "program_id"] in unique_indexes("centres")
+      assert ["centre_id", "grade_id", "exam_track_code"] in unique_indexes("centre_exam_tracks")
 
       refute Enum.any?(
                unique_indexes("centres"),
@@ -104,6 +123,7 @@ defmodule Dbservice.CentreSchemaTest do
       assert indexes("centres") |> Enum.any?(&(&1 == ["category_code"]))
       assert indexes("centres") |> Enum.any?(&(&1 == ["sub_category_code"]))
       assert gin_indexes("centres") |> Enum.any?(&(&1 == ["stream_codes"]))
+      assert indexes("centre_exam_tracks") |> Enum.any?(&(&1 == ["grade_id"]))
 
       assert foreign_keys("centre_options") == [
                {"option_set_id", "centre_option_sets", "id"}
@@ -112,6 +132,11 @@ defmodule Dbservice.CentreSchemaTest do
       assert foreign_keys("centres") == [
                {"program_id", "program", "id"},
                {"school_id", "school", "id"}
+             ]
+
+      assert foreign_keys("centre_exam_tracks") == [
+               {"centre_id", "centres", "id"},
+               {"grade_id", "grade", "id"}
              ]
     end
 

--- a/test/dbservice/lms_curriculum_test.exs
+++ b/test/dbservice/lms_curriculum_test.exs
@@ -16,6 +16,11 @@ defmodule Dbservice.LmsCurriculumTest do
   import Dbservice.ProgramsFixtures
 
   describe "chapter exam config schema" do
+    test "supports the five Curriculum Exam Tracks" do
+      assert ChapterExamConfig.exam_tracks() ==
+               ~w(jee_main jee_advanced neet cet math_foundation)
+    end
+
     test "validates configured counts and subject normalization" do
       assert ChapterExamConfigData.counts_by_subject() == %{
                "Physics" => 87,
@@ -128,6 +133,92 @@ defmodule Dbservice.LmsCurriculumTest do
 
       refute changeset.valid?
       assert "must be less than or equal to 720" in errors_on(changeset).duration_minutes
+    end
+
+    test "enforces the three LMS Curriculum Log shapes" do
+      %{program: program, grade: grade, subject: subject, chapter: chapter} = curriculum_scope()
+
+      base = %{
+        school_code: "SCH001",
+        program_id: program.id,
+        grade_id: grade.id,
+        subject_id: subject.id,
+        exam_track: "jee_main",
+        log_date: ~D[2026-08-07]
+      }
+
+      for attrs <- [
+            Map.put(base, :duration_minutes, nil),
+            Map.merge(base, %{log_type: "doubt_solving", chapter_id: chapter.id})
+          ] do
+        assert {:error, null_duration} =
+                 %CurriculumLog{}
+                 |> Ecto.Changeset.change(attrs)
+                 |> Ecto.Changeset.check_constraint(:duration_minutes,
+                   name: :lms_curriculum_logs_duration_minutes_check
+                 )
+                 |> Repo.insert()
+
+        assert %{duration_minutes: [_message]} = errors_on(null_duration)
+      end
+
+      cancelled_attrs =
+        Map.merge(base, %{
+          log_type: "class_cancelled",
+          chapter_id: chapter.id
+        })
+
+      assert {:ok, %CurriculumLog{duration_minutes: nil}} =
+               LmsCurriculum.create_curriculum_log(cancelled_attrs)
+
+      assert {:error, duplicate} = LmsCurriculum.create_curriculum_log(cancelled_attrs)
+      assert %{school_code: [_message]} = errors_on(duplicate)
+
+      assert {:ok, %CurriculumLog{duration_minutes: 30}} =
+               base
+               |> Map.merge(%{
+                 log_type: "doubt_solving",
+                 chapter_id: chapter.id,
+                 duration_minutes: 30
+               })
+               |> LmsCurriculum.create_curriculum_log()
+
+      refute CurriculumLog.changeset(
+               %CurriculumLog{},
+               Map.put(cancelled_attrs, :duration_minutes, 30)
+             ).valid?
+    end
+
+    test "persists the two new Exam Track codes across Curriculum tables" do
+      %{program: program, grade: grade, subject: subject, chapter: chapter} = curriculum_scope()
+
+      assert {:ok, %ChapterExamConfig{exam_track: "cet"}} =
+               LmsCurriculum.create_chapter_exam_config(%{
+                 chapter_id: chapter.id,
+                 exam_track: "cet",
+                 is_in_syllabus: true,
+                 prescribed_minutes: 0,
+                 coverage_sequence: 1
+               })
+
+      assert {:ok, %CurriculumLog{exam_track: "math_foundation"}} =
+               LmsCurriculum.create_curriculum_log(%{
+                 school_code: "SCH001",
+                 program_id: program.id,
+                 grade_id: grade.id,
+                 subject_id: subject.id,
+                 exam_track: "math_foundation",
+                 log_date: ~D[2026-08-07],
+                 duration_minutes: 45
+               })
+
+      assert {:ok, %ChapterCompletion{exam_track: "cet"}} =
+               LmsCurriculum.create_chapter_completion(%{
+                 school_code: "SCH001",
+                 program_id: program.id,
+                 chapter_id: chapter.id,
+                 exam_track: "cet"
+               })
     end
   end
 


### PR DESCRIPTION
## Summary

- This PR adds production migrations for the LMS Curriculum Log types. Each log links to a Chapter. The duration rules depend on the log type. One Chapter can have only one active Class Cancellation log per date.
- The Exam Track constraints now accept five codes: JEE Main, JEE Advanced, NEET, CET, and Math Foundation. This applies to `lms_chapter_exam_configs`, `lms_curriculum_logs`, and `lms_curriculum_chapter_completions`.
- This PR adds the `centre_exam_tracks` table. Each row maps one Centre and one Grade to one Exam Track. The combination is unique.
- The DB Service Ecto schemas and the migration tests match the new schema.

## Why

[AF LMS PR #268](https://github.com/avantifellows/af_lms/pull/268) needs this schema in production. [AF LMS issue #267](https://github.com/avantifellows/af_lms/issues/267) tracks the remaining rollout work.

The migrations inside the AF LMS repository are local mirrors for tests only. They do not change production.

## Impact

- Existing LMS Curriculum Logs stay Regular Class logs. The `regular` default sets this.
- The database enforces the shape of the new Class Cancellation and Doubt Solving logs.
- Curriculum can store Grade-specific Centre Exam Tracks with the fixed five-code vocabulary.
- This PR adds no new DB Service HTTP endpoint. AF LMS stays the product API and the permission boundary.

## Deployment order

1. Deploy these additive DB Service migrations to production.
2. Deploy AF LMS PR #268.
3. Admins enter the reviewed Grade 11 and Grade 12 Exam Track mappings manually in Centre Management. Then they verify the mappings there. (The earlier import script was removed. Entry is manual.)
4. Merge follow-up PR #692 after the new flow runs fine in production for a few days. It removes the legacy Centre Stream storage after AF LMS no longer reads it.

The destructive cleanup of `centres.stream_codes` and the Stream options is intentionally not in this PR. The current AF LMS stays compatible during the rollout. PR #692 holds that cleanup as a draft.

## Checks

- `mix check`
- `mix test test/dbservice/lms_curriculum_test.exs test/dbservice/centre_schema_test.exs` — 16 tests passed
- The test migrations rolled back and applied again without errors.
- The full `mix test` run shows 20 failures in unchanged Holistic Mentorship and Student eligibility tests. The local suite is missing their expected seed data. These failures are not related to this PR.
