### PR TITLE
Add Holistic audit compatibility

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,13 +72,25 @@ _Avoid_: definition history, content snapshot
 
 **Mentor-Mentee Mapping**:
 A time-bounded assignment of one Student to one Mentor User at a School for a
-Program and Academic Year. Ended rows remain as history.
+Program and Academic Year. Ended rows remain as history. Assignment and end
+events retain the authenticated actor email snapshot and may optionally link to
+the canonical actor User; machine `assignment_source`, `end_source`, and
+`end_reason` remain separate from human-entered assignment/end audit reasons.
+ID-only system and reconciliation writers remain valid without email or human
+reason snapshots.
 _Avoid_: Academic Mentorship mapping, overwriting assignment history
 
 **Post-Session Notes**:
 The current official ordered answer set for one Mentee and stable Phase, with
 optimistic revision and content-free mutation audit metadata.
 _Avoid_: meeting record, answer revision archive
+
+**Post-Session Note Audit**:
+An immutable content-free event for a Notes mutation. Every event retains at
+least one usable actor identity: a canonical `actor_user_id`, a nonblank
+`actor_email` snapshot, or both. Email-only permission actors are valid, while
+ID-only system and legacy writers remain valid.
+_Avoid_: editable audit row, content snapshot
 
 **Historical Holistic Notes**:
 A provenance-bearing legacy answer set imported for a safely matched Student,
@@ -110,6 +122,11 @@ _Avoid_: best-effort identity matching
 - A Program has one Phase Plan per Academic Year; a Phase Plan has ordered Phases.
 - A Student has at most one active Mentor-Mentee Mapping per Academic Year.
 - Post-Session Notes belong to one Student, one stable Phase, and their author.
+- Mapping and Post-Session Note audit events retain immutable actor snapshots;
+  canonical User links are optional where authenticated access has no User row.
+- Mapping machine source/reason fields are never repurposed for human audit
+  reasons; email and reason snapshots are nullable for system-created/ended
+  rows and reject blank/whitespace values at the database boundary.
 - A Student Profile belongs to the canonical Student journey and one immutable
   Prompt Configuration; older configurations remain retained.
 - A Regeneration Request points to its human actor, Student, requested
@@ -128,6 +145,9 @@ _Avoid_: best-effort identity matching
   state can be reconstructed without storing an Active or progress snapshot.
 - Phase definition mutations retain content-free actor/time audit without storing
   prior Guidance or Question versions.
+- Post-Session Note audits are immutable, keep nullable canonical User references,
+  require a canonical User ID or nonblank actor email, and allow 500-character
+  human reasons for draft-erasure events.
 - Raw questionnaire answers and rendered per-Student prompts are not persisted.
 - Profile Program eligibility comes from the Student's one current School and
   that School's canonical Program IDs; it does not require a Program enrollment.

--- a/priv/repo/migrations/20260817120000_add_holistic_mentorship_audit_snapshots.exs
+++ b/priv/repo/migrations/20260817120000_add_holistic_mentorship_audit_snapshots.exs
@@ -1,0 +1,119 @@
+defmodule Dbservice.Repo.Migrations.AddHolisticMentorshipAuditSnapshots do
+  use Ecto.Migration
+
+  @mapping_table "holistic_mentorship_mentor_mentee_mappings"
+  @note_audit_table "holistic_mentorship_post_session_note_audits"
+
+  def up do
+    alter table(@mapping_table) do
+      add :assigned_by_email, :string, size: 255
+      add :assignment_audit_reason, :string, size: 500
+      add :ended_by_email, :string, size: 255
+      add :end_audit_reason, :string, size: 500
+    end
+
+    execute("ALTER TABLE #{@mapping_table} DROP CONSTRAINT hm_mappings_lifecycle_check")
+
+    create constraint(
+             @mapping_table,
+             :hm_mappings_lifecycle_check,
+             check: """
+             assignment_source <> '' AND
+             (
+               ended_at IS NULL AND ended_by_user_id IS NULL AND ended_by_email IS NULL AND
+               end_source IS NULL AND end_reason IS NULL AND end_audit_reason IS NULL
+               OR
+               ended_at IS NOT NULL AND end_source IS NOT NULL AND end_source <> '' AND
+               end_reason IS NOT NULL AND end_reason <> '' AND ended_at >= started_at
+             )
+             """
+           )
+
+    create constraint(
+             @mapping_table,
+             :hm_mappings_audit_fields_check,
+             check: """
+             (assigned_by_email IS NULL OR assigned_by_email ~ '[^[:space:]]') AND
+             (assignment_audit_reason IS NULL OR assignment_audit_reason ~ '[^[:space:]]') AND
+             (ended_by_email IS NULL OR ended_by_email ~ '[^[:space:]]') AND
+             (end_audit_reason IS NULL OR end_audit_reason ~ '[^[:space:]]')
+             """
+           )
+
+    alter table(@note_audit_table) do
+      add :actor_email, :string, size: 255
+    end
+
+    execute("ALTER TABLE #{@note_audit_table} ALTER COLUMN actor_user_id DROP NOT NULL")
+    execute("ALTER TABLE #{@note_audit_table} ALTER COLUMN reason TYPE varchar(500)")
+
+    create constraint(
+             @note_audit_table,
+             :hm_post_session_note_audits_actor_email_check,
+             check: "actor_email IS NULL OR actor_email ~ '[^[:space:]]'"
+           )
+
+    create constraint(
+             @note_audit_table,
+             :hm_post_session_note_audits_actor_identity_check,
+             check: "actor_user_id IS NOT NULL OR coalesce(actor_email, '') ~ '[^[:space:]]'"
+           )
+  end
+
+  def down do
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM #{@note_audit_table}
+        WHERE actor_user_id IS NULL
+      ) THEN
+        RAISE EXCEPTION
+          'Cannot down-migrate Holistic Note audits while email-only actors exist';
+      END IF;
+    END
+    $$;
+    """)
+
+    drop constraint(
+           @note_audit_table,
+           :hm_post_session_note_audits_actor_identity_check
+         )
+
+    drop constraint(
+           @note_audit_table,
+           :hm_post_session_note_audits_actor_email_check
+         )
+
+    alter table(@note_audit_table) do
+      remove :actor_email
+    end
+
+    execute("ALTER TABLE #{@note_audit_table} ALTER COLUMN actor_user_id SET NOT NULL")
+    execute("ALTER TABLE #{@note_audit_table} ALTER COLUMN reason TYPE varchar(255)")
+
+    drop constraint(@mapping_table, :hm_mappings_audit_fields_check)
+    drop constraint(@mapping_table, :hm_mappings_lifecycle_check)
+
+    alter table(@mapping_table) do
+      remove :end_audit_reason
+      remove :ended_by_email
+      remove :assignment_audit_reason
+      remove :assigned_by_email
+    end
+
+    create constraint(
+             @mapping_table,
+             :hm_mappings_lifecycle_check,
+             check: """
+             assignment_source <> '' AND (
+               (ended_at IS NULL AND ended_by_user_id IS NULL AND end_source IS NULL AND end_reason IS NULL)
+               OR
+               (ended_at IS NOT NULL AND end_source IS NOT NULL AND end_source <> ''
+                 AND end_reason IS NOT NULL AND end_reason <> '' AND ended_at >= started_at)
+             )
+             """
+           )
+  end
+end

--- a/test/dbservice/holistic_mentorship_mapping_schema_test.exs
+++ b/test/dbservice/holistic_mentorship_mapping_schema_test.exs
@@ -8,11 +8,15 @@ defmodule Dbservice.HolisticMentorshipMappingSchemaTest do
   test "defines the canonical Mapping contract and indexes" do
     assert column_types() == %{
              "academic_year" => "character varying",
+             "assigned_by_email" => "character varying",
+             "assignment_audit_reason" => "character varying",
              "assigned_by_user_id" => "bigint",
              "assignment_source" => "character varying",
+             "end_audit_reason" => "character varying",
              "end_reason" => "character varying",
              "end_source" => "character varying",
              "ended_at" => "timestamp without time zone",
+             "ended_by_email" => "character varying",
              "ended_by_user_id" => "bigint",
              "id" => "bigint",
              "inserted_at" => "timestamp without time zone",
@@ -25,12 +29,23 @@ defmodule Dbservice.HolisticMentorshipMappingSchemaTest do
            }
 
     assert nullable_columns() == [
+             "assigned_by_email",
              "assigned_by_user_id",
+             "assignment_audit_reason",
+             "end_audit_reason",
              "end_reason",
              "end_source",
              "ended_at",
+             "ended_by_email",
              "ended_by_user_id"
            ]
+
+    assert column_lengths() == %{
+             "assigned_by_email" => 255,
+             "assignment_audit_reason" => 500,
+             "end_audit_reason" => 500,
+             "ended_by_email" => 255
+           }
 
     assert foreign_keys() == [
              {"assigned_by_user_id", "user", "NO ACTION"},
@@ -41,7 +56,10 @@ defmodule Dbservice.HolisticMentorshipMappingSchemaTest do
              {"student_id", "student", "NO ACTION"}
            ]
 
-    assert check_names() == ["hm_mappings_lifecycle_check"]
+    assert check_names() == [
+             "hm_mappings_audit_fields_check",
+             "hm_mappings_lifecycle_check"
+           ]
 
     assert indexes() == [
              {"hm_mappings_active_mentor_year_idx", false,
@@ -105,15 +123,17 @@ defmodule Dbservice.HolisticMentorshipMappingSchemaTest do
              end)
 
     assert Repo.query!(
-             "SELECT id, ended_at IS NOT NULL, ended_by_user_id, end_source, end_reason FROM #{@table}",
+             "SELECT id, ended_at IS NOT NULL, ended_by_user_id, ended_by_email, end_source, end_reason, end_audit_reason FROM #{@table}",
              []
            ).rows == [
              [
                mapping_id,
                true,
                nil,
+               nil,
                "db_service_student_eligibility",
-               "student_dropout"
+               "student_dropout",
+               nil
              ]
            ]
 
@@ -123,6 +143,70 @@ defmodule Dbservice.HolisticMentorshipMappingSchemaTest do
              end)
 
     assert Repo.query!("SELECT count(*) FROM #{@table}").rows == [[1]]
+  end
+
+  test "stores audit snapshots and rejects blank or active end-event metadata" do
+    scope = insert_scope()
+    assert {:ok, %{rows: [[mapping_id]]}} = insert_mapping(scope, [nil, nil, nil, nil])
+
+    assignment_reason = String.duplicate("a", 256)
+
+    Repo.query!(
+      """
+      UPDATE #{@table}
+      SET assigned_by_email = $1, assignment_audit_reason = $2
+      WHERE id = $3
+      """,
+      [" admin@example.com ", assignment_reason, mapping_id]
+    )
+
+    assert Repo.query!(
+             "SELECT assigned_by_email, assignment_audit_reason FROM #{@table} WHERE id = $1",
+             [mapping_id]
+           ).rows == [[" admin@example.com ", assignment_reason]]
+
+    for {column, value} <- [
+          {"assigned_by_email", "   "},
+          {"assignment_audit_reason", "\t  "}
+        ] do
+      assert_check_violation(fn ->
+        Repo.query("UPDATE #{@table} SET #{column} = $1 WHERE id = $2", [value, mapping_id])
+      end)
+    end
+
+    assert_check_violation(fn ->
+      Repo.query(
+        "UPDATE #{@table} SET ended_by_email = $1 WHERE id = $2",
+        ["admin@example.com", mapping_id]
+      )
+    end)
+
+    end_reason = String.duplicate("e", 256)
+
+    Repo.query!(
+      """
+      UPDATE #{@table}
+      SET ended_at = '2026-01-02 10:00:00', ended_by_email = $1,
+          end_source = 'af_lms_admin_remove', end_reason = 'admin_removal',
+          end_audit_reason = $2
+      WHERE id = $3
+      """,
+      ["admin@example.com", end_reason, mapping_id]
+    )
+
+    assert Repo.query!(
+             "SELECT ended_by_email, end_audit_reason FROM #{@table} WHERE id = $1",
+             [mapping_id]
+           ).rows == [["admin@example.com", end_reason]]
+
+    for {column, value} <- [
+          {"ended_by_email", "  "},
+          {"end_audit_reason", "\n"}
+        ] do
+      assert_check_violation(fn ->
+        Repo.query("UPDATE #{@table} SET #{column} = $1 WHERE id = $2", [value, mapping_id])
+      end)
+    end
   end
 
   test "retains ended assignment history and restricts canonical deletion" do
@@ -226,6 +310,25 @@ defmodule Dbservice.HolisticMentorshipMappingSchemaTest do
       [@table]
     ).rows
     |> Enum.map(fn [name] -> name end)
+  end
+
+  defp column_lengths do
+    Repo.query!(
+      """
+      SELECT column_name, character_maximum_length
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = $1
+        AND character_maximum_length IS NOT NULL
+      """,
+      [@table]
+    ).rows
+    |> Map.new(fn [name, length] -> {name, length} end)
+    |> Map.take([
+      "assigned_by_email",
+      "assignment_audit_reason",
+      "end_audit_reason",
+      "ended_by_email"
+    ])
   end
 
   defp foreign_keys do

--- a/test/dbservice/holistic_mentorship_notes_schema_test.exs
+++ b/test/dbservice/holistic_mentorship_notes_schema_test.exs
@@ -98,6 +98,7 @@ defmodule Dbservice.HolisticMentorshipNotesSchemaTest do
   test "defines a content-free Post-Session Notes mutation audit" do
     assert column_types("holistic_mentorship_post_session_note_audits") == %{
              "action" => "character varying",
+             "actor_email" => "character varying",
              "actor_user_id" => "bigint",
              "id" => "bigint",
              "inserted_at" => "timestamp without time zone",
@@ -106,6 +107,16 @@ defmodule Dbservice.HolisticMentorshipNotesSchemaTest do
              "reason" => "character varying",
              "updated_at" => "timestamp without time zone"
            }
+
+    assert column_lengths("holistic_mentorship_post_session_note_audits") == %{
+             "actor_email" => 255,
+             "reason" => 500
+           }
+
+    assert check_names("holistic_mentorship_post_session_note_audits") == [
+             "hm_post_session_note_audits_actor_email_check",
+             "hm_post_session_note_audits_actor_identity_check"
+           ]
   end
 
   test "defines the required namespaced Notes, Answer, and audit contract" do
@@ -138,7 +149,11 @@ defmodule Dbservice.HolisticMentorshipNotesSchemaTest do
 
     assert nullable_columns("holistic_mentorship_post_session_answers") == []
 
-    assert nullable_columns("holistic_mentorship_post_session_note_audits") == ["reason"]
+    assert nullable_columns("holistic_mentorship_post_session_note_audits") == [
+             "actor_email",
+             "actor_user_id",
+             "reason"
+           ]
 
     assert foreign_keys("holistic_mentorship_post_session_notes") == [
              {"author_user_id", "user", "NO ACTION"},
@@ -155,6 +170,122 @@ defmodule Dbservice.HolisticMentorshipNotesSchemaTest do
              {"actor_user_id", "user", "NO ACTION"},
              {"notes_id", "holistic_mentorship_post_session_notes", "NO ACTION"}
            ]
+
+    assert indexes("holistic_mentorship_post_session_note_audits") == [
+             {"hm_post_session_note_audits_actor_idx", false, ["actor_user_id"], nil},
+             {"hm_post_session_note_audits_notes_time_idx", false, ["notes_id", "occurred_at"],
+              nil},
+             {"holistic_mentorship_post_session_note_audits_pkey", true, ["id"], nil}
+           ]
+  end
+
+  test "supports ID-only, email-only, and dual-identity Note audits" do
+    scope = insert_scope()
+    {:ok, %{rows: [[notes_id]]}} = insert_note(scope, "draft", 1, nil)
+
+    assert {:ok, %{rows: [[id_only_id]]}} =
+             Repo.query(
+               """
+               INSERT INTO holistic_mentorship_post_session_note_audits
+                 (notes_id, actor_user_id, action, occurred_at)
+               VALUES ($1, $2, 'draft_saved', now())
+               RETURNING id
+               """,
+               [notes_id, scope.author_user_id]
+             )
+
+    assert {:ok, %{rows: [[email_only_id]]}} =
+             Repo.query(
+               """
+               INSERT INTO holistic_mentorship_post_session_note_audits
+                 (notes_id, actor_email, action, occurred_at)
+               VALUES ($1, 'permission-only@example.com', 'draft_erased_on_mapping_end', now())
+               RETURNING id
+               """,
+               [notes_id]
+             )
+
+    assert {:ok, %{rows: [[dual_identity_id]]}} =
+             Repo.query(
+               """
+               INSERT INTO holistic_mentorship_post_session_note_audits
+                 (notes_id, actor_user_id, actor_email, action, occurred_at)
+               VALUES ($1, $2, 'actor@example.com', 'draft_saved', now())
+               RETURNING id
+               """,
+               [notes_id, scope.author_user_id]
+             )
+
+    assert Repo.query!(
+             """
+             SELECT actor_user_id, actor_email
+             FROM holistic_mentorship_post_session_note_audits
+             WHERE id = ANY($1::bigint[])
+             ORDER BY id
+             """,
+             [[id_only_id, email_only_id, dual_identity_id]]
+           ).rows == [
+             [scope.author_user_id, nil],
+             [nil, "permission-only@example.com"],
+             [scope.author_user_id, "actor@example.com"]
+           ]
+
+    assert_constraint(:check_violation, fn ->
+      Repo.query(
+        """
+        INSERT INTO holistic_mentorship_post_session_note_audits
+          (notes_id, action, occurred_at)
+        VALUES ($1, 'draft_saved', now())
+        """,
+        [notes_id]
+      )
+    end)
+
+    for actor_email <- ["", "   ", "\t\n"] do
+      assert_constraint(:check_violation, fn ->
+        Repo.query(
+          """
+          INSERT INTO holistic_mentorship_post_session_note_audits
+            (notes_id, actor_user_id, actor_email, action, occurred_at)
+          VALUES ($1, $2, $3, 'draft_saved', now())
+          """,
+          [notes_id, scope.author_user_id, actor_email]
+        )
+      end)
+    end
+
+    assert_constraint(:check_violation, fn ->
+      Repo.query(
+        """
+        INSERT INTO holistic_mentorship_post_session_note_audits
+          (notes_id, actor_email, action, occurred_at)
+        VALUES ($1, ' \t ', 'draft_erased_on_mapping_end', now())
+        """,
+        [notes_id]
+      )
+    end)
+  end
+
+  test "accepts a 256-character draft-erasure audit reason" do
+    scope = insert_scope()
+    {:ok, %{rows: [[notes_id]]}} = insert_note(scope, "draft", 1, nil)
+    reason = String.duplicate("r", 256)
+
+    assert {:ok, %{rows: [[audit_id]]}} =
+             Repo.query(
+               """
+               INSERT INTO holistic_mentorship_post_session_note_audits
+                 (notes_id, actor_email, action, occurred_at, reason)
+               VALUES ($1, 'admin@example.com', 'draft_erased_on_mapping_end', now(), $2)
+               RETURNING id
+               """,
+               [notes_id, reason]
+             )
+
+    assert Repo.query!(
+             "SELECT actor_user_id, actor_email, reason FROM holistic_mentorship_post_session_note_audits WHERE id = $1",
+             [audit_id]
+           ).rows == [[nil, "admin@example.com", reason]]
   end
 
   test "retains used Notes records and mutation audits" do
@@ -321,6 +452,61 @@ defmodule Dbservice.HolisticMentorshipNotesSchemaTest do
       [table]
     ).rows
     |> Enum.map(fn [name] -> name end)
+  end
+
+  defp column_lengths(table) do
+    Repo.query!(
+      """
+      SELECT column_name, character_maximum_length
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = $1
+        AND character_maximum_length IS NOT NULL
+      """,
+      [table]
+    ).rows
+    |> Map.new(fn [name, length] -> {name, length} end)
+    |> Map.take(["actor_email", "reason"])
+  end
+
+  defp check_names(table) do
+    Repo.query!(
+      """
+      SELECT constraint_record.conname
+      FROM pg_constraint AS constraint_record
+      JOIN pg_class AS relation ON relation.oid = constraint_record.conrelid
+      JOIN pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+      WHERE namespace.nspname = 'public'
+        AND relation.relname = $1
+        AND constraint_record.contype = 'c'
+      ORDER BY constraint_record.conname
+      """,
+      [table]
+    ).rows
+    |> Enum.map(fn [name] -> name end)
+  end
+
+  defp indexes(table) do
+    Repo.query!(
+      """
+      SELECT index_record.relname,
+             index.indisunique,
+             array_agg(attribute.attname ORDER BY key.ordinality),
+             pg_get_expr(index.indpred, index.indrelid)
+      FROM pg_index AS index
+      JOIN pg_class AS table_record ON table_record.oid = index.indrelid
+      JOIN pg_class AS index_record ON index_record.oid = index.indexrelid
+      JOIN LATERAL unnest(index.indkey) WITH ORDINALITY AS key(attnum, ordinality) ON true
+      JOIN pg_attribute AS attribute
+        ON attribute.attrelid = table_record.oid AND attribute.attnum = key.attnum
+      WHERE table_record.relname = $1
+      GROUP BY index_record.relname, index.indisunique, index.indpred, index.indrelid
+      ORDER BY index_record.relname
+      """,
+      [table]
+    ).rows
+    |> Enum.map(fn [name, unique, columns, predicate] ->
+      {name, unique, columns, predicate}
+    end)
   end
 
   defp foreign_keys(table) do


### PR DESCRIPTION
## Summary

- Add the additive Main Postgres migration for Holistic Mapping actor/email snapshots and human audit reasons.
- Make Post-Session Note audits compatible with ID-only, email-only, and dual-identity writers while preserving the existing User foreign key, index, and immutable audit trigger.
- Add schema/behavior coverage for capacities, nullability, lifecycle rules, blank/whitespace rejection, writer compatibility, 256-character draft-erasure reasons, and unchanged indexes.
- Update the db-service Holistic domain context with the actor snapshot and machine-vs-human audit contract.

## Rollout

Merge and deploy this migration before AF LMS PR #289 consumes the new columns. AF LMS must reject audit reasons longer than 500 characters at its server boundary. Roll back the application before any database rollback; do not down-migrate after email-only Note-audit rows exist unless a preflight confirms every audit still has `actor_user_id`.

## Verification

- `mix format --check-formatted` ✅
- `mix check` ✅ (compiler, Credo, Dialyzer, formatter, unused deps)
- Focused Mapping/Notes schema tests: 14 passed ✅
- Migration rollback and re-migration ✅
- Full `mix test` with a temporary test token: 714 tests, 21 baseline fixture/seed failures unrelated to this change. A no-token run has the existing `BEARER_TOKEN` setup failure.

Closes #689
