### PR TITLE
Remove legacy Centre Stream storage

### DIFF
--- a/priv/repo/migrations/20260817120000_remove_legacy_centre_stream.exs
+++ b/priv/repo/migrations/20260817120000_remove_legacy_centre_stream.exs
@@ -1,0 +1,33 @@
+defmodule Dbservice.Repo.Migrations.RemoveLegacyCentreStream do
+  use Ecto.Migration
+
+  # Destructive follow-up to the Centre Exam Track rollout. Run only after
+  # AF LMS PR #268 is live in production and nothing reads
+  # centres.stream_codes anymore.
+
+  def up do
+    drop_if_exists(index(:centres, [:stream_codes], name: :centres_stream_codes_index))
+
+    alter table(:centres) do
+      remove(:stream_codes)
+    end
+
+    execute("""
+    DELETE FROM centre_options
+    WHERE option_set_id IN (SELECT id FROM centre_option_sets WHERE code = 'stream')
+    """)
+
+    execute("DELETE FROM centre_option_sets WHERE code = 'stream'")
+  end
+
+  def down do
+    # Restores only the column and index. The deleted stream option rows are
+    # seed data owned by the AF LMS option seed script and are not recreated
+    # here.
+    alter table(:centres) do
+      add(:stream_codes, {:array, :text}, default: fragment("'{}'::text[]"), null: false)
+    end
+
+    create(index(:centres, [:stream_codes], using: :gin))
+  end
+end

--- a/test/dbservice/centre_schema_test.exs
+++ b/test/dbservice/centre_schema_test.exs
@@ -33,7 +33,6 @@ defmodule Dbservice.CentreSchemaTest do
                "name",
                "program_id",
                "school_id",
-               "stream_codes",
                "sub_category_code",
                "type_code",
                "updated_at"
@@ -72,7 +71,6 @@ defmodule Dbservice.CentreSchemaTest do
       assert_required_columns("centres", [
         "id",
         "name",
-        "stream_codes",
         "is_physical",
         "is_active",
         "inserted_at",
@@ -93,14 +91,14 @@ defmodule Dbservice.CentreSchemaTest do
       assert columns("centres")["type_code"].nullable?
       assert columns("centres")["category_code"].nullable?
       assert columns("centres")["sub_category_code"].nullable?
-      assert columns("centres")["stream_codes"].type == "ARRAY"
-      assert columns("centres")["stream_codes"].udt_name == "_text"
+      # The legacy Centre Stream column is gone; grade-specific Exam Track
+      # mappings in centre_exam_tracks replaced it.
+      refute Map.has_key?(columns("centres"), "stream_codes")
 
       assert default_for("centre_option_sets", "allow_multi") =~ "false"
       assert default_for("centre_option_sets", "sort_order") =~ "0"
       assert default_for("centre_options", "sort_order") =~ "0"
       assert default_for("centre_options", "is_active") =~ "true"
-      assert default_for("centres", "stream_codes") =~ "'{}'::text[]"
       assert default_for("centres", "is_physical") =~ "false"
       assert default_for("centres", "is_active") =~ "true"
 
@@ -122,7 +120,7 @@ defmodule Dbservice.CentreSchemaTest do
       assert indexes("centres") |> Enum.any?(&(&1 == ["type_code"]))
       assert indexes("centres") |> Enum.any?(&(&1 == ["category_code"]))
       assert indexes("centres") |> Enum.any?(&(&1 == ["sub_category_code"]))
-      assert gin_indexes("centres") |> Enum.any?(&(&1 == ["stream_codes"]))
+      assert gin_indexes("centres") == []
       assert indexes("centre_exam_tracks") |> Enum.any?(&(&1 == ["grade_id"]))
 
       assert foreign_keys("centre_options") == [


### PR DESCRIPTION
## Summary

- This PR drops the legacy `centres.stream_codes` column and its GIN index.
- It deletes the `stream` option set and its options from `centre_options` and `centre_option_sets`.
- It updates the Centre schema test to assert that the column and index are gone.

## Why

[AF LMS PR #268](https://github.com/avantifellows/af_lms/pull/268) replaces Centre Streams with grade-specific Centre Exam Track mappings. After that PR is live, no code reads `centres.stream_codes`. This PR is the planned destructive cleanup that PR #681 deferred.

The AF LMS fixture migration `20260807030000_remove_legacy_centre_stream.sql` mirrors this change for local tests. This PR is the production version.

## ⚠️ Do not merge yet

Merge this PR only after both of these are true:

1. DB Service PR #681 and AF LMS PR #268 are live in production.
2. The new Centre Exam Track flow has run without problems for a few days.

Merging earlier breaks the currently deployed AF LMS, which still reads the column.

This PR's base is PR #681's branch, so it shows only the cleanup diff. When #681 merges, GitHub retargets this PR to `main`.

## Rollback

`mix ecto.rollback` restores the column (non-null, default `{}`) and the GIN index. It does not restore the deleted stream option rows; the AF LMS option seed script owns that seed data.

## Checks

- `mix test test/dbservice/centre_schema_test.exs test/dbservice/lms_curriculum_test.exs` — 16 tests passed on a fresh database
- The migration rolled back and applied again without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
