### PR TITLE
Add reviewed_stages to scholarship_applications

### DIFF
--- a/priv/repo/migrations/20260813120000_add_reviewed_stages_to_scholarship_applications.exs
+++ b/priv/repo/migrations/20260813120000_add_reviewed_stages_to_scholarship_applications.exs
@@ -1,0 +1,18 @@
+defmodule Dbservice.Repo.Migrations.AddReviewedStagesToScholarshipApplications do
+  use Ecto.Migration
+
+  # Reviewer stage-tick persistence (af-scholarship, Poojita 2026-08-13): the
+  # reviewer detail view ticks each application stage (About You / Education /
+  # College & bank) as the reviewer opens it, and shortlisting / Docs Verified is
+  # gated on all three having been reviewed. Until now that tick set lived only in
+  # the browser session, so reopening an application after a resubmit round started
+  # fresh. Persisting it per application lets the ticks survive across rounds.
+  #
+  # `{:array, :integer}` holds the reviewed stage numbers (1 / 2 / 3). Additive +
+  # NOT NULL with a default '{}' → deploy-safe, no backfill needed.
+  def change do
+    alter table(:scholarship_applications) do
+      add :reviewed_stages, {:array, :integer}, null: false, default: []
+    end
+  end
+end


### PR DESCRIPTION
For af-scholarship (Poojita, 2026-08-13).

Adds a `reviewed_stages {:array, :integer}` column (NOT NULL, default `'{}'`) to `scholarship_applications`, so the reviewer's per-stage review ticks (About You / Education / College & bank) **persist across resubmit rounds** instead of resetting each browser session. Docs Verified / Shortlist is gated on all three stages having been reviewed.

Additive + non-null default → deploy-safe, no backfill. Stage numbers 1/2/3 are stored in the array; af-scholarship writes/reads it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)