### PR TITLE
feat(import): add Student School Movement import type

### DIFF
--- a/lib/dbservice/constants/mappings.ex
+++ b/lib/dbservice/constants/mappings.ex
@@ -86,6 +86,7 @@ defmodule Dbservice.Constants.Mappings do
         "alumni_addition",
         "update_incorrect_batch_id_to_correct_batch_id",
         "update_incorrect_school_to_correct_school",
+        "student_school_movement",
         "update_incorrect_grade_to_correct_grade",
         "update_incorrect_auth_group_to_correct_auth_group"
       ],
@@ -332,6 +333,7 @@ defmodule Dbservice.Constants.Mappings do
         "re_enrollment",
         "update_incorrect_batch_id_to_correct_batch_id",
         "update_incorrect_school_to_correct_school",
+        "student_school_movement",
         "update_incorrect_grade_to_correct_grade",
         "update_incorrect_auth_group_to_correct_auth_group",
         "student_enrollment"
@@ -361,7 +363,8 @@ defmodule Dbservice.Constants.Mappings do
         "teacher_batch_assignment",
         "dropout",
         "re_enrollment",
-        "student_enrollment"
+        "student_enrollment",
+        "student_school_movement"
       ],
       optional: ["school_addition"],
       type: :string
@@ -403,6 +406,7 @@ defmodule Dbservice.Constants.Mappings do
       required: [
         "student",
         "update_incorrect_school_to_correct_school",
+        "student_school_movement",
         "re_enrollment",
         "school_addition",
         "school_deletion",
@@ -410,6 +414,12 @@ defmodule Dbservice.Constants.Mappings do
       ],
       optional: [],
       type: :string
+    },
+    "effective_date" => %{
+      db_field: "effective_date",
+      required: [],
+      optional: ["student_school_movement"],
+      type: :date
     },
     "udise_code" => %{
       db_field: "udise_code",

--- a/lib/dbservice/data_import.ex
+++ b/lib/dbservice/data_import.ex
@@ -38,6 +38,8 @@ defmodule Dbservice.DataImport do
   def format_type_name("update_incorrect_school_to_correct_school"),
     do: "Update Incorrect School to Correct School"
 
+  def format_type_name("student_school_movement"), do: "Student School Movement"
+
   def format_type_name("update_incorrect_grade_to_correct_grade"),
     do: "Update Incorrect Grade to Correct Grade"
 

--- a/lib/dbservice/services/school_movement_service.ex
+++ b/lib/dbservice/services/school_movement_service.ex
@@ -1,0 +1,151 @@
+defmodule Dbservice.Services.SchoolMovementService do
+  @moduledoc """
+  Moves a student to a new school while preserving enrollment history.
+
+  Unlike `Dbservice.Services.GroupUpdateService` (used by the
+  `update_incorrect_school_to_correct_school` import), which mutates the current
+  school enrollment in place and therefore loses the previous school, this
+  service:
+
+    * closes out the student's current school enrollment(s) by setting
+      `is_current: false` and stamping `end_date` — the row is kept, not deleted,
+      so the history of which school the student attended is preserved;
+    * inserts a new `is_current: true` school enrollment for the target academic
+      year (reactivating an existing row for the same school/year if one already
+      exists, so re-running an import is idempotent);
+    * swaps the single `group_user` membership row for the "school" group type
+      (that table has no history concept and always reflects the current school).
+
+  Enrollment records for other academic years (already `is_current: false`) are
+  left untouched. The whole operation runs in a transaction.
+
+  Note the two `group_id` conventions: `enrollment_record.group_id` stores the
+  child entity id (`school.id`, i.e. `group.child_id`), while `group_user.group_id`
+  stores the groups-table primary key (`group.id`).
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Dbservice.Repo
+  alias Dbservice.Groups
+  alias Dbservice.Groups.Group
+  alias Dbservice.Groups.GroupUser
+  alias Dbservice.GroupUsers
+  alias Dbservice.EnrollmentRecords
+  alias Dbservice.EnrollmentRecords.EnrollmentRecord
+
+  @school_group_type "school"
+
+  @doc """
+  Moves a student to a new school, preserving the previous school as history.
+
+  Expects a params map with:
+    * `"user_id"` - the student's user id
+    * `"group_id"` - the groups-table PK of the target (correct) school group
+    * `"academic_year"` - the academic year the new enrollment applies to
+    * `"effective_date"` - optional ISO8601 date string; defaults to today
+
+  Returns `{:ok, %EnrollmentRecord{}}` or `{:error, reason}`.
+  """
+  def move_student_school(%{"user_id" => user_id, "group_id" => group_id} = params) do
+    academic_year = params["academic_year"]
+
+    with {:ok, effective_date} <- parse_effective_date(params["effective_date"]) do
+      school_group = Groups.get_group!(group_id)
+
+      Repo.transaction(fn ->
+        # Close out the student's current school enrollment(s), preserving them as
+        # history. Rows for other years are already is_current: false, so untouched.
+        close_out_current_school_enrollments(user_id, effective_date)
+
+        with {:ok, enrollment} <-
+               upsert_school_enrollment(
+                 user_id,
+                 school_group.child_id,
+                 academic_year,
+                 effective_date
+               ),
+             {:ok, _group_user} <- swap_school_group_user(user_id, group_id) do
+          enrollment
+        else
+          {:error, reason} -> Repo.rollback(reason)
+        end
+      end)
+    end
+  end
+
+  defp close_out_current_school_enrollments(user_id, end_date) do
+    from(er in EnrollmentRecord,
+      where:
+        er.user_id == ^user_id and
+          er.group_type == ^@school_group_type and
+          er.is_current == true,
+      update: [set: [is_current: false, end_date: ^end_date]]
+    )
+    |> Repo.update_all([])
+  end
+
+  defp upsert_school_enrollment(user_id, school_id, academic_year, start_date) do
+    case get_school_enrollment(user_id, school_id, academic_year) do
+      nil ->
+        EnrollmentRecords.create_enrollment_record(%{
+          "user_id" => user_id,
+          "group_id" => school_id,
+          "group_type" => @school_group_type,
+          "academic_year" => academic_year,
+          "start_date" => start_date,
+          "is_current" => true
+        })
+
+      %EnrollmentRecord{} = record ->
+        # A record for this school/year already exists (e.g. a re-run) — reactivate
+        # it rather than inserting a duplicate.
+        EnrollmentRecords.update_enrollment_record(record, %{
+          "is_current" => true,
+          "start_date" => start_date,
+          "end_date" => nil
+        })
+    end
+  end
+
+  defp get_school_enrollment(user_id, school_id, academic_year) do
+    Repo.one(
+      from er in EnrollmentRecord,
+        where:
+          er.user_id == ^user_id and
+            er.group_id == ^school_id and
+            er.group_type == ^@school_group_type and
+            er.academic_year == ^academic_year,
+        order_by: [desc: er.id],
+        limit: 1
+    )
+  end
+
+  # Mirrors the group_user handling in ReEnrollmentService: group_user carries no
+  # history, so all school-type memberships for the user are removed and a single
+  # fresh one is created for the new school group.
+  defp swap_school_group_user(user_id, group_id) do
+    group = Groups.get_group!(group_id)
+
+    group_ids_subquery =
+      from(g in Group, where: g.type == ^group.type, select: g.id)
+
+    from(gu in GroupUser,
+      where: gu.user_id == ^user_id and gu.group_id in subquery(group_ids_subquery)
+    )
+    |> Repo.delete_all()
+
+    GroupUsers.create_group_user(%{"user_id" => user_id, "group_id" => group_id})
+  end
+
+  defp parse_effective_date(nil), do: {:ok, Date.utc_today()}
+  defp parse_effective_date(""), do: {:ok, Date.utc_today()}
+  defp parse_effective_date(%Date{} = date), do: {:ok, date}
+
+  defp parse_effective_date(date) when is_binary(date) do
+    case Date.from_iso8601(String.trim(date)) do
+      {:ok, parsed} -> {:ok, parsed}
+      {:error, _} -> {:error, "Invalid effective_date: #{date}. Expected format YYYY-MM-DD"}
+    end
+  end
+end

--- a/lib/dbservice/utils/group_update_processor.ex
+++ b/lib/dbservice/utils/group_update_processor.ex
@@ -10,6 +10,8 @@ defmodule Dbservice.DataImport.GroupUpdateProcessor do
   alias Dbservice.Batches
   alias Dbservice.AuthGroups
   alias Dbservice.Services.GroupUpdateService
+  alias Dbservice.Services.SchoolMovementService
+  alias Dbservice.Utils.ChangesetFormatter
 
   @doc """
   Processes batch ID correction (old_batch_id -> new batch_id)
@@ -41,6 +43,35 @@ defmodule Dbservice.DataImport.GroupUpdateProcessor do
       "school",
       "School update"
     )
+  end
+
+  @doc """
+  Processes a student school movement (student_id or apaar_id, school_code, academic_year).
+
+  Unlike `process_school_update/1`, which overwrites the current school enrollment
+  in place and loses history, this closes out the student's current school
+  enrollment (keeping it as history) and inserts a new active enrollment for the
+  target academic year, scoped to that year and leaving other years untouched.
+  """
+  def process_school_movement(record) do
+    with {:ok, student} <- get_student(record),
+         {:ok, academic_year} <- get_academic_year(record),
+         {:ok, school_group_id} <- get_school_group_id(record["school_code"]) do
+      params = %{
+        "user_id" => student.user_id,
+        "group_id" => school_group_id,
+        "academic_year" => academic_year,
+        "effective_date" => record["effective_date"]
+      }
+
+      case SchoolMovementService.move_student_school(params) do
+        {:ok, _} -> {:ok, "School movement processed successfully"}
+        {:error, %Ecto.Changeset{} = changeset} -> {:error, format_changeset(changeset)}
+        {:error, reason} -> {:error, "School movement failed: #{inspect(reason)}"}
+      end
+    else
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   @doc """
@@ -112,6 +143,19 @@ defmodule Dbservice.DataImport.GroupUpdateProcessor do
           {:ok, student}
       end
     end
+  end
+
+  # academic_year is a required header for school movement, but a given row may
+  # leave it blank; guard so we fail that row clearly instead of mis-scoping.
+  defp get_academic_year(record) do
+    case record["academic_year"] do
+      year when is_binary(year) and year != "" -> {:ok, year}
+      _ -> {:error, "academic_year is required"}
+    end
+  end
+
+  defp format_changeset(changeset) do
+    "School movement failed: #{ChangesetFormatter.format_errors(changeset)}"
   end
 
   defp get_batch_by_id(batch_id) do

--- a/lib/dbservice/utils/import_worker.ex
+++ b/lib/dbservice/utils/import_worker.ex
@@ -99,6 +99,7 @@ defmodule Dbservice.DataImport.ImportWorker do
       "batch_id_correction" => &process_batch_id_correction_record/1,
       "update_incorrect_batch_id_to_correct_batch_id" => &process_batch_id_update_record/1,
       "update_incorrect_school_to_correct_school" => &process_school_update_record/1,
+      "student_school_movement" => &process_school_movement_record/1,
       "update_incorrect_grade_to_correct_grade" => &process_grade_update_record/1,
       "update_incorrect_auth_group_to_correct_auth_group" => &process_auth_group_update_record/1,
       "dropout" => &process_dropout_record/1,
@@ -1740,6 +1741,10 @@ defmodule Dbservice.DataImport.ImportWorker do
 
   defp process_school_update_record(record) do
     DataImport.GroupUpdateProcessor.process_school_update(record)
+  end
+
+  defp process_school_movement_record(record) do
+    DataImport.GroupUpdateProcessor.process_school_movement(record)
   end
 
   defp process_grade_update_record(record) do

--- a/lib/dbservice_web/controllers/template_controller.ex
+++ b/lib/dbservice_web/controllers/template_controller.ex
@@ -30,6 +30,7 @@ defmodule DbserviceWeb.TemplateController do
          "batch_id_correction",
          "update_incorrect_batch_id_to_correct_batch_id",
          "update_incorrect_school_to_correct_school",
+         "student_school_movement",
          "update_incorrect_grade_to_correct_grade",
          "update_incorrect_auth_group_to_correct_auth_group"
        ] do

--- a/lib/dbservice_web/live/import_live/new.ex
+++ b/lib/dbservice_web/live/import_live/new.ex
@@ -205,6 +205,7 @@ defmodule DbserviceWeb.ImportLive.New do
                     <option value="batch_id_correction" selected={@form[:type].value == "batch_id_correction"}>Batch ID Correction</option>
                     <option value="update_incorrect_batch_id_to_correct_batch_id" selected={@form[:type].value == "update_incorrect_batch_id_to_correct_batch_id"}>Update Incorrect Batch ID to Correct Batch ID</option>
                     <option value="update_incorrect_school_to_correct_school" selected={@form[:type].value == "update_incorrect_school_to_correct_school"}>Update Incorrect School to Correct School</option>
+                    <option value="student_school_movement" selected={@form[:type].value == "student_school_movement"}>Student School Movement</option>
                     <option value="update_incorrect_grade_to_correct_grade" selected={@form[:type].value == "update_incorrect_grade_to_correct_grade"}>Update Incorrect Grade to Correct Grade</option>
                     <option value="update_incorrect_auth_group_to_correct_auth_group" selected={@form[:type].value == "update_incorrect_auth_group_to_correct_auth_group"}>Update Incorrect Auth Group to Correct Auth Group</option>
 

--- a/test/dbservice/utils/group_update_processor_test.exs
+++ b/test/dbservice/utils/group_update_processor_test.exs
@@ -1,7 +1,12 @@
 defmodule Dbservice.DataImport.GroupUpdateProcessorTest do
   use Dbservice.DataCase
 
+  import Ecto.Query
+
   alias Dbservice.DataImport.GroupUpdateProcessor
+  alias Dbservice.EnrollmentRecords.EnrollmentRecord
+  alias Dbservice.Groups.Group
+  alias Dbservice.Groups.GroupUser
   import Dbservice.UsersFixtures
   import Dbservice.BatchesFixtures
   import Dbservice.SchoolsFixtures
@@ -188,6 +193,150 @@ defmodule Dbservice.DataImport.GroupUpdateProcessorTest do
       result = GroupUpdateProcessor.process_school_update(record)
 
       assert {:error, "Group user or enrollment record not found"} = result
+    end
+  end
+
+  describe "process_school_movement/1" do
+    test "closes out the current school enrollment and creates a new active one for the target year" do
+      {user, student} = student_fixture(%{student_id: "STUDENT001"})
+      old_school = school_fixture(%{code: "OLD_SCHOOL"})
+      new_school = school_fixture(%{code: "NEW_SCHOOL"})
+
+      old_school_group = Dbservice.Groups.get_group_by_child_id_and_type(old_school.id, "school")
+      new_school_group = Dbservice.Groups.get_group_by_child_id_and_type(new_school.id, "school")
+
+      # Existing (current) school membership + enrollment for the old school
+      {:ok, _group_user} =
+        Dbservice.GroupUsers.create_group_user(%{
+          user_id: user.id,
+          group_id: old_school_group.id
+        })
+
+      {:ok, old_enrollment} =
+        Dbservice.EnrollmentRecords.create_enrollment_record(%{
+          user_id: user.id,
+          group_id: old_school.id,
+          group_type: "school",
+          is_current: true,
+          start_date: ~D[2025-06-01],
+          academic_year: "2025-2026"
+        })
+
+      record = %{
+        "student_id" => student.student_id,
+        "school_code" => new_school.code,
+        "academic_year" => "2026-2027",
+        "effective_date" => "2026-06-01"
+      }
+
+      assert {:ok, "School movement processed successfully"} =
+               GroupUpdateProcessor.process_school_movement(record)
+
+      # Old enrollment is preserved as history: kept, but inactive with an end date
+      old = Repo.get!(EnrollmentRecord, old_enrollment.id)
+      refute old.is_current
+      assert old.end_date == ~D[2026-06-01]
+      assert old.academic_year == "2025-2026"
+
+      # A new active enrollment exists for the correct school and target year
+      new =
+        Repo.get_by(EnrollmentRecord,
+          user_id: user.id,
+          group_id: new_school.id,
+          group_type: "school",
+          academic_year: "2026-2027"
+        )
+
+      assert new
+      assert new.is_current
+      assert new.start_date == ~D[2026-06-01]
+
+      # The single school membership row now points to the new school group
+      school_group_ids = Repo.all(from(g in Group, where: g.type == "school", select: g.id))
+
+      group_users =
+        Repo.all(
+          from(gu in GroupUser,
+            where: gu.user_id == ^user.id and gu.group_id in ^school_group_ids
+          )
+        )
+
+      assert [%GroupUser{group_id: gid}] = group_users
+      assert gid == new_school_group.id
+    end
+
+    test "defaults effective_date to today when not provided" do
+      {user, student} = student_fixture(%{student_id: "STUDENT001"})
+      school = school_fixture(%{code: "NEW_SCHOOL"})
+
+      record = %{
+        "student_id" => student.student_id,
+        "school_code" => school.code,
+        "academic_year" => "2026-2027"
+      }
+
+      assert {:ok, "School movement processed successfully"} =
+               GroupUpdateProcessor.process_school_movement(record)
+
+      new =
+        Repo.get_by(EnrollmentRecord,
+          user_id: user.id,
+          group_id: school.id,
+          group_type: "school",
+          academic_year: "2026-2027"
+        )
+
+      assert new.is_current
+      assert new.start_date == Date.utc_today()
+    end
+
+    test "returns error when academic_year is missing" do
+      {_user, student} = student_fixture(%{student_id: "STUDENT001"})
+      school = school_fixture(%{code: "NEW_SCHOOL"})
+
+      record = %{"student_id" => student.student_id, "school_code" => school.code}
+
+      assert {:error, "academic_year is required"} =
+               GroupUpdateProcessor.process_school_movement(record)
+    end
+
+    test "returns error when student is not found" do
+      record = %{
+        "student_id" => "NONEXISTENT_STUDENT",
+        "school_code" => "NEW_SCHOOL",
+        "academic_year" => "2026-2027"
+      }
+
+      assert {:error, "Student not found. student_id: \"NONEXISTENT_STUDENT\", apaar_id: nil"} =
+               GroupUpdateProcessor.process_school_movement(record)
+    end
+
+    test "returns error when school is not found" do
+      {_user, student} = student_fixture(%{student_id: "STUDENT001"})
+
+      record = %{
+        "student_id" => student.student_id,
+        "school_code" => "NONEXISTENT_SCHOOL",
+        "academic_year" => "2026-2027"
+      }
+
+      assert {:error, "School not found with code: NONEXISTENT_SCHOOL"} =
+               GroupUpdateProcessor.process_school_movement(record)
+    end
+
+    test "returns error when effective_date is malformed" do
+      {_user, student} = student_fixture(%{student_id: "STUDENT001"})
+      school = school_fixture(%{code: "NEW_SCHOOL"})
+
+      record = %{
+        "student_id" => student.student_id,
+        "school_code" => school.code,
+        "academic_year" => "2026-2027",
+        "effective_date" => "not-a-date"
+      }
+
+      assert {:error, "School movement failed: " <> _} =
+               GroupUpdateProcessor.process_school_movement(record)
     end
   end
 


### PR DESCRIPTION
## Problem

The existing **"Update Incorrect School to Correct School"** import overwrites a student's school record **globally**. It finds the student's current school enrollment (`enrollment_record` where `group_type = "school"` and `is_current = true`) and simply swaps its `group_id` to the new school — destroying the previous value with no history. If a student legitimately attended School A in one year and School B in another, "fixing" one year clobbers the record with no way to recover the prior school.

Reported via Discord: a student who was at school `24230141302` through 2025-2026 and should be at `24240500404` for 2026-2027 could not be represented — the tool would overwrite whatever the current school was.

## Fix — new import type: "Student School Movement"

Instead of overwriting in place, this preserves history:

- **Closes out** the student's current school enrollment(s) — sets `is_current: false` and stamps `end_date`. The row is **kept, not deleted**.
- **Inserts a new** `is_current: true` enrollment scoped to the target academic year (reactivating an existing same-school/year row if present, so re-running an import is idempotent).
- **Swaps** the single `group_user` membership row for the `"school"` group type (that table has no history concept and always reflects the current school).
- **Leaves other academic years untouched** (their rows are already `is_current: false`).

The whole operation runs in a transaction.

## Data-model notes

School and grade are stored as **separate** enrollment rows; the school row carries `academic_year` (not grade), so corrections are scoped by **academic year**. Watch the two `group_id` conventions: `enrollment_record.group_id` = `school.id` (`group.child_id`), while `group_user.group_id` = the groups-table PK. Core logic mirrors the close-out + insert pattern already used by `ReEnrollmentService`.

## CSV columns

| Column | Required | Notes |
|---|---|---|
| `student_id` | ✅ (or provide `apaar_id`) | |
| `apaar_id` | optional | globally unique; preferred for cross-school identification |
| `school_code` | ✅ | the correct/target school |
| `academic_year` | ✅ | e.g. `2026-2027` |
| `effective_date` | optional | `YYYY-MM-DD`; defaults to today |

## Changes

- **New** `Dbservice.Services.SchoolMovementService` — transactional close-out + insert + group_user swap.
- `GroupUpdateProcessor.process_school_movement/1` — resolves student/school/year, delegates to the service.
- Wired through the standard import touch points: `mappings.ex`, `data_import.format_type_name/1`, `import_worker` dispatch + wrapper, `template_controller` whitelist, LiveView dropdown.

## Testing

- 6 new tests in `group_update_processor_test.exs` (history close-out + new active row + group_user swap, default effective_date, and error cases for missing year / unknown student / unknown school / malformed date).
- `mix check` (compiler, credo, dialyzer, formatter) ✅
- `mix test` for `data_import`, `utils`, `services` — 200 tests, 0 failures ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)