### PR TITLE
feat(batch): add system field to batch table and imports

### DIFF
--- a/lib/dbservice/batches/batch.ex
+++ b/lib/dbservice/batches/batch.ex
@@ -17,6 +17,7 @@ defmodule Dbservice.Batches.Batch do
     field :start_date, :date
     field :end_date, :date
     field :af_medium, :string
+    field :system, :string
     field :metadata, :map, default: %{}
 
     belongs_to :program, Program
@@ -43,6 +44,7 @@ defmodule Dbservice.Batches.Batch do
       :program_id,
       :auth_group_id,
       :af_medium,
+      :system,
       :metadata
     ])
     |> validate_required([:name])

--- a/lib/dbservice/constants/mappings.ex
+++ b/lib/dbservice/constants/mappings.ex
@@ -777,6 +777,12 @@ defmodule Dbservice.Constants.Mappings do
       optional: ["batch_addition"],
       type: :string
     },
+    "System" => %{
+      db_field: "system",
+      required: [],
+      optional: ["batch_addition"],
+      type: :string
+    },
     "district_code" => %{
       db_field: "district_code",
       required: ["teacher_addition", "school_addition"],

--- a/lib/dbservice/utils/import_worker.ex
+++ b/lib/dbservice/utils/import_worker.ex
@@ -1375,6 +1375,7 @@ defmodule Dbservice.DataImport.ImportWorker do
     |> maybe_put_batch("end_date", parse_date(record["end_date"]))
     |> maybe_put_batch("program_id", record["program_id"])
     |> maybe_put_batch("auth_group_id", record["auth_group_id"])
+    |> maybe_put_batch("system", record["system"] |> trim_str())
     |> maybe_put_batch("metadata", metadata_value)
   end
 

--- a/lib/dbservice_web/json/batch_json.ex
+++ b/lib/dbservice_web/json/batch_json.ex
@@ -19,6 +19,7 @@ defmodule DbserviceWeb.BatchJSON do
       program_id: batch.program_id,
       auth_group_id: batch.auth_group_id,
       af_medium: batch.af_medium,
+      system: batch.system,
       metadata: batch.metadata
     }
   end

--- a/lib/dbservice_web/swagger_schemas/batch.ex
+++ b/lib/dbservice_web/swagger_schemas/batch.ex
@@ -16,6 +16,7 @@ defmodule DbserviceWeb.SwaggerSchema.Batch do
             batch_id(:string, "The id of a batch")
             parent_id(:string, "The id of a parent batch")
             af_medium(:stream, "AF medium")
+            system(:string, "The system of a batch")
             metadata(:map, "Metadata of a batch")
           end
 
@@ -25,6 +26,7 @@ defmodule DbserviceWeb.SwaggerSchema.Batch do
             batch_id: "DelhiStudents_11_Photon_Eng_23_001",
             parent_id: 1,
             af_medium: "medical",
+            system: "some-system",
             metadata: %{"key" => "value"}
           })
         end

--- a/priv/repo/migrations/20260812123557_add_system_to_batch.exs
+++ b/priv/repo/migrations/20260812123557_add_system_to_batch.exs
@@ -1,0 +1,9 @@
+defmodule Dbservice.Repo.Migrations.AddSystemToBatch do
+  use Ecto.Migration
+
+  def change do
+    alter table(:batch) do
+      add(:system, :string)
+    end
+  end
+end

--- a/test/dbservice_web/controllers/batch_controller_test.exs
+++ b/test/dbservice_web/controllers/batch_controller_test.exs
@@ -14,7 +14,8 @@ defmodule DbserviceWeb.BatchControllerTest do
     end_date: "2024-06-01",
     program_id: nil,
     auth_group_id: nil,
-    af_medium: "online"
+    af_medium: "online",
+    system: "some system"
   }
   @update_attrs %{
     name: "some updated batch name",
@@ -25,7 +26,8 @@ defmodule DbserviceWeb.BatchControllerTest do
     end_date: "2024-07-01",
     program_id: nil,
     auth_group_id: nil,
-    af_medium: "offline"
+    af_medium: "offline",
+    system: "some updated system"
   }
   @invalid_attrs %{
     name: nil,
@@ -77,7 +79,8 @@ defmodule DbserviceWeb.BatchControllerTest do
                "end_date" => "2024-06-01",
                "program_id" => nil,
                "auth_group_id" => nil,
-               "af_medium" => "online"
+               "af_medium" => "online",
+               "system" => "some system"
              } = response
     end
 
@@ -105,7 +108,8 @@ defmodule DbserviceWeb.BatchControllerTest do
                "end_date" => "2024-06-01",
                "program_id" => nil,
                "auth_group_id" => nil,
-               "af_medium" => "online"
+               "af_medium" => "online",
+               "system" => "some system"
              } = response
     end
   end
@@ -131,7 +135,8 @@ defmodule DbserviceWeb.BatchControllerTest do
                "end_date" => "2024-07-01",
                "program_id" => nil,
                "auth_group_id" => nil,
-               "af_medium" => "offline"
+               "af_medium" => "offline",
+               "system" => "some updated system"
              } = response
     end
 

--- a/test/support/fixtures/batch_fixtures.ex
+++ b/test/support/fixtures/batch_fixtures.ex
@@ -19,7 +19,8 @@ defmodule Dbservice.BatchesFixtures do
         end_date: ~D[2024-06-01],
         program_id: nil,
         auth_group_id: nil,
-        af_medium: "online"
+        af_medium: "online",
+        system: "some system"
       })
       |> Dbservice.Batches.create_batch()
 


### PR DESCRIPTION
## What

Adds a `system` field to the `batch` table, requested to let batches carry a system identifier.

## Changes

- **Migration** — new nullable `system` varchar column on `batch`.
- **Schema/changeset** (`batches/batch.ex`) — `system` cast as optional.
- **API** — returned in batch JSON responses (`batch_json.ex`) and documented in Swagger (`swagger_schemas/batch.ex`).
- **Data import** — new `System` column in the Batch Addition CSV import (`mappings.ex` + `import_worker.ex`), optional. Add a `System` header to the batch-addition sheet and the value flows into the new column.
- **Tests** — batch controller test + fixture updated.

## Notes

- The import `System` column is **optional**. Easy to make required if needed.
- Field is nullable — existing batches are unaffected.

## Verification

- `mix test` (batch suites): 13 tests, 0 failures
- `mix format --check-formatted`: clean
- `mix credo` (non-strict): no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)